### PR TITLE
fix compile with GHC 7.2.1

### DIFF
--- a/persistent-mongoDB/persistent-mongoDB.cabal
+++ b/persistent-mongoDB/persistent-mongoDB.cabal
@@ -14,7 +14,7 @@ homepage:        http://www.yesodweb.com/book/persistent
 library
     build-depends:   base               >= 4 && < 5
                    , persistent         >= 0.6.0 && < 0.7.0
-                   , template-haskell   >= 2.4     && < 2.6
+                   , template-haskell   >= 2.4     && < 2.7
                    , text               >= 0.8     && < 0.12
                    , transformers       >= 0.2.1   && < 0.3
                    , containers         >= 0.2     && < 0.5

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -46,7 +46,7 @@ test-suite test
                    , hspec >= 0.6 && < 0.7
                    , file-location == 0.2.3
                    , base >= 4 && < 5
-                   , template-haskell >= 2.4 && < 2.6
+                   , template-haskell >= 2.4 && < 2.7
                    , HDBC-postgresql
                    , HDBC
                    -- mongoDB dependencies

--- a/persistent/test/main.hs
+++ b/persistent/test/main.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE EmptyDataDecls #-}
 
 import Test.HUnit hiding (Test)
 import Test.Hspec.Monadic


### PR DESCRIPTION
update template-haskell dependency and test framework to compile with GHC 7.2.1. Note that the dependencies bson and compact-string-fix have not yet been updated for GHC 7.2.1
