### PR TITLE
persistent-postgresql: Make some config values optional (untested)

### DIFF
--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -49,6 +49,7 @@ import qualified Data.Text.Encoding as T
 import Data.Text (Text, pack)
 import Data.Aeson
 import Control.Monad (forM, mzero)
+import Control.Applicative ((<|>), pure)
 
 withPostgresqlPool :: C.ResourceIO m
                    => PG.ConnectInfo
@@ -559,10 +560,10 @@ instance PersistConfig PostgresConf where
     runPool _ = runSqlPool
     loadConfig (Object o) = do
         database <- o .: "database"
-        host     <- o .: "host"
-        port     <- o .: "port"
-        user     <- o .: "user"
-        password <- o .: "password"
+        host     <- (o .: "host")     <|> pure ""
+        port     <- (o .: "port")     <|> pure (-1)
+        user     <- (o .: "user")     <|> pure ""
+        password <- (o .: "password") <|> pure ""
         pool     <- o .: "poolsize"
         let ci = PG.ConnectInfo
                    { PG.connectHost     = host


### PR DESCRIPTION
This applies for user, password, host and port.
