### PR TITLE
Cure a false positive in persistent-test

### DIFF
--- a/persistent-test/MaxLenTest.hs
+++ b/persistent-test/MaxLenTest.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE EmptyDataDecls #-}
 module MaxLenTest (
   specs
+  , maxlenMigrate
 ) where
 
 import Init
@@ -20,7 +21,7 @@ import Data.ByteString (ByteString)
 #if WITH_MONGODB
 mkPersist MkPersistSettings { mpsBackend = ConT ''Action } [persist|
 #else
-share [mkPersist sqlSettings,  mkMigrate "testMigrate"] [persist|
+share [mkPersist sqlSettings,  mkMigrate "maxlenMigrate"] [persist|
 #endif
   MaxLen
     text1 Text

--- a/persistent-test/test/main.hs
+++ b/persistent-test/test/main.hs
@@ -37,6 +37,7 @@ main = do
   runConn (setup EmbedTest.embedMigrate)
   runConn (setup LargeNumberTest.numberMigrate)
   runConn (setup JoinTest.joinMigrate)
+  runConn (setup MaxLenTest.maxlenMigrate)
 
   hspecX $
     RenameTest.specs >>


### PR DESCRIPTION
Failure was:

```
>>> 1) Maximum length attribute  FAILED
>>> user error (SQLite3 returned ErrorError while attempting to perform prepare "INSERT INTO \"MaxLen\"(\"text1\",\"text2\",\"bs1\",\"bs2\",\"str1\",\"str2\") VALUES(?,?,?,?,?,?)": no such table: MaxLen)
>>>
```

Maybe there's some way to make sure the testdb.sqlite3 is pristine/empty before starting tests, to catch this kind of thing earlier?
