### PR TITLE
include test/main.hs missing from persistent-0.9.0.1.tar.gz

### DIFF
--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -11,6 +11,8 @@ stability:       Stable
 cabal-version:   >= 1.8
 build-type:      Simple
 homepage:        http://www.yesodweb.com/book/persistent
+extra-source-files:
+  test/main.hs
 
 flag nooverlap
     default: False


### PR DESCRIPTION
Add test/main.hs to extra-source-files: to hopefully fix similar issue in persistent as https://github.com/yesodweb/yesod/issues/331
