### PR TITLE
Auth for MongoDB

### DIFF
--- a/persistent-mongoDB/Database/Persist/MongoDB.hs
+++ b/persistent-mongoDB/Database/Persist/MongoDB.hs
@@ -99,7 +99,7 @@ connectMongoDB :: Database -> HostName -> UString -> UString -> DB.IOE DB.Pipe
 connectMongoDB dbname hostname user pass = do
     x <- DB.connect (DB.host hostname)
     _ <- DB.access x DB.UnconfirmedWrites dbname (DB.auth user pass)
-    return(x)
+    return x
 
 createMongoDBPool :: (Trans.MonadIO m, Applicative m) =>
   Database -> HostName -> UString -> UString -> Int -> m ConnectionPool


### PR DESCRIPTION
The return from the auth call is specifically ignored so that running mongodb in unsecure mode will not cause errors. Any auth errors will be seen upon query.
