### PR TITLE
mongoDB version issue

### DIFF
--- a/persistent-mongoDB/persistent-mongoDB.cabal
+++ b/persistent-mongoDB/persistent-mongoDB.cabal
@@ -22,7 +22,7 @@ library
                    , conduit            >= 0.4     && < 0.5
                    , resourcet          >= 0.3     && < 0.4
                    , mongoDB            >= 1.2     && < 1.3
-                   , bson               >= 0.1.6
+                   , bson               >= 0.1.6   && < 0.1.8
                    , network            >= 2.2.1.7 && < 3
                    , compact-string-fix >= 0.3.1   && < 0.4
                    , cereal             >= 0.3.0.0


### PR DESCRIPTION
Using the mongoDB does not work correctly on my ubuntu box in a new scaffolded project.

It stops with the error:

Building mongoDB-1.2.0...

Database/MongoDB/Admin.hs:34:8:
    Could not find module `Data.UString'
    Perhaps you meant Data.String (from base)
    Use -v to see a list of the files searched for.
cabal: Error: some packages failed to install:
mongoDB-1.2.0 failed during the building phase. The exception was:
ExitFailure 1

Using the constraint:

$ cabal-dev install mongoDB-1.2.0 --constraint=bson-0.1.7

it works like a charm.

I just altered the cabal file for the mongodb. this should solve the issue.

would be nice to have this cabal updated soon
