### PR TITLE
Compatibility with new mongoDB and bson

### DIFF
--- a/persistent-mongoDB/persistent-mongoDB.cabal
+++ b/persistent-mongoDB/persistent-mongoDB.cabal
@@ -21,10 +21,9 @@ library
                    , bytestring         >= 0.9
                    , conduit            >= 0.4     && < 0.5
                    , resourcet          >= 0.3     && < 0.4
-                   , mongoDB            >= 1.2     && < 1.3
-                   , bson               >= 0.1.6
+                   , mongoDB            >= 1.3     && < 1.4
+                   , bson               >= 0.2     && < 0.3
                    , network            >= 2.2.1.7 && < 3
-                   , compact-string-fix >= 0.3.1   && < 0.4
                    , cereal             >= 0.3.0.0
                    , path-pieces        >= 0.1     && < 0.2
                    , monad-control      >= 0.3     && < 0.4


### PR DESCRIPTION
New versions of mongoDB and bson use text instead of compact-string-fix.
