### PR TITLE
backend specific types

### DIFF
--- a/persistent-postgresql/persistent-postgresql.cabal
+++ b/persistent-postgresql/persistent-postgresql.cabal
@@ -25,6 +25,7 @@ library
                    , time                  >= 1.1
                    , aeson                 >= 0.5
                    , conduit               >= 0.5      && < 0.6
+                   , blaze-builder         >= 0.3
     exposed-modules: Database.Persist.Postgresql
     ghc-options:     -Wall
 


### PR DESCRIPTION
This commit adds a PersistSpecific PersistValue representing an sql entity with a type specific to some particular backend. In particular, this is useful for postGIS, which uses geometry and geography types not found in other backends. 
