### PR TITLE
.gitignore mod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ TAGS
 .virthualenv
 # hsenv does this
 dist_y
+*cabal-dev


### PR DESCRIPTION
This commit simply modifies the .gitignore file to ignore cabal-dev directories within the project.

DISCLAIMER: I'm new to Haskell package development and honestly I'm not even sure if cabal-dev is any good. But I'm trying it at the moment and I thought there might be others out there like me, so I thought I'd offer this up. But if cabal-dev is bad for some reason, I'd really like to hear all about it. Like I said, I'm just learning.
