### PR TITLE
MongoDB non-default port (e.g. for mongolab.com)

### DIFF
--- a/persistent-mongoDB/test/app/mongoapp.hs
+++ b/persistent-mongoDB/test/app/mongoapp.hs
@@ -12,6 +12,7 @@ import Database.MongoDB.Connection -- (ConnPool)
 import qualified Database.MongoDB as DB
 import Control.Monad.Context (Context (..))
 import Network.Abstract (ANetwork)
+import Network (PortID (PortNumber))
 import Control.Monad.Trans.Reader
 import Control.Monad.Util
 
@@ -24,7 +25,7 @@ Person
 -- runMongo :: MongoDBReader Database.MongoDB.Connection.Host (GGHandler M M IO) a -> GHandler M M a
 runMongo :: MongoDBReader (GGHandler M M IO) a -> GHandler M M a
 runMongo x = liftIOHandler $ 
-  withMongoDBConn (DB.Database "test") "127.0.0.1" $ runMongoDBConn x DB.safe DB.Master
+  withMongoDBConn (DB.Database "test") "127.0.0.1" (PortNumber 27017) $ runMongoDBConn x DB.safe DB.Master
 
 getConnection :: (ConnPool t, HostName)
 getConnection = undefined

--- a/persistent-test/Init.hs
+++ b/persistent-test/Init.hs
@@ -58,6 +58,8 @@ import Database.Persist.TH (MkPersistSettings(..))
 import Control.Monad (replicateM)
 import qualified Data.ByteString as BS
 
+import Network (PortID (PortNumber))
+
 #else
 import Database.Persist.GenericSql
 import Database.Persist.Sqlite
@@ -115,7 +117,7 @@ persistSettings = MkPersistSettings { mpsBackend = ConT ''Action }
 type BackendMonad = Action
 runConn :: (MonadIO m, MonadBaseControl IO m) => Action m backend -> m ()
 runConn f = do
-  _<-withMongoDBConn "test" "127.0.0.1" Nothing 5 $
+  _<-withMongoDBConn "test" "127.0.0.1" (PortNumber 27017) Nothing 5 $
       runMongoDBPool MongoDB.master f
   return ()
 


### PR DESCRIPTION
Some cloud MongoDB services (like www.mongolab.com)
require connecting using a port number other than the default 27017
