### PR TITLE
Make it possible to use Persistent from code that has a connection from Database.PostgreSQL.Simple

### DIFF
--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -11,6 +11,7 @@ module Database.Persist.Postgresql
     , module Database.Persist.GenericSql
     , ConnectionString
     , PostgresConf (..)
+    , openSimpleConn
     ) where
 
 import Database.Persist hiding (Entity (..))
@@ -102,7 +103,11 @@ withPostgresqlConn = withSqlConn . open'
 
 open' :: ConnectionString -> IO Connection
 open' cstr = do
-    conn <- PG.connectPostgreSQL cstr
+    PG.connectPostgreSQL cstr >>= openSimpleConn
+
+-- | Generate a 'Connection' from a 'PG.Connection'
+openSimpleConn :: PG.Connection -> IO Connection
+openSimpleConn conn = do
     smap <- newIORef $ Map.empty
     return Connection
         { prepare    = prepare' conn


### PR DESCRIPTION
openSimpleConn turns a connection from Database.PostgreSQL.Simple into a Persistent connection, so Persistent can be used in code that already has a a connection.
