### PR TITLE
map JSON key to start with lower-case

### DIFF
--- a/persistent-template/persistent-template.cabal
+++ b/persistent-template/persistent-template.cabal
@@ -22,6 +22,7 @@ library
                    , transformers             >= 0.2       && < 0.4
                    , containers
                    , aeson
+                   , unordered-containers
     exposed-modules: Database.Persist.TH
     ghc-options:     -Wall
     if impl(ghc >= 7.4)

--- a/persistent-template/test/main.hs
+++ b/persistent-template/test/main.hs
@@ -48,5 +48,5 @@ main = hspec $ do
         prop "to/from is idempotent" $ \person ->
             decode (encode person) == Just (person :: Person)
         it "decode" $
-            decode "{\"name\":\"Michael\",\"age\":27,\"address\":{\"street\":\"Narkis\",\"city\":\"Maalot\"}}" `shouldBe` Just
+            decode "{\"Name\":\"Michael\",\"age\":27,\"address\":{\"street\":\"Narkis\",\"city\":\"Maalot\"}}" `shouldBe` Just
                 (Person "Michael" (Just 27) $ Address "Narkis" "Maalot" Nothing)


### PR DESCRIPTION
Persistent's JSON data mapping is very useful, but I found a problem.
If a JSON object's "key" starts with upper-case alphabet, we can't map it to Haskell internal data in intact.
So I wrote a patch that convert such key name to start with corresponding lower case letter.
