### PR TITLE
Testsuite segfaults when a certain test fails

### DIFF
--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -105,6 +105,7 @@ library
                    , mongoDB       == 1.3.*
                    , bson
                    , silently
+                   , hashable < 1.2
 
 
    if flag(postgresql)


### PR DESCRIPTION
I got a segfault running the testsuite.  It happens on the EmbedTest.hs "Set" test.  I added traces and found that it's `reset`ting a statement after it has been finalized:

```
Statement 365: withStmt
Statement 366: execute
Statement 362: finalize
Statement 363: finalize
Statement 366: finalize
Statement 365: finalize
Statement 364: finalize
Statement 365: reset
 - Set FAILED [1]
```

The problematic `finalize` calls only appear when the test fails.  Here is the exception causing the failure:

```
PersistMarshalError "Cannot convert PersistMap to String"
```

So there are two problems:
- The "Set" test fails intermittently.
- When the test fails, things are finalized in the wrong order.

It looks like the database is closed before `withStmt` completes.
