### PR TITLE
Fixed dependencies around mongoDB.

### DIFF
--- a/persistent-test/DataTypeTest.hs
+++ b/persistent-test/DataTypeTest.hs
@@ -69,7 +69,7 @@ specs = describe "data type specs" $ do
         _ <- runMigrationSilent dataTypeMigrate
 #endif
         rvals <- liftIO randomValues
-        forM_ (take 1000 rvals) $ \x -> do         
+        forM_ (take 1000 rvals) $ \x -> do
             key <- insert x
             Just y <- get key
             liftIO $ do
@@ -91,8 +91,8 @@ specs = describe "data type specs" $ do
 #ifndef WITH_MONGODB
                 check' "pico" dataTypeTablePico
                 check "time" dataTypeTableTime
-                check "utc" dataTypeTableUtc
 #endif
+                check "utc" dataTypeTableUtc
                 check "zoned" dataTypeTableZonedTime
 
                 -- Do a special check for Double since it may

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -117,7 +117,6 @@ library
                    , QuickCheck >= 2.5
                    , blaze-html >= 0.5
                    , quickcheck-instances >= 0.3
-                   , blaze-html >= 0.5 && < 0.6
                    , pool-conduit
                    , transformers-base
                    , attoparsec
@@ -126,10 +125,6 @@ library
                    , monad-logger >= 0.2.3
                    , hashable
                    , th-orphans
-                   -- actually just a mongoDB dependency
-                   -- fixes build warning on current build server
-                   , cereal
-                   , bson
                    , silently
                    , blaze-builder
 


### PR DESCRIPTION
These are really simple:
- `check "utc" dataTypeTableUtc` is not inline with other mongoDB exclusions on the same file (DataTypeTest.hs)
- cereal and bson dependencies were still applied on the general section of the cabal file, while they only concern mongodb
