### PR TITLE
persistent-test double precision

### DIFF
--- a/persistent-test/DataTypeTest.hs
+++ b/persistent-test/DataTypeTest.hs
@@ -97,8 +97,11 @@ specs = describe "data type specs" $ do
 
                 -- Do a special check for Double since it may
                 -- lose precision when serialized.
-                when (abs (dataTypeTableDouble x - dataTypeTableDouble y) > 1e-14) $
+                when (getDoubleDiff (dataTypeTableDouble x)(dataTypeTableDouble y) > 1e-14) $
                   check "double" dataTypeTableDouble
+    where normDouble x = if abs x > 1 then x / 10^(truncate $ logBase 10 (abs x))
+                                      else x
+          getDoubleDiff x y = abs ((normDouble x) - (normDouble y)) :: Double
 
 randomValues :: IO [DataTypeTable]
 randomValues = do


### PR DESCRIPTION
These two doubles:
x = 1234.56789012345 :: Double
y = 1234.56789012346 :: Double

Are 'the same' with a 14 digit precision, but the test:
`abs (dataTypeTableDouble x - dataTypeTableDouble y) > 1e-14`

Will return true nevertheless.

The provided alternative first converts each operand to a common format (1.23456789012345), so that the difference comparison makes sense. Of course, my math may be off, so feel free to check it!
