### PR TITLE
Fix build of persistent-postgresql and persistent-sqlite

### DIFF
--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -488,10 +488,10 @@ getColumn _ _ x =
     return $ Left $ pack $ "Invalid result from information_schema: " ++ show x
 
 findAlters :: Column -> [Column] -> ([AlterColumn'], [Column])
-findAlters col@(Column name isNull sqltype def _maxLen ref) cols =
+findAlters col@(Column name isNull sqltype def _cn _maxLen ref) cols =
     case filter (\c -> cName c == name) cols of
         [] -> ([(name, Add' col)], cols)
-        Column _ isNull' sqltype' def' _maxLen' ref':_ ->
+        Column _ isNull' sqltype' def' _cn _maxLen' ref':_ ->
             let refDrop Nothing = []
                 refDrop (Just (_, cname)) = [(name, DropReference cname)]
                 refAdd Nothing = []
@@ -520,13 +520,13 @@ findAlters col@(Column name isNull sqltype def _maxLen ref) cols =
 
 -- | Get the references to be added to a table for the given column.
 getAddReference :: DBName -> Column -> Maybe AlterDB
-getAddReference table (Column n _nu _ _def _maxLen ref) =
+getAddReference table (Column n _nu _ _def _cn _maxLen ref) =
     case ref of
         Nothing -> Nothing
         Just (s, _) -> Just $ AlterColumn table (n, AddReference s)
 
 showColumn :: Column -> String
-showColumn (Column n nu sqlType def _maxLen _ref) = concat
+showColumn (Column n nu sqlType def _cn _maxLen _ref) = concat
     [ T.unpack $ escape n
     , " "
     , showSqlType sqlType

--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -267,7 +267,7 @@ mkCreateTable isTemp entity (cols, uniqs) = T.concat
     ]
 
 sqlColumn :: Column -> Text
-sqlColumn (Column name isNull typ def _maxLen ref) = T.concat
+sqlColumn (Column name isNull typ def _cn _maxLen ref) = T.concat
     [ ","
     , escape name
     , " "


### PR DESCRIPTION
This was broken by b1ae9340c7a2acbdb6d947ad4767b844dfd79a1e

Maybe -mysql needs a fix too, but I'll add another ticket for that since mysql (not persistent-mysql) doesn't build with with Cabal 1.18. Edit: Ticket is bos/mysql#6
