### PR TITLE
Make TH function fromPersistValue work with any field ordering.

### DIFF
--- a/persistent-template/Database/Persist/TH.hs
+++ b/persistent-template/Database/Persist/TH.hs
@@ -47,6 +47,7 @@ import Data.List (foldl', find)
 import Data.Maybe (isJust)
 import Data.Monoid (mappend, mconcat)
 import qualified Data.Map as M
+import qualified Data.HashMap.Strict as HM
 import Data.Aeson
     ( ToJSON (toJSON), FromJSON (parseJSON), (.=), object
     , Value (Object), (.:), (.:?)
@@ -618,13 +619,15 @@ mkEntity mps t = do
 --
 -- instance PersistEntity e => PersistField e where
 --    toPersistValue = PersistMap $ zip columNames (map toPersistValue . toPersistFields)
---    fromPersistValue (PersistMap o) = fromPersistValues $ map (\name ->
---        case lookup name o of
---          Just v ->
---            case fromPersistValue v of
---              Left e -> error e
---              Right r -> r
---          Nothing -> error $ "Missing field: " `mappend` unpack name) columnNames 
+--    fromPersistValue (PersistMap o) = 
+--        let columns = HM.fromList x
+--        in fromPersistValues $ map (\name ->
+--          case HM.lookup name o of
+--            Just v ->
+--              case fromPersistValue v of
+--                Left e -> error e
+--                Right r -> r
+--            Nothing -> error $ "Missing field: " `mappend` unpack name) columnNames 
 --    fromPersistValue x = Left $ "Expected PersistMap, received: " ++ show x
 --    sqlType _ = SqlString
 persistFieldFromEntity :: MkPersistSettings -> EntityDef a -> Q [Dec]
@@ -632,13 +635,14 @@ persistFieldFromEntity mps e = do
     ss <- [|SqlString|]
     let columnNames = map (unpack . unHaskellName . fieldHaskell) (entityFields e)
     obj <- [|\ent -> PersistMap $ zip (map pack columnNames) (map toPersistValue $ toPersistFields ent)|]
-    fpv <- [|\x -> fromPersistValues $ map (\name -> 
-                                              case lookup name x of
-                                                  Just v -> 
-                                                      case fromPersistValue v of
-                                                          Left e' -> error $ unpack e'
-                                                          Right r -> r
-                                                  Nothing -> error $ "Missing field: " `mappend` unpack name) (map pack columnNames)|]
+    fpv <- [|\x -> let columns = HM.fromList x
+                   in fromPersistValues $ map (\name -> 
+                                                  case HM.lookup name columns of
+                                                      Just v -> 
+                                                          case fromPersistValue v of
+                                                              Left e' -> error $ unpack e'
+                                                              Right r -> r
+                                                      Nothing -> error $ "Missing field: " `mappend` unpack name) (map pack columnNames)|]
     let typ = genericDataType mps (pack entityName) $ VarT $ mkName "backend"
 
     compose <- [|(<=<)|]


### PR DESCRIPTION
This addresses #176 and #177.

The issue is that Aeson doesn't guarantee the ordering of fields in serialized/deserialized objects. So, for example in ghci:

```
fromJust $ decode $ encode $ toJSON $ toPersistValue $ Bar "b" "u" "g" :: PersistValue
PersistMap [("b",PersistText "b"),("g",PersistText "g"),("u",PersistText "u")]
```

The code for fromPersistValue assumed that the ordering matched the original column ordering. This patch causes the generated fromPersistValue to lookup each column name in the PersistMap list. It passes the test from #177 in sqlite, postgres and MySQL (not tested with Mongo). Repeated use of lookup also makes fromPersistValue O(n^2) in the number of columns rather than O(n) in the original, which may be an issue for performance, but I don't have a very good heuristic sense on whether that matters.
