### PR TITLE
add idempotent migration test

### DIFF
--- a/persistent-test/MigrationTest.hs
+++ b/persistent-test/MigrationTest.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE EmptyDataDecls #-}
+module MigrationTest where
+
+import Database.Persist.Sqlite
+import Database.Persist.TH
+import qualified Data.Text as T
+
+import Init
+
+#ifdef WITH_MONGODB
+mkPersist persistSettings [persistUpperCase|
+#else
+share [mkPersist sqlSettings, mkMigrate "migrationMigrate", mkDeleteCascade sqlSettings] [persistLowerCase|
+#endif
+Target
+    field1 Int
+    field2 T.Text
+    deriving Eq Show
+
+Source
+    field3 Int
+    field4 TargetId
+|]
+specs :: Spec
+specs = describe "Migration" $ do
+#ifndef WITH_MONGODB
+    it "is idempotent" $ db $ do
+      again <- getMigration migrationMigrate
+      liftIO $ again @?= []
+#endif

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -56,6 +56,7 @@ library
                      MaxLenTest
                      SumTypeTest
                      MigrationOnlyTest
+                     MigrationTest
                      CompositeTest
                      Init
 

--- a/persistent-test/test/main.hs
+++ b/persistent-test/test/main.hs
@@ -10,6 +10,7 @@ import qualified LargeNumberTest
 import qualified MaxLenTest
 import qualified SumTypeTest
 import qualified UniqueTest
+import qualified MigrationTest
 import qualified MigrationOnlyTest
 import qualified CompositeTest
 import Test.Hspec (hspec)
@@ -55,17 +56,17 @@ main = do
   runConn (setup UniqueTest.uniqueMigrate)
   runConn (setup MaxLenTest.maxlenMigrate)
   runConn (setup CompositeTest.compositeMigrate)
+  runConn (setup MigrationTest.migrationMigrate)
 #endif
 
   hspec $ do
     RenameTest.specs
-#ifndef WITH_POSTGRESQL
-    -- FIXME for postgres
+#ifndef WITH_POSTGRESQL // FIXME
     DataTypeTest.specs
 #endif
     HtmlTest.specs
     EmbedTest.specs
-    -- EmbedOrderTest.specs
+    EmbedOrderTest.specs
     LargeNumberTest.specs
     UniqueTest.specs
     MaxLenTest.specs
@@ -74,4 +75,5 @@ main = do
     PersistentTest.specs
 #ifndef WITH_MONGODB
     CompositeTest.specs
+    MigrationTest.specs
 #endif


### PR DESCRIPTION
First of 2 pull requests to fix #196

This request adds a new test, that a particular migration involving a foreign key is idempotent. I'm confident that this is broadly right, and have checked that it would have caught the bug. (It occurs to me now that perhaps we should append the idempotency test to _every_ test.)
