### PR TITLE
existence of a nullable field should be optional

### DIFF
--- a/persistent-test/MigrationTest.hs
+++ b/persistent-test/MigrationTest.hs
@@ -11,7 +11,9 @@
 {-# LANGUAGE EmptyDataDecls #-}
 module MigrationTest where
 
+#ifndef WITH_MONGODB
 import Database.Persist.Sqlite
+#endif
 import Database.Persist.TH
 import qualified Data.Text as T
 
@@ -32,9 +34,10 @@ Source
     field3 Int
     field4 TargetId
 |]
+
+#ifndef WITH_MONGODB
 specs :: Spec
 specs = describe "Migration" $ do
-#ifndef WITH_MONGODB
     it "is idempotent" $ db $ do
       again <- getMigration migrationMigrate
       liftIO $ again @?= []


### PR DESCRIPTION
In MongoDB it already is except for embedded entities.

In MongoDB it saves space to have a non-existent field
rather than a null.
In addition, it avoids the need for a migration when adding a nullable
field.
