### PR TITLE
General persistent-postgresql cleanup

### DIFF
--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -31,6 +31,7 @@ import Database.PostgreSQL.Simple.Ok (Ok (..))
 
 import qualified Database.PostgreSQL.LibPQ as LibPQ
 
+import Control.Monad.Trans.Resource
 import Control.Exception (throw)
 import Control.Monad.IO.Class (MonadIO (..))
 import Data.Typeable


### PR DESCRIPTION
1. Removes deprecated import of `Database.PostgreSQL.Simple.BuiltinTypes` in favor of `getTypeInfo`
2. Makes JSON act like a ByteString for ease of decoding
3. Start on PG array support
4. hlint
5. -Wall
