### PR TITLE
One possible workaround for 7.8.1 bug.

### DIFF
--- a/persistent/Database/Persist/Class/PersistEntity.hs
+++ b/persistent/Database/Persist/Class/PersistEntity.hs
@@ -1,4 +1,8 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ExistentialQuantification #-}
+#if defined(SYN_WORKAROUND)
+{-# LANGUAGE UndecidableInstances #-}
+#endif
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
@@ -107,7 +111,12 @@ data Filter record = forall typ. PersistField typ => Filter
 -- | Helper wrapper, equivalent to @Key (PersistEntityBackend val) val@.
 --
 -- Since 1.1.0
+#if defined(SYN_WORKAROUND)
+type family Key record :: * where
+    Key record = KeyBackend (PersistEntityBackend record) record
+#else
 type Key record = KeyBackend (PersistEntityBackend record) record
+#endif
 
 -- | Datatype that represents an entity, with both its 'Key' and
 -- its Haskell record representation.

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -21,6 +21,9 @@ library
     if flag(nooverlap)
         cpp-options: -DNO_OVERLAP
 
+    if impl(ghc == 7.8.1)
+        cpp-options: -DSYN_WORKAROUND
+
     build-depends:   base                     >= 4       && < 5
                    , bytestring               >= 0.9
                    , transformers             >= 0.2.1


### PR DESCRIPTION
Hopefully this is not extremely intrusive.

The other alternative I propose is to define a CPP macro `SAFE_SYNONYM(synonym, expanded type, kind)` which is a closed type family in 7.8.\* and a regular synonym otherwise. The problem with that solution is that it will still be in effect in 7.8.2, at which point this bug should be fixed.
