### PR TITLE
Prevent migrating migrating the schema for mysql numeric type

### DIFF
--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -503,6 +503,7 @@ getColumn _ _ _ x =
 -- @INFORMATION_SCHEMA@ tables.
 parseType :: ByteString -> SqlType
 parseType "bigint(20)" = SqlInt64
+parseType "decimal(32,20)" = SqlNumeric 32 20
 {-
 parseType "tinyint"    = SqlBool
 -- Ints


### PR DESCRIPTION
This prevents re-running migrations for Rationals 

Felt wrong to hardcode the precision like this; mostly just basing this off of https://github.com/yesodweb/persistent/commit/b2abdfc5fe117da9e81680682a5179c4757448ff
