### PR TITLE
Adds support for PostgreSQL's enumerated types

### DIFF
--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -333,16 +333,22 @@ builtinGetters = I.fromList
         k (PGFF.typoid -> i) = PG.oid2int i
         listOf f = convertPV (PersistList . map f . PG.fromPGArray)
 
+enumGetter :: Getter PersistValue
+enumGetter = convertPV (PersistText . T.decodeUtf8 . unUnknown)
+
 getGetter :: PG.Connection -> PG.Oid -> IO (Getter PersistValue)
 getGetter conn oid = case I.lookup (PG.oid2int oid) builtinGetters of
     Just getter -> return getter
     Nothing -> do
         tyinfo <- PG.getTypeInfo conn oid
-        error $ "Postgresql.getGetter: type "
-             ++ explain tyinfo
-             ++ " ("
-             ++ show oid
-             ++ ") not supported."
+        -- If the type in a PostgreSQL Enum
+        if (PG.typcategory tyinfo == 'E')
+            then return $ enumGetter
+            else error $ "Postgresql.getGetter: type "
+                     ++ explain tyinfo
+                     ++ " ("
+                     ++ show oid
+                     ++ ") not supported."
     where
         explain tyinfo = case B8.unpack $ PG.typname tyinfo of
                         t@('_':ty) -> t ++ " (array of " ++ ty ++ ")"

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -341,7 +341,7 @@ getGetter conn oid = case I.lookup (PG.oid2int oid) builtinGetters of
     Just getter -> return getter
     Nothing -> do
         tyinfo <- PG.getTypeInfo conn oid
-        -- If the type in a PostgreSQL Enum
+        -- If the type is a PostgreSQL Enum
         if (PG.typcategory tyinfo == 'E')
             then return $ enumGetter
             else error $ "Postgresql.getGetter: type "


### PR DESCRIPTION
This was my attempt at fixing Issue #264. I doubt it's as clean as it should be, but let me know if you have any suggestions.
## persistent-template
### Changes
- Generalized `derivePersistField` into `derivePersistFieldGeneric` that accepts a `Q Exp` for the `PersistFieldSql` instance.
- Added `derivePersistFieldSqlTypeOther` which creates the `PersistFieldSql` instance with `SqlOther`.
- This fixes migrations always using `VARCHAR` in #264 .
### Example
#### PostgreSQL

```
CREATE TYPE color AS ENUM ('Red', 'Blue', 'Yellow');
```
#### Sum type

```
data Color = Red | Yellow | Blue deriving (Show, Read, Eq)
derivePersistFieldSqlTypeOther "Color" "color"
                           --     ^       ^
                           --     |       +--- Name of type in PostgreSQL
                           --     +----------- Name of type in Haskell
```
#### Table definition

```
share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistLowerCase|
Person sql=people
    name String
    favorite_color Color default="'Blue'::color"
    deriving Show
|]
```
## persistent-postgresql
### Changes
- Adds a check into `getGetter` that sees if the incoming type in a PostgreSQL Enum.
- If it is an Enum, it converts the `ByteString` to a `PersistText` via UTF8.
- This fixes reading the Enum in #246.
