### PR TITLE
Add `insertMany_`

### DIFF
--- a/persistent-test/PersistentTest.hs
+++ b/persistent-test/PersistentTest.hs
@@ -198,13 +198,13 @@ specs = describe "persistent" $ do
       limitOffsetOrder [Desc PersonAge, LimitTo 2] `eq` (2, 0)
       limitOffsetOrder [LimitTo 2, Desc PersonAge, OffsetBy 3] `eq` (2, 3)
 
-      _ <- insertMany [ Person "z" 1 Nothing
-                     , Person "y" 2 Nothing
-                     , Person "x" 1 Nothing
-                     , Person "w" 2 Nothing
-                     , Person "v" 1 Nothing
-                     , Person "u" 2 Nothing
-                     ]
+      insertMany_ [ Person "z" 1 Nothing
+                  , Person "y" 2 Nothing
+                  , Person "x" 1 Nothing
+                  , Person "w" 2 Nothing
+                  , Person "v" 1 Nothing
+                  , Person "u" 2 Nothing
+                  ]
 
       a <- fmap (map $ personName . entityVal) $ selectList [] [Desc PersonAge, Asc PersonName, OffsetBy 2, LimitTo 3]
       a @== ["y", "v", "x"]
@@ -294,11 +294,11 @@ specs = describe "persistent" $ do
 
   it "and/or" $ db $ do
       deleteWhere ([] :: [Filter Person1])
-      _ <- insertMany [ Person1 "Michael" 25
-                     , Person1 "Miriam" 25
-                     , Person1 "Michael" 30
-                     , Person1 "Michael" 35
-                     ]
+      insertMany_ [ Person1 "Michael" 25
+                  , Person1 "Miriam" 25
+                  , Person1 "Michael" 30
+                  , Person1 "Michael" 35
+                  ]
 
       c10 <- count $ [Person1Name ==. "Michael"] ||. [Person1Name ==. "Miriam", Person1Age ==. 25]
       c10 @== 4

--- a/persistent/Database/Persist/Class/PersistStore.hs
+++ b/persistent/Database/Persist/Class/PersistStore.hs
@@ -76,6 +76,12 @@ class PersistStore backend where
                => [val] -> ReaderT backend m [Key val]
     insertMany vals = mapM insert vals
 
+    -- | Same as 'insertMany', but doesn't return any @Key@s.
+    -- SQL backends use faster implementation for this than is currently
+    -- used by 'insertMany'.
+    insertMany_ :: (MonadIO m, backend ~ PersistEntityBackend val, PersistEntity val)
+                => [val] -> ReaderT backend m ()
+
     -- | Create a new record in the database using the given key.
     insertKey :: (MonadIO m, backend ~ PersistEntityBackend val, PersistEntity val)
               => Key val -> val -> ReaderT backend m ()

--- a/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
@@ -69,6 +69,22 @@ instance PersistStore Connection where
         t = entityDef $ Just val
         vals = map toPersistValue $ toPersistFields val
 
+    insertMany_ vals = do
+        conn <- ask
+        let sql = T.concat
+                [ "INSERT INTO "
+                , connEscapeName conn (entityDB t)
+                , "("
+                , T.intercalate "," $ map (connEscapeName conn . fieldDB) $ entityFields t
+                , ") VALUES ("
+                , T.intercalate "),(" $ replicate (length valss) $ T.intercalate "," $ map (const "?") (entityFields t)
+                , ")"
+                ]
+        rawExecute sql (concat valss)
+      where
+        t = entityDef vals
+        valss = map (map toPersistValue . toPersistFields) vals
+
     replace k val = do
         conn <- ask
         let t = entityDef $ Just val


### PR DESCRIPTION
`insertMany_` uses a faster batch style query as opposed to `insertMany` which
is currently implemented as `mapM . insert` by default (see #131, https://github.com/circuithub/persistent-mysql-extra/issues/1).
