### PR TITLE
allow a Foreign key to be nullable

### DIFF
--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -305,7 +305,7 @@ migrate' connectInfo allDefs getter val = do
               Column { cName=cname, cReference=Just (refTblName, a) } <- newcols
               return $ AlterColumn name (refTblName, addReference allDefs (refName name cname) refTblName cname)
                  
-        let foreignsAlt = map (\fdef -> let (childfields, parentfields) = unzip (map (\(_,b,_,d) -> (b,d)) (foreignFields fdef)) 
+        let foreignsAlt = map (\fdef -> let (childfields, parentfields) = unzip (map (\((_,b),(_,d)) -> (b,d)) (foreignFields fdef)) 
                                         in AlterColumn name (foreignRefTableDBName fdef, AddReference (foreignRefTableDBName fdef) (foreignConstraintNameDBName fdef) childfields parentfields)) fdefs
         
         return $ Right $ map showAlterDb $ addTable : uniques ++ foreigns ++ foreignsAlt

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -408,7 +408,7 @@ migrate' allDefs getter val = fmap (fmap $ map showAlterDb) $ do
                     let uniques = flip concatMap udspair $ \(uname, ucols) ->
                             [AlterTable name $ AddUniqueConstraint uname ucols]
                         references = mapMaybe (\c@Column { cName=cname, cReference=Just (refTblName, _) } -> getAddReference allDefs name refTblName cname (cReference c)) $ filter (isJust . cReference) newcols
-                        foreignsAlt = map (\fdef -> let (childfields, parentfields) = unzip (map (\(_,b,_,d) -> (b,d)) (foreignFields fdef))
+                        foreignsAlt = map (\fdef -> let (childfields, parentfields) = unzip (map (\((_,b),(_,d)) -> (b,d)) (foreignFields fdef))
                                                     in AlterColumn name (foreignRefTableDBName fdef, AddReference (foreignConstraintNameDBName fdef) childfields parentfields)) fdefs
                     return $ Right $ addTable : uniques ++ references ++ foreignsAlt
                 else do

--- a/persistent-test/CompositeTest.hs
+++ b/persistent-test/CompositeTest.hs
@@ -65,6 +65,11 @@ share [mkPersist persistSettings { mpsGeneric = False }, mkMigrate "compositeMig
       extra44 String
       Primary name name2 age
       deriving Show Eq
+  Tree
+      name    Text
+      parent  Text Maybe
+      Primary name
+      Foreign Tree fkparent parent
   Citizen 
     name String
     age Int Maybe
@@ -167,6 +172,17 @@ specs = describe "composite" $
       let Just c11 = mc
       c1 @== c11
       testChildFkparent c11 @== kp1
+
+    it "Tree relationships" $ db $ do
+      kgp@(TreeKey gpt) <- insert $ Tree "grandpa" Nothing
+      kdad@(TreeKey dadt) <- insert $ Tree "dad" $ Just gpt
+      kc <- insert $ Tree "child" $ Just dadt
+      c <- getJust kc
+      treeFkparent c @== Just kdad
+      dad <- getJust kdad
+      treeFkparent dad @== Just kgp
+      gp <- getJust kgp
+      treeFkparent gp @== Nothing
         
     it "Validate Key contents" $ db $ do
       _ <- insert p1

--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -197,13 +197,18 @@ data PrimaryDef = PrimaryDef
     }
     deriving (Show, Eq, Read, Ord)
 
+-- | Used instead of FieldDef
+-- to generate a smaller amount of code
+type ForeignFieldDef = (HaskellName, DBName)
+
 data ForeignDef = ForeignDef
     { foreignRefTableHaskell       :: !HaskellName
     , foreignRefTableDBName        :: !DBName
     , foreignConstraintNameHaskell :: !HaskellName
     , foreignConstraintNameDBName  :: !DBName
-    , foreignFields                :: ![(HaskellName, DBName, HaskellName, DBName)] -- foreignkey name gb our field plus corresponding other primary field:make this a real adt
+    , foreignFields                :: ![(ForeignFieldDef, ForeignFieldDef)] -- this entity plus the primary entity
     , foreignAttrs                 :: ![Attr]
+    , foreignNullable              :: Bool
     }
     deriving (Show, Eq, Read, Ord)
 


### PR DESCRIPTION
All or none of the Foreign fields must be nullable.

See the Tree test case added in CompositeTest.hs

I made a questionable breaking change of the type of ForeignDef. Since we said 2.0 was unstable I am ok with releasing this with just a bump to 2.0.1 even though that breaks.
