### PR TITLE
Fix composite primary key constraint in sqlite

### DIFF
--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -271,7 +271,7 @@ getCopyTable allDefs getter val = do
 mkCreateTable :: Bool -> EntityDef -> ([Column], [UniqueDef]) -> Text
 mkCreateTable isTemp entity (cols, uniqs) =
   case entityPrimary entity of
-    Just _ ->
+    Just pdef ->
        T.concat
         [ "CREATE"
         , if isTemp then " TEMP" else ""
@@ -281,7 +281,7 @@ mkCreateTable isTemp entity (cols, uniqs) =
         , T.drop 1 $ T.concat $ map sqlColumn cols
         , ", PRIMARY KEY "
         , "("
-        , T.intercalate "," $ map (escape . fieldDB) $ entityFields entity
+        , T.intercalate "," $ map (escape . fieldDB) $ primaryFields pdef
         , ")"
         , ")"
         ]


### PR DESCRIPTION
Only add columns specified in primary key constraint rather than all
table columns.
