### PR TITLE
Fixes #295

### DIFF
--- a/persistent-sqlite/persistent-sqlite.cabal
+++ b/persistent-sqlite/persistent-sqlite.cabal
@@ -39,6 +39,7 @@ library
         extra-libraries: sqlite3
     else
         c-sources:   cbits/sqlite3.c
+        cc-options:  -fPIC
 
     if !os(windows)
         extra-libraries: pthread


### PR DESCRIPTION
Linker error when using `cbits/sqlite.h`.
