### PR TITLE
backend specific updates for MongoDB

### DIFF
--- a/persistent-template/Database/Persist/TH.hs
+++ b/persistent-template/Database/Persist/TH.hs
@@ -1316,6 +1316,7 @@ instance Lift PersistUpdate where
     lift Subtract = [|Subtract|]
     lift Multiply = [|Multiply|]
     lift Divide = [|Divide|]
+    lift (BackendSpecificUpdate x) = [|BackendSpecificUpdate x|]
 
 instance Lift SqlType where
     lift SqlString = [|SqlString|]

--- a/persistent-test/CompositeTest.hs
+++ b/persistent-test/CompositeTest.hs
@@ -36,10 +36,10 @@ import qualified Control.Exception.Control as Control
 #  endif
 
 import Init
-import Data.Maybe (isJust)
 
 import Control.Applicative ((<$>),(<*>))
 #ifndef WITH_MONGODB
+import Data.Maybe (isJust)
 import Database.Persist.TH (mkDeleteCascade)
 #endif
 

--- a/persistent/Database/Persist/Sql/Orphan/PersistQuery.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistQuery.hs
@@ -214,6 +214,7 @@ updateWhereCount filts upds = do
     go'' n Subtract = mconcat [n, "=", n, "-?"]
     go'' n Multiply = mconcat [n, "=", n, "*?"]
     go'' n Divide = mconcat [n, "=", n, "/?"]
+    go'' _ (BackendSpecificUpdate up) = error $ T.unpack $ "BackendSpecificUpdate" `mappend` up `mappend` "not supported"
     go' conn (x, pu) = go'' (connEscapeName conn x) pu
     go x = (updateField x, updateUpdate x)
 

--- a/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
@@ -51,6 +51,7 @@ instance PersistStore Connection where
             go'' n Subtract = T.concat [n, "=", n, "-?"]
             go'' n Multiply = T.concat [n, "=", n, "*?"]
             go'' n Divide = T.concat [n, "=", n, "/?"]
+            go'' _ (BackendSpecificUpdate up) = error $ T.unpack $ "BackendSpecificUpdate" `mappend` up `mappend` "not supported"
         let go' (x, pu) = go'' (connEscapeName conn x) pu
         let wher = case entityPrimary t of
                 Just pdef -> T.intercalate " AND " $ map (\fld -> connEscapeName conn (fieldDB fld) <> "=? ") $ compositeFields pdef

--- a/persistent/Database/Persist/Types.hs
+++ b/persistent/Database/Persist/Types.hs
@@ -4,9 +4,10 @@ module Database.Persist.Types
     ( module Database.Persist.Types.Base
     , SomePersistField (..)
     , Update (..)
+    , BackendSpecificUpdate
     , SelectOpt (..)
-    , BackendSpecificFilter
     , Filter (..)
+    , BackendSpecificFilter
     , Key
     , Entity (..)
     ) where

--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -432,5 +432,6 @@ instance Show OnlyUniqueException where
 instance Exception OnlyUniqueException
 
 
-data PersistUpdate = Assign | Add | Subtract | Multiply | Divide -- FIXME need something else here
-    deriving (Read, Show, Enum, Bounded)
+data PersistUpdate = Assign | Add | Subtract | Multiply | Divide
+                   | BackendSpecificUpdate T.Text
+    deriving (Read, Show)


### PR DESCRIPTION
@snoyberg this only affects persistent-mongoDB except that the PersistUpdate type was changed. Do you have any idea why that type previously derived Enum and Bounded?
