### PR TITLE
Update lower bound of postgresql-simple

### DIFF
--- a/persistent-postgresql/persistent-postgresql.cabal
+++ b/persistent-postgresql/persistent-postgresql.cabal
@@ -16,7 +16,7 @@ bug-reports:     https://github.com/yesodweb/persistent/issues
 library
     build-depends:   base                  >= 4        && < 5
                    , transformers          >= 0.2.1
-                   , postgresql-simple     >= 0.3.10   && < 0.5
+                   , postgresql-simple     >= 0.4.0    && < 0.5
                    , postgresql-libpq      >= 0.6.1    && < 0.10
                    , persistent            >= 2.0.5    && < 2.1
                    , containers            >= 0.2


### PR DESCRIPTION
fromPGArray is only available in postgresql-simple-0.4.0 or newer.

The same patch should be applied to 1.3 branch.
