### PR TITLE
MySQL: read parameter 'path' (socket) in the YAML config

### DIFF
--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -807,14 +807,16 @@ instance PersistConfig MySQLConf where
         database <- o .: "database"
         host     <- o .: "host"
         port     <- o .: "port"
-        path     <- o .: "path"
+        path     <- o .:? "path"
         user     <- o .: "user"
         password <- o .: "password"
         pool     <- o .: "poolsize"
         let ci = MySQL.defaultConnectInfo
                    { MySQL.connectHost     = host
                    , MySQL.connectPort     = port
-                   , MySQL.connectPath     = path
+                   , MySQL.connectPath     = case path of
+                         Just p  -> p
+                         Nothing -> ""
                    , MySQL.connectUser     = user
                    , MySQL.connectPassword = password
                    , MySQL.connectDatabase = database


### PR DESCRIPTION
The `connectInfo` record (inherited from `Database.MySQL.Base`) has a field `connectPath`. I supposed that `Database.Persist.loadConfig` would parse the YAML field "path" like "host" and "port", but it silently ignores it. This simple patch allows to configure a socket access to a MySQL-compatible server (Sphinx Search in my case).

I suggest cherry-picking it to persistent-mysql-1.*.
