### PR TITLE
Changed scripts submodule url to its public location to facilitate public recursive cloning

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "scripts"]
 	path = scripts
-	url = git://github.com/yesodweb/scripts.git
+	url = https://github.com/yesodweb/scripts.git
 [submodule "pool"]
 	path = pool
 	url = https://github.com/bos/pool.git


### PR DESCRIPTION
This allows calls to git submodule update --init to succeed for users without a private key to the
github/yesodweb repositories. Prevents the following error message during a call
to the cabal-meta install command prescribed in the yesod README:

Exception: error running: git clone --recursive https://github.com/yesodweb/persistent
exit status: 1
stderr: fatal: unable to connect to github.com:
github.com[0: 192.30.252.131]: errno=Connection timed out

Clone of 'git://github.com/yesodweb/scripts.git' into submodule path 'scripts' failed
