### PR TITLE
refactor to expose some utilities for Esqueleto

### DIFF
--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -88,6 +88,7 @@ library
                      Database.Persist.Sql.Migration
                      Database.Persist.Sql.Internal
                      Database.Persist.Sql.Types
+                     Database.Persist.Sql.Util
                      Database.Persist.Sql.Raw
                      Database.Persist.Sql.Run
                      Database.Persist.Sql.Class
@@ -149,6 +150,7 @@ library
                    , resource-pool
                    , exceptions
                    , tagged
+                   , old-locale
 
    if flag(nooverlap)
      cpp-options: -DNO_OVERLAP

--- a/persistent/Database/Persist/Sql/Orphan/PersistQuery.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistQuery.hs
@@ -9,7 +9,8 @@ module Database.Persist.Sql.Orphan.PersistQuery
     ) where
 
 import Database.Persist hiding (updateField)
-import Database.Persist.Sql.Util (entityColumnNames, parseEntityValues)
+import Database.Persist.Sql.Util (
+  entityColumnNames, parseEntityValues, isIdField)
 import Database.Persist.Sql.Types
 import Database.Persist.Sql.Raw
 import Database.Persist.Sql.Orphan.PersistStore (withRawQuery)
@@ -192,9 +193,6 @@ updateWhereCount filts upds = do
 
 fieldName ::  forall record typ.  (PersistEntity record, PersistEntityBackend record ~ SqlBackend) => EntityField record typ -> DBName
 fieldName f = fieldDB $ persistFieldDef f
-
-isIdField ::  forall record typ.  (PersistEntity record) => EntityField record typ -> Bool
-isIdField f = fieldHaskell (persistFieldDef f) == HaskellName "Id"
 
 dummyFromFilts :: [Filter v] -> Maybe v
 dummyFromFilts _ = Nothing

--- a/persistent/Database/Persist/Sql/Util.hs
+++ b/persistent/Database/Persist/Sql/Util.hs
@@ -1,17 +1,20 @@
+{-# LANGUAGE OverloadedStrings #-}
 module Database.Persist.Sql.Util (
     parseEntityValues
   , entityColumnNames
   , entityColumnCount
+  , isIdField
+  , hasCompositeKey
 ) where
 
 import Data.Maybe (isJust)
 import Data.Monoid ((<>))
 import Data.Text (Text, pack)
 import Database.Persist (
-    Entity(Entity), EntityDef
+    Entity(Entity), EntityDef, EntityField, HaskellName(HaskellName)
   , PersistEntity, PersistValue, PersistException(PersistMarshalError)
   , keyFromValues, fromPersistValues, fieldDB, entityId, entityPrimary
-  , entityFields, fieldHaskell, compositeFields)
+  , entityFields, fieldHaskell, compositeFields, persistFieldDef)
 import Database.Persist.Sql.Types (Sql, SqlBackend, connEscapeName)
 import Control.Monad.IO.Class (MonadIO(liftIO))
 import Control.Exception (throwIO)
@@ -58,4 +61,7 @@ parseEntityValues t vals =
                 Left _ -> error "fromPersistValuesComposite': keyFromValues failed"
                 Right key -> Right (Entity key xs')
 
+
+isIdField :: PersistEntity record => EntityField record typ -> Bool
+isIdField f = fieldHaskell (persistFieldDef f) == HaskellName "Id"
 

--- a/persistent/Database/Persist/Sql/Util.hs
+++ b/persistent/Database/Persist/Sql/Util.hs
@@ -1,0 +1,61 @@
+module Database.Persist.Sql.Util (
+    parseEntityValues
+  , entityColumnNames
+  , entityColumnCount
+) where
+
+import Data.Maybe (isJust)
+import Data.Monoid ((<>))
+import Data.List (find)
+import Data.Text (Text, pack)
+import Database.Persist (
+    Entity(Entity), EntityDef
+  , PersistEntity, PersistValue, PersistException(PersistMarshalError)
+  , keyFromValues, fromPersistValues, fieldDB, entityId, entityPrimary
+  , entityFields, fieldHaskell, compositeFields)
+import Database.Persist.Sql.Types (Sql, SqlBackend, connEscapeName)
+import Control.Monad.IO.Class (MonadIO(liftIO))
+import Control.Exception (throwIO)
+
+entityColumnNames :: EntityDef -> SqlBackend -> [Sql]
+entityColumnNames ent conn =
+     (if hasCompositeKey ent
+      then [] else [connEscapeName conn $ fieldDB (entityId ent)])
+  <> map (connEscapeName conn . fieldDB) (entityFields ent)
+
+entityColumnCount :: EntityDef -> Int
+entityColumnCount e = length (entityFields e)
+                    + if hasCompositeKey e then 0 else 1
+
+hasCompositeKey :: EntityDef -> Bool
+hasCompositeKey = isJust . entityPrimary
+
+parseEntityValues :: PersistEntity record
+                  => EntityDef -> [PersistValue] -> Either Text (Entity record)
+parseEntityValues t vals = 
+    case entityPrimary t of
+      Just pdef -> 
+            let pks = map fieldHaskell $ compositeFields pdef
+                keyvals = map snd $ filter (\(a, _) -> let ret=isJust (find (== a) pks) in ret) $ zip (map fieldHaskell $ entityFields t) vals
+            in fromPersistValuesComposite' keyvals vals
+      Nothing -> fromPersistValues' vals
+  where
+    fromPersistValues' (kpv:xs) = -- oracle returns Double 
+        case fromPersistValues xs of
+            Left e -> Left e
+            Right xs' ->
+                case keyFromValues [kpv] of
+                    Left _ -> error $ "fromPersistValues': keyFromValues failed on " ++ show kpv
+                    Right k -> Right (Entity k xs')
+
+
+    fromPersistValues' xs = Left $ pack ("error in fromPersistValues' xs=" ++ show xs)
+
+    fromPersistValuesComposite' keyvals xs =
+        case fromPersistValues xs of
+            Left e -> Left e
+            Right xs' -> case keyFromValues keyvals of
+                Left _ -> error "fromPersistValuesComposite': keyFromValues failed"
+                Right key -> Right (Entity key xs')
+
+

--- a/persistent/Database/Persist/Sql/Util.hs
+++ b/persistent/Database/Persist/Sql/Util.hs
@@ -6,7 +6,6 @@ module Database.Persist.Sql.Util (
 
 import Data.Maybe (isJust)
 import Data.Monoid ((<>))
-import Data.List (find)
 import Data.Text (Text, pack)
 import Database.Persist (
     Entity(Entity), EntityDef
@@ -36,7 +35,8 @@ parseEntityValues t vals =
     case entityPrimary t of
       Just pdef -> 
             let pks = map fieldHaskell $ compositeFields pdef
-                keyvals = map snd $ filter (\(a, _) -> let ret=isJust (find (== a) pks) in ret) $ zip (map fieldHaskell $ entityFields t) vals
+                keyvals = map snd . filter ((`elem` pks) . fst)
+                        $ zip (map fieldHaskell $ entityFields t) vals
             in fromPersistValuesComposite' keyvals vals
       Nothing -> fromPersistValues' vals
   where

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:            persistent
-version:         2.1.1.2
+version:         2.1.1.3
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -58,6 +58,7 @@ library
                      Database.Persist.Types
                      Database.Persist.Class
                      Database.Persist.Sql
+                     Database.Persist.Sql.Util
 
     other-modules:   Database.Persist.Types.Base
                      Database.Persist.Class.DeleteCascade


### PR DESCRIPTION
Moved some functionality regarding composite/custom primary keys to an exposed module (perhaps it should be under an "Internal" folder?) so Esqueleto can reuse it. See https://github.com/prowdsponsor/esqueleto/issues/87