### PR TITLE
Fix typo in Postgresql.hs

### DIFF
--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -92,7 +92,7 @@ withPostgresqlPool ci = withSqlPool $ open' ci
 
 
 -- | Create a PostgreSQL connection pool.  Note that it's your
--- responsability to properly close the connection pool when
+-- responsibility to properly close the connection pool when
 -- unneeded.  Use 'withPostgresqlPool' for an automatic resource
 -- control.
 createPostgresqlPool :: (MonadIO m, MonadBaseControl IO m, MonadLogger m)


### PR DESCRIPTION
(This is the same as the typo in MySQL, I just happened to find this one after submitting the MySQL PR and was fixing typos from the Github editing interface)