### PR TITLE
Bump persistent-postgresql version to match hackage (2.1.2.2).

### DIFF
--- a/persistent-postgresql/persistent-postgresql.cabal
+++ b/persistent-postgresql/persistent-postgresql.cabal
@@ -1,5 +1,5 @@
 name:            persistent-postgresql
-version:         2.1.2.1
+version:         2.1.2.2
 license:         MIT
 license-file:    LICENSE
 author:          Felipe Lessa, Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
I noticed the version number was one revision behind: http://hackage.haskell.org/package/persistent-postgresql-2.1.2.2

It might be worth noting that a user was having compile errors with this version earlier in IRC: http://dpaste.com/3RZE40T. I've encouraged them to open an issue.