### PR TITLE
Up dependency on the base package to >= 4.6 (removes GHC 7.4 support)

### DIFF
--- a/experimental/couchDB/persistent-couchdb.cabal
+++ b/experimental/couchDB/persistent-couchdb.cabal
@@ -14,7 +14,7 @@ homepage:        http://www.yesodweb.com/book/persistent
 bug-reports:     https://github.com/yesodweb/persistent/issues
 
 library
-    build-depends:   base                  >= 4        && < 5
+    build-depends:   base                  >= 4.6        && < 5
                    , enumerator
                    , pool
                    , json

--- a/persistent-mongoDB/persistent-mongoDB.cabal
+++ b/persistent-mongoDB/persistent-mongoDB.cabal
@@ -19,7 +19,7 @@ Flag high_precision_date
    Default: False
 
 library
-    build-depends:   base               >= 4 && < 5
+    build-depends:   base               >= 4.6 && < 5
                    , persistent         >= 2.1.1   && < 3
                    , text               >= 0.8
                    , transformers       >= 0.2.1

--- a/persistent-mysql/persistent-mysql.cabal
+++ b/persistent-mysql/persistent-mysql.cabal
@@ -26,7 +26,7 @@ description:
 extra-source-files: ChangeLog.md
 
 library
-    build-depends:   base                  >= 4        && < 5
+    build-depends:   base                  >= 4.6        && < 5
                    , transformers          >= 0.2.1
                    , mysql-simple          >= 0.2.2.3  && < 0.3
                    , mysql                 >= 0.1.1.3  && < 0.2

--- a/persistent-postgresql/persistent-postgresql.cabal
+++ b/persistent-postgresql/persistent-postgresql.cabal
@@ -15,7 +15,7 @@ bug-reports:     https://github.com/yesodweb/persistent/issues
 extra-source-files: ChangeLog.md
 
 library
-    build-depends:   base                  >= 4        && < 5
+    build-depends:   base                  >= 4.6        && < 5
                    , transformers          >= 0.2.1
                    , postgresql-simple     >= 0.4.0    && < 0.5
                    , postgresql-libpq      >= 0.6.1    && < 0.10

--- a/persistent-redis/persistent-redis.cabal
+++ b/persistent-redis/persistent-redis.cabal
@@ -17,7 +17,7 @@ source-repository head
         location:       https://github.com/yesodweb/persistent.git
 
 library
-    build-depends:   base                  >= 4        && < 5
+    build-depends:   base                  >= 4.6        && < 5
                    , hedis                 >= 0.6.0    && < 0.7.0
                    , bytestring            >= 0.10.0.0 && < 0.11.0.0
                    , persistent            >= 2.1      && < 2.2
@@ -47,7 +47,7 @@ library
 test-suite  basic
     type: exitcode-stdio-1.0
     main-is: tests/basic-test.hs
-    build-depends:   base                  >= 4        && < 5
+    build-depends:   base                  >= 4.6        && < 5
                    , hedis                 >= 0.6.0    && < 0.7.0
                    , persistent            >= 2.1      && < 2.2
                    , persistent-template   >= 2.1      && < 2.2

--- a/persistent-sqlite/persistent-sqlite.cabal
+++ b/persistent-sqlite/persistent-sqlite.cabal
@@ -22,7 +22,7 @@ flag build-sanity-exe
   default: False
 
 library
-    build-depends:   base                    >= 4         && < 5
+    build-depends:   base                    >= 4.6         && < 5
                    , bytestring              >= 0.9.1
                    , transformers            >= 0.2.1
                    , persistent              >= 2.1       && < 3

--- a/persistent-template/persistent-template.cabal
+++ b/persistent-template/persistent-template.cabal
@@ -15,7 +15,7 @@ bug-reports:     https://github.com/yesodweb/persistent/issues
 extra-source-files: test/main.hs ChangeLog.md README.md
 
 library
-    build-depends:   base                     >= 4         && < 5
+    build-depends:   base                     >= 4.6         && < 5
                    , template-haskell
                    , persistent               >= 2.1       && < 3
                    , monad-control            >= 0.2       && < 1.1
@@ -39,7 +39,7 @@ test-suite test
     main-is:       main.hs
     hs-source-dirs: test
 
-    build-depends:   base >= 4 && < 5
+    build-depends:   base >= 4.6 && < 5
                    , persistent-template
                    , aeson
                    , hspec >= 1.3

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -105,7 +105,7 @@ library
     -- if impl(ghc >= 7.4)
     --   cpp-options: -DGHC_7_4
 
-    build-depends:   base                     >= 4       && < 5
+    build-depends:   base                     >= 4.6       && < 5
                    , HUnit
                    , hspec >= 1.12.1
                    , hspec-expectations
@@ -238,7 +238,7 @@ test-suite test
   hs-source-dirs: test
   default-language: Haskell2010
 
-  build-depends:   base >= 4 && < 5
+  build-depends:   base >= 4.6 && < 5
                  , persistent-test
                  , hspec
                  , system-filepath

--- a/persistent-zookeeper/persistent-zookeeper.cabal
+++ b/persistent-zookeeper/persistent-zookeeper.cabal
@@ -16,7 +16,7 @@ source-repository head
         location:       https://github.com/junjihashimoto/persistent.git
 
 library
-    build-depends:   base                  >= 4        && < 5
+    build-depends:   base                  >= 4.6        && < 5
                    , bytestring            >= 0.10.0.0 && < 0.11.0.0
                    , persistent            >= 2.1
                    , persistent-template
@@ -57,7 +57,7 @@ library
 test-suite  basic
     type: exitcode-stdio-1.0
     main-is: tests/basic-test.hs
-    build-depends:   base                  >= 4        && < 5
+    build-depends:   base                  >= 4.6        && < 5
                    , persistent            >= 2.1
                    , persistent-template
                    , mtl

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -22,7 +22,7 @@ library
     if flag(nooverlap)
         cpp-options: -DNO_OVERLAP
 
-    build-depends:   base                     >= 4       && < 5
+    build-depends:   base                     >= 4.6       && < 5
                    , bytestring               >= 0.9
                    , transformers             >= 0.2.1
                    , time                     >= 1.1.4
@@ -85,7 +85,7 @@ test-suite test
     type:          exitcode-stdio-1.0
     main-is:       test/main.hs
 
-    build-depends:   base >= 4 && < 5
+    build-depends:   base >= 4.6 && < 5
                    , hspec >= 1.3
                    , containers
                    , text


### PR DESCRIPTION
Based on the discussion in #367 about dropping support for GHC 7.4