### PR TITLE
Add `Show` instances for MySQLConf, SqliteConf and PostgresqlConf

### DIFF
--- a/persistent-mysql/ChangeLog.md
+++ b/persistent-mysql/ChangeLog.md
@@ -1,3 +1,7 @@
+## Master
+
+Added a `Show` instance for `MySQLConf`.
+
 ## 2.1.2.1
 
 Documentation typo fix

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -807,7 +807,7 @@ data MySQLConf = MySQLConf
       -- ^ The connection information.
     , myPoolSize :: Int
       -- ^ How many connections should be held on the connection pool.
-    }
+    } deriving Show
 
 instance FromJSON MySQLConf where
     parseJSON = withObject "MySQLConf" $ \o -> do

--- a/persistent-postgresql/ChangeLog.md
+++ b/persistent-postgresql/ChangeLog.md
@@ -1,3 +1,7 @@
+## Master
+
+Added a `Show` instance for `PostgresConf`.
+
 ## 2.1.2.1
 
 Documentation typo fix

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -868,7 +868,7 @@ data PostgresConf = PostgresConf
       -- ^ The connection string.
     , pgPoolSize :: Int
       -- ^ How many connections should be held on the connection pool.
-    }
+    } deriving Show
 
 instance FromJSON PostgresConf where
     parseJSON = withObject "PostgresConf" $ \o -> do

--- a/persistent-sqlite/ChangeLog.md
+++ b/persistent-sqlite/ChangeLog.md
@@ -1,3 +1,7 @@
+## Master
+
+Added a `Show` instance for `SqliteConf`.
+
 ## 2.1.2
 
 * Turn on write-ahead log [#363](https://github.com/yesodweb/persistent/issues/363)

--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -350,7 +350,7 @@ escape (DBName s) =
 data SqliteConf = SqliteConf
     { sqlDatabase :: Text
     , sqlPoolSize :: Int
-    }
+    } deriving Show
 
 instance FromJSON SqliteConf where
     parseJSON = withObject "SqliteConf" $ \o -> SqliteConf


### PR DESCRIPTION
Derives `Show` instances for configuration values. The main advantage is easier debugging + it let's you derive `Show` for records that contain a Conf value, like `AppSettings` in the scaffolding.

(MongoDB already derives `Show` for its configuration record).