### PR TITLE
Treat unknown extension types as PersistDbSpecific values

### DIFF
--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -320,13 +320,9 @@ builtinGetters = I.fromList
     , (k PS.varbit,      convertPV PersistInt64)
     , (k PS.numeric,     convertPV PersistRational)
     , (k PS.void,        \_ _ -> return PersistNull)
-    , (k PS.uuid,        convertPV (PersistDbSpecific . unUnknown))
     , (k PS.json,        convertPV (PersistByteString . unUnknown))
     , (k PS.jsonb,       convertPV (PersistByteString . unUnknown))
     , (k PS.unknown,     convertPV (PersistByteString . unUnknown))
-    -- add Inet and Cidr types
-    , (k PS.inet,        convertPV (PersistDbSpecific . unUnknown))
-    , (k PS.cidr,        convertPV (PersistDbSpecific . unUnknown))
 
 
 

--- a/persistent-postgresql/persistent-postgresql.cabal
+++ b/persistent-postgresql/persistent-postgresql.cabal
@@ -1,5 +1,5 @@
 name:            persistent-postgresql
-version:         2.1.3
+version:         2.1.4
 license:         MIT
 license-file:    LICENSE
 author:          Felipe Lessa, Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
I'm in the process of implementing a library to create PostgreSQL full text search queries using Esqueleto (https://github.com/albertov/esqueleto-textsearch) and I need to create `PersistField` instance for postgres' `tsvector`, `regconfig` and `tsquery` types. I was tempted to add another set of converters for these types in `builtInExtensionGetters` but since it's not the first time I've done this (see #313) I think a more future-proof solution would be to treat all unknown oids as `PersistDbSpecific` values and let the `PersistField` instances parse them as they see fit.