### PR TITLE
don't use Int internally and throw an error on 32 bit machines when Int is used

### DIFF
--- a/persistent-redis/tests/basic-test.hs
+++ b/persistent-redis/tests/basic-test.hs
@@ -10,6 +10,7 @@ import Database.Persist.TH
 import Language.Haskell.TH.Syntax
 import Control.Monad.IO.Class (liftIO)
 import Data.Text (Text, pack, unpack)
+import Data.Int (Int64)
 
 let redisSettings = mkPersistSettings (ConT ''RedisBackend)
  in share [mkPersist redisSettings] [persistLowerCase| 

--- a/persistent-sqlite/test/Spec.hs
+++ b/persistent-sqlite/test/Spec.hs
@@ -9,6 +9,7 @@
 
 import Control.Monad.IO.Class  (liftIO)
 import Data.Time
+import Data.Int (Int64)
 import Database.Persist.Sqlite
 import Database.Persist.TH
 import Test.Hspec

--- a/persistent-template/test/main.hs
+++ b/persistent-template/test/main.hs
@@ -15,6 +15,7 @@ import Database.Persist.TH
 import Database.Persist.Types (PersistValue(..))
 import Data.Text (Text, pack)
 import Data.Aeson
+import Data.Int (Int64)
 
 share [mkPersist sqlSettings { mpsGeneric = False }, mkDeleteCascade sqlSettings { mpsGeneric = False }] [persistUpperCase|
 Person json

--- a/persistent-zookeeper/tests/basic-test.hs
+++ b/persistent-zookeeper/tests/basic-test.hs
@@ -10,6 +10,7 @@ import Database.Persist.Zookeeper
 import Database.Persist.Zookeeper.Internal
 import Database.Persist.TH
 import Language.Haskell.TH.Syntax ()
+import Data.Int (Int64)
 import Data.Maybe
 import Data.Pool ()
 import Test.Hspec

--- a/persistent/Database/Persist/Quasi.hs
+++ b/persistent/Database/Persist/Quasi.hs
@@ -356,7 +356,7 @@ mkAutoIdField ps entName idName idSqlType = FieldDef
       , fieldType = FTTypeCon Nothing $ keyConName $ unHaskellName entName
       , fieldSqlType = idSqlType
       -- the primary field is actually a reference to the entity
-      , fieldReference = ForeignRef entName (FTTypeCon Nothing "Int")
+      , fieldReference = ForeignRef entName (FTTypeCon Nothing "Int64")
       , fieldAttrs = []
       , fieldStrict = True
       }

--- a/persistent/Database/Persist/Sql/Class.hs
+++ b/persistent/Database/Persist/Sql/Class.hs
@@ -211,7 +211,8 @@ instance PersistFieldSql Html where
     sqlType _ = SqlString
 instance PersistFieldSql Int where
     sqlType _
-        | bitSize (0 :: Int) <= 32 = SqlInt32
+        | bitSize (0 :: Int) <= 32 = error
+            "PersistFieldSql: Int not supported for 32 bit machines. Use Int32 or Int64 instead"
         | otherwise = SqlInt64
 instance PersistFieldSql Int8 where
     sqlType _ = SqlInt32

--- a/persistent/Database/Persist/Sql/Class.hs
+++ b/persistent/Database/Persist/Sql/Class.hs
@@ -211,7 +211,7 @@ instance PersistFieldSql Html where
     sqlType _ = SqlString
 instance PersistFieldSql Int where
     sqlType _
-        | bitSize (0 :: Int) <= 32 = error
+        | bitSize (0 :: Int) < 64 = error
             "PersistFieldSql: Int not supported for 32 bit machines. Use Int32 or Int64 instead"
         | otherwise = SqlInt64
 instance PersistFieldSql Int8 where


### PR DESCRIPTION
Int32 or Int64 should be explicitly used instead

closes #399 