### PR TITLE
Relax aeson upper bound for 0.9.x

### DIFF
--- a/persistent-template/persistent-template.cabal
+++ b/persistent-template/persistent-template.cabal
@@ -23,7 +23,7 @@ library
                    , text                     >= 0.5
                    , transformers             >= 0.2       && < 0.5
                    , containers
-                   , aeson                    >= 0.7       && < 0.9
+                   , aeson                    >= 0.7       && < 0.10
                    , monad-logger
                    , unordered-containers
                    , tagged


### PR DESCRIPTION
`cabal test`'d with `aeson-0.9.1`, passed:

```
$ cabal sandbox hc-pkg list | grep aeson
    aeson-0.9.0.1
```
```
$ cabal test
Package has never been configured. Configuring with default flags. If this
fails, please run configure manually.
Resolving dependencies...
Configuring persistent-template-2.1.3.3...
Preprocessing library persistent-template-2.1.3.3...

Database/Persist/TH.hs:12:14: Warning:
    -XOverlappingInstances is deprecated: instead use per-instance pragmas OVERLAPPING/OVERLAPPABLE/OVERLAPS
[1 of 1] Compiling Database.Persist.TH ( Database/Persist/TH.hs, dist/build/Database/Persist/TH.o )

Database/Persist/TH.hs:62:1: Warning:
    The import of ‘Data.Monoid’ is redundant
      except perhaps to import instances from ‘Data.Monoid’
    To import instances alone, use: import Data.Monoid()

Database/Persist/TH.hs:71:1: Warning:
    The import of ‘Control.Applicative’ is redundant
      except perhaps to import instances from ‘Control.Applicative’
    To import instances alone, use: import Control.Applicative()

Database/Persist/TH.hs:235:26: Warning: Defined but not used: ‘x’

Database/Persist/TH.hs:267:22: Warning:
    This binding for ‘ent’ shadows the existing binding
      bound at Database/Persist/TH.hs:247:41
In-place registering persistent-template-2.1.3.3...
Preprocessing test suite 'test' for persistent-template-2.1.3.3...
[1 of 1] Compiling Main             ( test/main.hs, dist/build/test/test-tmp/Main.o )
Linking dist/build/test/test ...
Running 1 test suites...
Test suite test: RUNNING...
Test suite test: PASS
Test suite logged to: dist/test/persistent-template-2.1.3.3-test.log
1 of 1 test suites (1 of 1 test cases) passed.
```