### PR TITLE
add stack.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 dist
 *.hi
 *.o
+.stack-work/
 
 ## Editor ignores
 TAGS
@@ -27,11 +28,13 @@ cabal.sandbox.config
 
 ## Docker image ignores
 /.cabal/
+/.stackage/
 /.ghc/
 /.bash_history
 /.bashrc
 .mongorc.js
 .dbshell
+crane.yml
 # can use this for Docker databases
 persistent-test/db/
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,11 @@
+resolver: lts-2.9
+packages:
+  - ./persistent
+  - ./persistent-template
+  - ./persistent-sqlite
+  - ./persistent-test
+  - ./persistent-mongoDB
+  - ./persistent-mysql
+  - ./persistent-postgresql
+  #- ./persistent-redis
+  #- ./persistent-zookeeper


### PR DESCRIPTION
With persistent we of course have the issue that someone may not have all the C driver libraries installed (which is why I use the Dockerfile). I only have redis & zookeeper commented out right now because I think their deps don't align with stackage, but we can figure that out later.