### PR TITLE
[WIP] add SqlType constructors to support JSONB

### DIFF
--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -306,10 +306,10 @@ migrate' connectInfo allDefs getter val = do
         let foreigns = do
               Column { cName=cname, cReference=Just (refTblName, a) } <- newcols
               return $ AlterColumn name (refTblName, addReference allDefs (refName name cname) refTblName cname)
-                 
-        let foreignsAlt = map (\fdef -> let (childfields, parentfields) = unzip (map (\((_,b),(_,d)) -> (b,d)) (foreignFields fdef)) 
+
+        let foreignsAlt = map (\fdef -> let (childfields, parentfields) = unzip (map (\((_,b),(_,d)) -> (b,d)) (foreignFields fdef))
                                         in AlterColumn name (foreignRefTableDBName fdef, AddReference (foreignRefTableDBName fdef) (foreignConstraintNameDBName fdef) childfields parentfields)) fdefs
-        
+
         return $ Right $ map showAlterDb $ addTable : uniques ++ foreigns ++ foreignsAlt
       -- No errors and something found, migrate
       (_, _, ([], old')) -> do
@@ -354,7 +354,7 @@ findMaxLenOfColumn allDefs name col =
 
 -- | Helper for 'AddRefence' that finds out the 'entityId'.
 addReference :: [EntityDef] -> DBName -> DBName -> DBName -> AlterColumn
-addReference allDefs fkeyname reftable cname = AddReference reftable fkeyname [cname] [id_] 
+addReference allDefs fkeyname reftable cname = AddReference reftable fkeyname [cname] [id_]
     where
       id_ = maybe (error $ "Could not find ID of entity " ++ show reftable
                          ++ " (allDefs = " ++ show allDefs ++ ")")
@@ -675,6 +675,8 @@ showSqlType SqlString  Nothing    False = "TEXT"
 showSqlType SqlString  (Just i)   True  = "VARCHAR(" ++ show i ++ ") CHARACTER SET utf8"
 showSqlType SqlString  (Just i)   False = "VARCHAR(" ++ show i ++ ")"
 showSqlType SqlTime    _          _     = "TIME"
+showSqlType SqlMap     _          _     = "TEXT" -- serialized to JSON
+showSqlType SqlArray   _          _     = "TEXT" -- serialized to JSON
 showSqlType (SqlOther t) _        _     = T.unpack t
 
 -- | Render an action that must be done on the database.

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -757,6 +757,9 @@ showSqlType SqlDayTime = "TIMESTAMP WITH TIME ZONE"
 showSqlType SqlBlob = "BYTEA"
 showSqlType SqlBool = "BOOLEAN"
 
+showSqlType SqlArray = "VARCHAR" -- serialized to JSON
+showSqlType SqlMap = "VARCHAR"   -- serialized to JSOn
+
 -- Added for aliasing issues re: https://github.com/yesodweb/yesod/issues/682
 showSqlType (SqlOther (T.toLower -> "integer")) = "INT4"
 

--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -211,6 +211,8 @@ showSqlType SqlTime = "TIME"
 showSqlType SqlDayTime = "TIMESTAMP"
 showSqlType SqlBlob = "BLOB"
 showSqlType SqlBool = "BOOLEAN"
+showSqlType SqlArray = "VARCHAR" -- serialized to JSON
+showSqlType SqlMap = "VARCHAR" -- serialized to JSON
 showSqlType (SqlOther t) = t
 
 migrate' :: [EntityDef]

--- a/persistent/Database/Persist/Sql/Class.hs
+++ b/persistent/Database/Persist/Sql/Class.hs
@@ -249,17 +249,17 @@ instance PersistFieldSql TimeOfDay where
 instance PersistFieldSql UTCTime where
     sqlType _ = SqlDayTime
 instance PersistFieldSql a => PersistFieldSql [a] where
-    sqlType _ = SqlString
+    sqlType _ = SqlArray
 instance PersistFieldSql a => PersistFieldSql (V.Vector a) where
-  sqlType _ = SqlString
+  sqlType _ = SqlArray
 instance (Ord a, PersistFieldSql a) => PersistFieldSql (S.Set a) where
-    sqlType _ = SqlString
+    sqlType _ = SqlArray
 instance (PersistFieldSql a, PersistFieldSql b) => PersistFieldSql (a,b) where
-    sqlType _ = SqlString
+    sqlType _ = SqlArray
 instance PersistFieldSql v => PersistFieldSql (IM.IntMap v) where
-    sqlType _ = SqlString
+    sqlType _ = SqlMap
 instance PersistFieldSql v => PersistFieldSql (M.Map T.Text v) where
-    sqlType _ = SqlString
+    sqlType _ = SqlMap
 instance PersistFieldSql PersistValue where
     sqlType _ = SqlInt64 -- since PersistValue should only be used like this for keys, which in SQL are Int64
 instance PersistFieldSql Checkmark where
@@ -277,4 +277,4 @@ instance PersistFieldSql Rational where
 
 -- An embedded Entity
 instance (PersistField record, PersistEntity record) => PersistFieldSql (Entity record) where
-    sqlType _ = SqlString
+    sqlType _ = SqlMap

--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -268,23 +268,23 @@ data PersistValue = PersistText Text
 --
 -- @
 -- data Geo = Geo ByteString
--- 
+--
 -- instance PersistField Geo where
 --   toPersistValue (Geo t) = PersistDbSpecific t
--- 
+--
 --   fromPersistValue (PersistDbSpecific t) = Right $ Geo $ Data.ByteString.concat ["'", t, "'"]
 --   fromPersistValue _ = Left "Geo values must be converted from PersistDbSpecific"
--- 
+--
 -- instance PersistFieldSql Geo where
 --   sqlType _ = SqlOther "GEOGRAPHY(POINT,4326)"
--- 
+--
 -- toPoint :: Double -> Double -> Geo
 -- toPoint lat lon = Geo $ Data.ByteString.concat ["'POINT(", ps $ lon, " ", ps $ lat, ")'"]
 --   where ps = Data.Text.pack . show
 -- @
--- 
+--
 -- If Foo has a geography field, we can then perform insertions like the following:
--- 
+--
 -- @
 -- insert $ Foo (toPoint 44 44)
 -- @
@@ -421,6 +421,8 @@ data SqlType = SqlString
              | SqlTime
              | SqlDayTime -- ^ Always uses UTC timezone
              | SqlBlob
+             | SqlArray
+             | SqlMap
              | SqlOther T.Text -- ^ a backend-specific name
     deriving (Show, Read, Eq, Typeable, Ord)
 


### PR DESCRIPTION
This PR is opened at a very early state and nowhere near done.

The intention of this PR is to have PostgreSQL use the JSONB data type for embedded data rather than serialize things to JSON. Theoretically it may be possible to use PostgreSQL arrays and custom types to achieve this result, but I am assuming that JSONB is more performant particularly as the size of the data that is stored increases.

- [ ] postgresql-simple support?

- [ ] Migration support for JSONB
  - [x] SqlType support for embedding
  - [ ] Use the JSONB type in the migration

- [ ] Serialization support for JSONB
  - [ ] Convert to JSONB
  - [ ] Convert from JSONB

- [ ] PostgreSQL version
  - [ ] Have a check at startup for postgres version 9.4
  - [ ] Determine how to handle < 9.4 (maybe don't support it)