### PR TITLE
allow read-only access to sqlite dbs with optional param in connection string

### DIFF
--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -64,7 +64,12 @@ open' connStr logFunc = do
             | Just cs <- T.stripPrefix "WAL=off " connStr -> (cs, False)
             | otherwise                                   -> (connStr, True)
 
-    conn <- Sqlite.open connStr'
+    let (connStr'', readOnly) = case () of
+          ()
+            | Just cs <- T.stripPrefix "READONLY " connStr'  -> (cs, True)
+            | Just cs <- T.stripPrefix "READWRITE " connStr' -> (cs, False)
+            | otherwise                                      -> (connStr', False)
+    conn <- Sqlite.open connStr'' readOnly
     wrapConnectionWal enableWal conn logFunc
 
 -- | Wrap up a raw 'Sqlite.Connection' as a Persistent SQL 'Connection'.

--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -58,21 +58,14 @@ withSqliteConn = withSqlConn . open'
 
 open' :: Text -> LogFunc -> IO SqlBackend
 open' connStr logFunc = do
-    let (connStr', readOnly) = removeFirst "READONLY " connStr
-    let (connStr'', enableWal) = case () of
+    let (connStr', enableWal) = case () of
           ()
-            | Just cs <- T.stripPrefix "WAL=on "  connStr' -> (cs, True)
-            | Just cs <- T.stripPrefix "WAL=off " connStr' -> (cs, False)
-            | otherwise                                    -> (connStr', True)
+            | Just cs <- T.stripPrefix "WAL=on "  connStr -> (cs, True)
+            | Just cs <- T.stripPrefix "WAL=off " connStr -> (cs, False)
+            | otherwise                                   -> (connStr, True)
 
-    conn <- Sqlite.open connStr'' readOnly
+    conn <- Sqlite.open connStr'
     wrapConnectionWal enableWal conn logFunc
-  where
-    removeFirst :: Text -> Text -> (Text, Bool)
-    removeFirst sub str = case T.splitOn sub str of
-        [_]    -> (str, False)
-        _:strs -> (T.intercalate sub strs, True)
-        []     -> (str, False) -- impossible case, splitOn never returns []
 
 -- | Wrap up a raw 'Sqlite.Connection' as a Persistent SQL 'Connection'.
 --


### PR DESCRIPTION
Sqlite connection can be set to read-only access now.
The default for sqlite connections remains intact (WAL on and READWRITE)

By adding "READONLY " behind an optional "WAL=off ", it is now possible to forbid write actions to the database. Also, when no db file exists, an error is thrown (in the READWRITE default case: the file is created).

The c function `sqlite3_open` is replaced by `sqlite3_open_v2` which allows to set the appropriate flag for read-only access and behaves like `sqlite3_open` otherwise.