### PR TITLE
Have SQLite backend use multi-row inserts for insertMany_

### DIFF
--- a/persistent/Database/Persist/Class/PersistStore.hs
+++ b/persistent/Database/Persist/Class/PersistStore.hs
@@ -95,10 +95,8 @@ class
 
     -- | Same as 'insertMany', but doesn't return any 'Key's.
     --
-    -- The MongoDB, PostgreSQL, and MySQL backends insert all records in
+    -- The MongoDB, PostgreSQL, SQLite and MySQL backends insert all records in
     -- one database query.
-    --
-    -- The SQLite backend inserts rows one-by-one.
     insertMany_ :: (MonadIO m, backend ~ PersistEntityBackend val, PersistEntity val)
                 => [val] -> ReaderT backend m ()
     insertMany_ x = insertMany x >> return ()

--- a/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
@@ -214,11 +214,7 @@ instance PersistStore SqlBackend where
                 , T.intercalate "),(" $ replicate (length valss) $ T.intercalate "," $ map (const "?") (entityFields t)
                 , ")"
                 ]
-
-        -- SQLite only supports multi-row inserts in 3.7.11+ (see https://www.sqlite.org/releaselog/3_7_11.html).
-        if connRDBMS conn == "sqlite"
-            then mapM_ insert vals
-            else rawExecute sql (concat valss)
+        rawExecute sql (concat valss)
       where
         t = entityDef vals
         valss = map (map toPersistValue . toPersistFields) vals


### PR DESCRIPTION
Closes #419 

This doesn't implement any checking of SQLite version before using the feature. I'm not sure if compiling Persistent with system SQLite is a common use case, though. Ubuntu LTS 12's default SQLite wouldn't support the multi-row insert, but Ubuntu LTS 14 would. Edit: Do you guys think it's worth implementing that? I imagine you'd pass the version of SQLite you're using as a config option?

Had some issues running the tests locally for this, but the existing test suite on Travis covers `insertMany_` in several spots so I'm not too concerned.