### PR TITLE
Support multiple GHC versions in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,21 @@
-language: haskell
+
+env:
+ - GHCVER=7.6.3 CABALVER=1.18
+ - GHCVER=7.8.4 CABALVER=1.18
+ - GHCVER=7.10.1 CABALVER=1.22
+ - GHCVER=head CABALVER=head
+
+matrix:
+  allow_failures:
+   - env: GHCVER=7.10.1 CABALVER=1.22
+   - env: GHCVER=head CABALVER=head
+
+before_install:
+ - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
+ - travis_retry sudo apt-get update
+ - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$HOME/.cabal/bin:$PATH
+ - cabal --version
 
 install:
     - sudo add-apt-repository -y ppa:yandex-sysmon/zookeeper-3.4


### PR DESCRIPTION
GHC 7.10.1 is currently an allowed failure due to some version constraint issues in persistent-zookeeper.
