### PR TITLE
Remove version constraints.

### DIFF
--- a/persistent-zookeeper/persistent-zookeeper.cabal
+++ b/persistent-zookeeper/persistent-zookeeper.cabal
@@ -23,7 +23,7 @@ library
                    , template-haskell
                    , text                  >= 0.8
                    , aeson                 >= 0.6.2
-                   , time                  >= 1.4      && < 1.5
+                   , time                  
                    , attoparsec
                    , mtl
                    , transformers
@@ -67,7 +67,7 @@ test-suite  basic
                    , text                  >= 0.8
                    , aeson                 >= 0.6.2
                    , binary                >= 0.7      && < 0.8
-                   , time                  >= 1.4      && < 1.5
+                   , time                  
                    , attoparsec
                    , template-haskell
                    , monad-control


### PR DESCRIPTION
Both the build jobs[1][2] are failing because of the package time.
I'm removing the version constraint in time since there is already a
constraint placed on time by the persistent package. And looking on the
code of persistent-zookeeper, I don't see why a minimal version of 1.4
is required.

https://travis-ci.org/yesodweb/persistent/jobs/72733457
https://travis-ci.org/yesodweb/persistent/jobs/72733456