### PR TITLE
Distinguish between binary and non-binary strings in MySQL

### DIFF
--- a/persistent-mysql/ChangeLog.md
+++ b/persistent-mysql/ChangeLog.md
@@ -1,3 +1,9 @@
+## 2.3
+
+* Distinguish between binary and non-binary strings in MySQL [451](https://github.com/yesodweb/persistent/pull/451)
+	* Previously all string columns (VARCHAR, TEXT, etc.) were being returned from Persistent as `PersistByteString`s (i.e. as binary data). Persistent now checks character set information to determine if the value should be returned as `PersistText` or `PersistByteString`. 
+	* This is a **breaking change** if your code is relying on a `PersistByteString` being returned for string-like MySQL values; persistent-mysql itself had several runtime errors that needed to be fixed because of this patch. High-level code dealing purely with `PersistEntities` should be unaffected.
+
 ## 2.2
 
 * Update to persistent 2.2

--- a/persistent-mysql/persistent-mysql.cabal
+++ b/persistent-mysql/persistent-mysql.cabal
@@ -1,5 +1,5 @@
 name:            persistent-mysql
-version:         2.2
+version:         2.3
 license:         MIT
 license-file:    LICENSE
 author:          Felipe Lessa <felipe.lessa@gmail.com>, Michael Snoyman

--- a/persistent-test/CustomPersistField.hs
+++ b/persistent-test/CustomPersistField.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module CustomPersistField where
+
+import Init
+import Data.Text (pack)
+import qualified Data.Text.Lazy as TL
+import Data.Text.Lazy (toStrict, fromStrict)
+import Data.String (IsString)
+
+newtype Markdown = Markdown TL.Text
+  deriving (Eq, Ord, Monoid, IsString, Show)
+
+instance PersistField Markdown where
+  toPersistValue (Markdown t) = PersistText $ toStrict t
+  fromPersistValue (PersistText t) = Right $ Markdown $ fromStrict t
+  fromPersistValue wrongValue = Left $ pack $ "Yesod.Text.Markdown: When attempting to create Markdown from a PersistValue, received " ++ show wrongValue ++ " when a value of type PersistText was expected."
+
+instance PersistFieldSql Markdown where
+    sqlType _ = SqlString

--- a/persistent-test/CustomPersistField.hs
+++ b/persistent-test/CustomPersistField.hs
@@ -1,10 +1,7 @@
-{-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving, QuasiQuotes, TemplateHaskell, CPP, GADTs, TypeFamilies, OverloadedStrings, FlexibleContexts, FlexibleInstances, EmptyDataDecls, MultiParamTypeClasses #-}
 
+-- This module is used for CustomPersistFieldTest; the TH GHC stage restriction requires it to be here.
+-- The code is taken from the Yesod.Text.Markdown package; see https://github.com/yesodweb/persistent/issues/448
 module CustomPersistField where
 
 import Init
@@ -12,14 +9,16 @@ import Data.Text (pack)
 import qualified Data.Text.Lazy as TL
 import Data.Text.Lazy (toStrict, fromStrict)
 import Data.String (IsString)
+import Database.Persist.Sql
 
 newtype Markdown = Markdown TL.Text
-  deriving (Eq, Ord, Monoid, IsString, Show)
+  deriving (Eq, Ord, IsString, Show)
 
 instance PersistField Markdown where
   toPersistValue (Markdown t) = PersistText $ toStrict t
   fromPersistValue (PersistText t) = Right $ Markdown $ fromStrict t
-  fromPersistValue wrongValue = Left $ pack $ "Yesod.Text.Markdown: When attempting to create Markdown from a PersistValue, received " ++ show wrongValue ++ " when a value of type PersistText was expected."
+  fromPersistValue wrongValue = Left $ pack $ "Received " ++ show wrongValue ++ " when a value of type PersistText was expected."
+
 
 instance PersistFieldSql Markdown where
     sqlType _ = SqlString

--- a/persistent-test/CustomPersistFieldTest.hs
+++ b/persistent-test/CustomPersistFieldTest.hs
@@ -1,0 +1,33 @@
+{-# OPTIONS_GHC -fno-warn-unused-binds #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving, QuasiQuotes, TemplateHaskell, CPP, GADTs, TypeFamilies, OverloadedStrings, FlexibleContexts, FlexibleInstances, EmptyDataDecls, MultiParamTypeClasses #-}
+
+module CustomPersistFieldTest (
+  specs
+#ifndef WITH_NOSQL
+  , customFieldMigrate
+#endif
+) where
+
+import Init
+import CustomPersistField
+
+#ifdef WITH_NOSQL
+db :: Action IO () -> Assertion
+db = db' (return ())
+mkPersist persistSettings [persistUpperCase|
+#else
+share [mkPersist sqlSettings,  mkMigrate "customFieldMigrate"] [persistLowerCase|
+#endif
+  BlogPost
+    article Markdown
+    deriving Show Eq
+|]
+
+specs :: Spec
+specs = describe "Custom persist field" $ do
+  it "should read what it wrote" $ db $ do
+    let originalBlogPost = BlogPost "article"
+    blogPostId <- insert originalBlogPost
+    Just newBlogPost <- get blogPostId
+    liftIO $ originalBlogPost @?= newBlogPost
+

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -84,6 +84,8 @@ library
                      CompositeTest
                      Init
                      PrimaryTest
+                     CustomPersistField
+                     CustomPersistFieldTest
 
                      Database.Persist
                      Database.Persist.Quasi

--- a/persistent-test/test/main.hs
+++ b/persistent-test/test/main.hs
@@ -18,6 +18,7 @@ import qualified MigrationOnlyTest
 import qualified PersistUniqueTest
 import qualified CompositeTest
 import qualified PrimaryTest
+import qualified CustomPersistFieldTest
 import Test.Hspec (hspec)
 import Test.Hspec.Runner
 import Init
@@ -62,6 +63,7 @@ main = do
       , MigrationTest.migrationMigrate
       , PersistUniqueTest.migration
       , RenameTest.migration
+      , CustomPersistFieldTest.customFieldMigrate
 #  ifndef WITH_MYSQL
       , PrimaryTest.migration
 #  endif
@@ -86,6 +88,7 @@ main = do
     CompositeTest.specs
     PersistUniqueTest.specs
     PrimaryTest.specs
+    CustomPersistFieldTest.specs
 
 #ifndef WITH_NOSQL
     MigrationTest.specs


### PR DESCRIPTION
Closes #448 

This PR adds a failing test case demonstrating persistent-mysql writing a `PersistText` but reading a `PersistByteString`. The second commit of the PR uses character set information to distinguish between ~~TEXT and BLOB~~ binary and non-binary strings in MySQL, fixing the failing test.

This PR could break existing code. If code is relying on reading a `PersistByteString` from a MySQL `TEXT` column, that code will break (as it did for `getColumn`).