### PR TITLE
Handle composite keys in RawSql (Entity a)

### DIFF
--- a/persistent-test/CompositeTest.hs
+++ b/persistent-test/CompositeTest.hs
@@ -269,11 +269,15 @@ specs = describe "composite" $
 
       newp2 <- get kp2
       newp2 @== Just p2
-    it "rawSql instance" $ db $ do
+    it "RawSql Key instance" $ db $ do
       key <- insert p1
       keyFromRaw <- rawSql "SELECT name, name2, age FROM test_parent LIMIT 1" []
       [key] @== keyFromRaw
-      
+    it "RawSql Entity instance" $ db $ do
+      key <- insert p1
+      newp1 <- rawSql "SELECT ?? FROM test_parent LIMIT 1" []
+      [Entity key p1] @== newp1
+
 #endif
 
 matchK :: (PersistField a, PersistEntity record) => Key record -> Either Text a


### PR DESCRIPTION
This is an attempt to resolve #457 by teaching `RawSql` how to handle composite keys (i.e. `Primary`). The crux of it is [`keyFields`](https://github.com/yesodweb/persistent/pull/463/files#diff-360db80d5d02f984c61fb1c708497d3aR86), which (intends to!) find the "true" `FieldDef`s for an entity's key.