### PR TITLE
Improve failed migration error message

### DIFF
--- a/persistent/Database/Persist/Sql/Migration.hs
+++ b/persistent/Database/Persist/Sql/Migration.hs
@@ -81,13 +81,13 @@ runMigration'
     -> ReaderT SqlBackend m [Text]
 runMigration' m silent = do
     mig <- parseMigration' m
-    case filter fst mig of
-        [] -> mapM (executeMigrate silent) $ sortMigrations $ safeSql mig
-        _  -> error $ concat
-            [ "\n\nDatabase migration: manual intervention required.\n"
-            , "The unsafe actions are prefixed by '***' below:\n\n"
-            , unlines $ map displayMigration mig
-            ]
+    if any fst mig
+        then error $ concat
+                 [ "\n\nDatabase migration: manual intervention required.\n"
+                 , "The unsafe actions are prefixed by '***' below:\n\n"
+                 , unlines $ map displayMigration mig
+                 ]
+        else mapM (executeMigrate silent) $ sortMigrations $ safeSql mig
   where
     displayMigration :: (Bool, Sql) -> String
     displayMigration (True,  s) = "*** " ++ unpack s ++ ";"


### PR DESCRIPTION
It would be nice to see the entire migration when an unsafe statement is found, using `runMigration` and friends.

Before:
```
Database migration: manual intervention required.
The following actions are considered unsafe:

    DROP TABLE "player";
```

After:
```
Database migration: manual intervention required.
The unsafe actions are prefixed by '***' below:

    CREATE TEMP TABLE "player_backup"("id" INTEGER PRIMARY KEY,"device_idee" BLOB NOT NULL);
    INSERT INTO "player_backup"("id") SELECT "id" FROM "player";
*** DROP TABLE "player";
    CREATE TABLE "player"("id" INTEGER PRIMARY KEY,"device_idee" BLOB NOT NULL);
    INSERT INTO "player" SELECT "id","device_idee" FROM "player_backup";
    DROP TABLE "player_backup";
```