### PR TITLE
persistent-sqlite.cabal: fix test/sanity.hs test

### DIFF
--- a/persistent-sqlite/persistent-sqlite.cabal
+++ b/persistent-sqlite/persistent-sqlite.cabal
@@ -74,4 +74,4 @@ executable sanity
         buildable: False
     main-is: sanity.hs
     hs-source-dirs: test
-    build-depends: base, persistent-sqlite
+    build-depends: base, persistent-sqlite, monad-logger

--- a/persistent-sqlite/test/sanity.hs
+++ b/persistent-sqlite/test/sanity.hs
@@ -1,8 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 import Database.Persist.Sqlite
+import Control.Monad.Logger
 
 $(return []) -- just force TH to run
 
 main :: IO ()
-main = withSqliteConn ":memory:" $ const $ return ()
+main = runStderrLoggingT $ withSqliteConn ":memory:" $ const $ return ()


### PR DESCRIPTION
ghc detects build failure as:
  Preprocessing executable 'sanity' for persistent-sqlite-2.2.1...
  [1 of 1] Compiling Main             ( test/sanity.hs, dist/build/sanity/sanity-tmp/Main.dyn_o )

  test/sanity.hs:8:8:
    No instance for (monad-logger-0.3.13.2:Control.Monad.Logger.MonadLogger
                       IO)
      arising from a use of ‘withSqliteConn’
    In the expression: withSqliteConn ":memory:"
    In the expression: withSqliteConn ":memory:" $ const $ return ()
    In an equation for ‘main’:
        main = withSqliteConn ":memory:" $ const $ return ()

Reported-by: Nick Bowler
Gentoo-bug: https://bugs.gentoo.org/show_bug.cgi?id=561274
Signed-off-by: Sergei Trofimovich <siarheit@google.com>