### PR TITLE
use an aeson compatibility layer

### DIFF
--- a/persistent-template/Database/Persist/TH.hs
+++ b/persistent-template/Database/Persist/TH.hs
@@ -63,7 +63,7 @@ import Data.Monoid (mappend, mconcat)
 import Text.Read (readPrec, lexP, step, prec, parens, Lexeme(Ident))
 import qualified Data.Map as M
 import qualified Data.HashMap.Strict as HM
-import Data.Aeson
+import Data.Aeson.Compat
     ( ToJSON (toJSON), FromJSON (parseJSON), (.=), object
     , Value (Object), (.:), (.:?)
     , eitherDecodeStrict'
@@ -914,7 +914,7 @@ mkEntity mps t = do
     fkc <- mapM (mkForeignKeysComposite mps t) $ entityForeigns t
 
     let primaryField = entityId t
-    
+
     fields <- mapM (mkField mps t) $ primaryField : entityFields t
     toFieldNames <- mkToFieldNames $ entityUniques t
 
@@ -1036,12 +1036,12 @@ mkForeignKeysComposite mps t ForeignDef {..} = do
    let reftableKeyName = mkName $ reftableString `mappend` "Key"
    let tablename = mkName $ unpack $ entityText t
    recordName <- newName "record"
-   
+
    let fldsE = map (\((foreignName, _),_) -> VarE (fieldName $ foreignName)
                  `AppE` VarE recordName) foreignFields
    let mkKeyE = foldl' AppE (maybeExp foreignNullable $ ConE reftableKeyName) fldsE
    let fn = FunD fname [normalClause [VarP recordName] mkKeyE]
-   
+
    let t2 = maybeTyp foreignNullable $ ConT ''Key `AppT` ConT (mkName reftableString)
    let sig = SigD fname $ (ArrowT `AppT` (ConT tablename)) `AppT` t2
    return [sig, fn]
@@ -1060,7 +1060,7 @@ maybeTyp may typ | may = ConT ''Maybe `AppT` typ
 -- @
 --   instance PersistEntity e => PersistField e where
 --      toPersistValue = PersistMap $ zip columNames (map toPersistValue . toPersistFields)
---      fromPersistValue (PersistMap o) = 
+--      fromPersistValue (PersistMap o) =
 --          let columns = HM.fromList o
 --          in fromPersistValues $ map (\name ->
 --            case HM.lookup name columns of
@@ -1266,7 +1266,7 @@ derivePersistField s = do
 -- | Automatically creates a valid 'PersistField' instance for any datatype
 -- that has valid 'ToJSON' and 'FromJSON' instances. For a datatype @T@ it
 -- generates instances similar to these:
--- 
+--
 -- @
 --    instance PersistField T where
 --        toPersistValue = PersistByteString . L.toStrict . encode

--- a/persistent-template/persistent-template.cabal
+++ b/persistent-template/persistent-template.cabal
@@ -1,5 +1,5 @@
 name:            persistent-template
-version:         2.1.3.6
+version:         2.1.3.7
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -23,7 +23,8 @@ library
                    , text                     >= 0.5
                    , transformers             >= 0.2       && < 0.5
                    , containers
-                   , aeson                    >= 0.7       && < 0.10
+                   , aeson                    >= 0.7       && < 0.11
+                   , aeson-extra              >= 0.2.1.0   && < 0.3
                    , monad-logger
                    , unordered-containers
                    , tagged

--- a/persistent-test/CustomPersistField.hs
+++ b/persistent-test/CustomPersistField.hs
@@ -9,7 +9,6 @@ import Data.Text (pack)
 import qualified Data.Text.Lazy as TL
 import Data.Text.Lazy (toStrict, fromStrict)
 import Data.String (IsString)
-import Database.Persist.Sql
 
 newtype Markdown = Markdown TL.Text
   deriving (Eq, Ord, IsString, Show)

--- a/persistent-test/CustomPrimaryKeyReferenceTest.hs
+++ b/persistent-test/CustomPrimaryKeyReferenceTest.hs
@@ -42,12 +42,11 @@ specs = describe "custom primary key reference" $ do
 #else
 
   let tweet = Tweet {tweetTweetId = 1, tweetStatusText = "Hello!"}
-  
+
   it "can insert a Tweet" $ db $ do
     tweetId <- insert tweet
     let url = TweetUrl {tweetUrlTweetId = tweetId, tweetUrlTweetUrl = "http://google.com", tweetUrlFinalUrl = Just "http://example.com"}
-    u <- insert url
-    return ()
+    insert_ url
 
   return ()
 

--- a/persistent-test/EmbedTest.hs
+++ b/persistent-test/EmbedTest.hs
@@ -23,7 +23,6 @@ import Database.MongoDB (Value(String))
 import EntityEmbedTest
 import System.Process (readProcess)
 #endif
-import Database.Persist.Sql.Class
 import Data.List.NonEmpty hiding (insert, length)
 
 data TestException = TestException

--- a/persistent-test/Init.hs
+++ b/persistent-test/Init.hs
@@ -42,6 +42,8 @@ module Init (
   , module Control.Monad
 #ifndef WITH_NOSQL
   , module Database.Persist.Sql
+#else
+  , PersistFieldSql(..)
 #endif
 ) where
 
@@ -63,6 +65,7 @@ import qualified Data.ByteString as BS
 #ifdef WITH_NOSQL
 import Language.Haskell.TH.Syntax (Type(..))
 import Database.Persist.TH (mkPersistSettings)
+import Database.Persist.Sql (PersistFieldSql(..))
 
 import Control.Monad (void, replicateM, liftM)
 

--- a/persistent-test/PersistentTest.hs
+++ b/persistent-test/PersistentTest.hs
@@ -195,9 +195,6 @@ catchPersistException action errValue = do
 
 specs :: Spec
 specs = describe "persistent" $ do
-  let petOwner = belongsToJust petOwnerId
-  let maybeOwnedPetOwner = belongsTo maybeOwnedPetOwnerId
-
   it "fieldLens" $ do
       let michael = Entity undefined $ Person "Michael" 28 Nothing :: Entity Person
           michaelP1 = Person "Michael" 29 Nothing :: Person
@@ -207,22 +204,20 @@ specs = describe "persistent" $ do
   it "FilterOr []" $ db $ do
       let p = Person "z" 1 Nothing
       _ <- insert p
-      let action = selectList [FilterOr []] [Desc PersonAge]
 #ifdef WITH_MONGODB
-      ps <- catchPersistException action []
+      ps <- catchPersistException (selectList [FilterOr []] [Desc PersonAge]) []
 #else
-      ps <- action
+      ps <- (selectList [FilterOr []] [Desc PersonAge])
 #endif
       assertEmpty ps
 
   it "||. []" $ db $ do
       let p = Person "z" 1 Nothing
       _ <- insert p
-      let action = count $ [PersonName ==. "a"] ||. []
 #ifdef WITH_MONGODB
-      c <- catchPersistException action 1
+      c <- catchPersistException (count $ [PersonName ==. "a"] ||. []) 1
 #else
-      c <- action
+      c <- (count $ [PersonName ==. "a"] ||. [])
 #endif
       c @== (1::Int)
 
@@ -683,7 +678,7 @@ specs = describe "persistent" $ do
       let cat = Pet person "Mittens" Cat
       p2 <- getJust $ petOwnerId cat
       p @== p2
-      p3 <- petOwner cat
+      p3 <- belongsToJust petOwnerId $ cat
       p @== p3
 
   it "retrieves a belongsTo association" $ db $ do
@@ -692,7 +687,7 @@ specs = describe "persistent" $ do
       let cat = MaybeOwnedPet (Just person) "Mittens" Cat
       p2 <- getJust $ fromJust $ maybeOwnedPetOwnerId cat
       p @== p2
-      Just p4 <- maybeOwnedPetOwner cat
+      Just p4 <- belongsTo maybeOwnedPetOwnerId $ cat
       p @== p4
 
   it "derivePersistField" $ db $ do

--- a/persistent-test/PrimaryTest.hs
+++ b/persistent-test/PrimaryTest.hs
@@ -40,8 +40,8 @@ specs = describe "primary key reference" $ do
   return ()
 #  else
   it "insert a primary reference" $ db $ do
-    kf <- insert $ Foo "name"
-    kb <- insert $ Bar kf
+    kf  <- insert $ Foo "name"
+    _kb <- insert $ Bar kf
     return ()
   it "uses RawSql for a Primary key" $ db $ do
     key <- insert $ Foo "name"

--- a/persistent-test/RenameTest.hs
+++ b/persistent-test/RenameTest.hs
@@ -11,12 +11,14 @@ import Data.Time (getCurrentTime, Day, UTCTime(..))
 import qualified Data.Map as Map
 import qualified Data.Text as T
 import Data.Aeson
-
-
 import Init
 
+#if MIN_VERSION_aeson(0,10,0)
+import Data.Aeson.Types
+#else
 instance ToJSON Day   where toJSON    = error "Day.toJSON"
 instance FromJSON Day where parseJSON = error "Day.parseJSON"
+#endif
 
 -- persistent used to not allow types with an "Id" suffix
 -- this verifies that the issue is fixed

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -132,6 +132,7 @@ library
                    , file-location >= 0.4
                    , template-haskell
                    , aeson                    >= 0.7
+                   , aeson-extra              >= 0.2
                    , lifted-base              >= 0.1
                    , network
                    , path-pieces              >= 0.1

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -190,7 +190,7 @@ library
 
    if flag(postgresql)
      build-depends:
-                     postgresql-simple     >= 0.4
+                     postgresql-simple     >= 0.4 && < 0.5
                    , postgresql-libpq      >= 0.6
 
      exposed-modules:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-2.17
+resolver: lts-3.4
 packages:
   - ./persistent
   - ./persistent-template
@@ -9,3 +9,8 @@ packages:
   #- ./persistent-postgresql
   #- ./persistent-redis
   #- ./persistent-zookeeper
+
+extra-deps:
+  - aeson-extra-0.2.0.0
+  - aeson-0.10.0.0
+  - attoparsec-0.13.0.1


### PR DESCRIPTION
0.11 introduced an arbitrary break in the API. It may be better just to correct that with the following

```
(.:??) :: FromJSON a => Object -> Text -> Parser (Maybe a)
o .:?? k = fmap join (o .:? k)
```