### PR TITLE
Database/Persist/MySQL.hs: fix haddock markup

### DIFF
--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -415,10 +415,10 @@ data AlterColumn = Change Column
                  | Update' String
                  -- | See the definition of the 'showAlter' function to see how these fields are used.
                  | AddReference
-                    DBName -- ^ Referenced table
-                    DBName -- ^ Foreign key name
-                    [DBName] -- ^ Referencing columns
-                    [DBName] -- ^ Referenced columns
+                    DBName -- Referenced table
+                    DBName -- Foreign key name
+                    [DBName] -- Referencing columns
+                    [DBName] -- Referenced columns
                  | DropReference DBName
 
 type AlterColumn' = (DBName, AlterColumn)


### PR DESCRIPTION
haddock does not allow sticking docstrings to
unnamed constructor fields:
    Database/Persist/MySQL.hs:419:21: parse error on input ‘DBName’

Signed-off-by: Sergei Trofimovich <siarheit@google.com>