### PR TITLE
Support http-api-data

### DIFF
--- a/persistent-mongoDB/Database/Persist/MongoDB.hs
+++ b/persistent-mongoDB/Database/Persist/MongoDB.hs
@@ -132,8 +132,7 @@ import qualified Data.ByteString as BS
 import qualified Data.Text.Encoding as E
 import qualified Data.Serialize as Serialize
 import Web.PathPieces (PathPiece(..))
-import Web.HttpApiData (ToHttpApiData(..), FromHttpApiData(..))
-import Web.HttpApiData.Internal (parseUrlPieceWithPrefix, readEitherTextData, parseUrlPieceMaybe)
+import Web.HttpApiData (ToHttpApiData(..), FromHttpApiData(..), parseUrlPieceMaybe, parseUrlPieceWithPrefix, readTextData)
 import Data.Conduit
 import Control.Monad.IO.Class (liftIO)
 import Data.Aeson (Value (Number), (.:), (.:?), (.!=), FromJSON(..), ToJSON(..), withText, withObject)
@@ -220,7 +219,7 @@ instance ToHttpApiData (BackendKey DB.MongoContext) where
 instance FromHttpApiData (BackendKey DB.MongoContext) where
     parseUrlPiece input = do
       s <- parseUrlPieceWithPrefix "o" input <!> return input
-      MongoKey <$> readEitherTextData s
+      MongoKey <$> readTextData s
       where
         infixl 3 <!>
         Left _ <!> y = y

--- a/persistent-mongoDB/Database/Persist/MongoDB.hs
+++ b/persistent-mongoDB/Database/Persist/MongoDB.hs
@@ -122,7 +122,7 @@ import qualified Data.Traversable as Traversable
 import Data.Bson (ObjectId(..))
 import qualified Database.MongoDB as DB
 import Database.MongoDB.Query (Database)
-import Control.Applicative (Applicative)
+import Control.Applicative (Applicative, (<$>))
 import Network (PortID (PortNumber))
 import Network.Socket (HostName)
 import Data.Maybe (mapMaybe, fromJust)

--- a/persistent-mongoDB/Database/Persist/MongoDB.hs
+++ b/persistent-mongoDB/Database/Persist/MongoDB.hs
@@ -131,9 +131,9 @@ import Data.Text (Text)
 import qualified Data.ByteString as BS
 import qualified Data.Text.Encoding as E
 import qualified Data.Serialize as Serialize
-import Web.PathPieces (PathPiece)
+import Web.PathPieces (PathPiece(..))
 import Web.HttpApiData (ToHttpApiData(..), FromHttpApiData(..))
-import Web.HttpApiData.Internal (parseUrlPieceWithPrefix, readEitherTextData)
+import Web.HttpApiData.Internal (parseUrlPieceWithPrefix, readEitherTextData, parseUrlPieceMaybe)
 import Data.Conduit
 import Control.Monad.IO.Class (liftIO)
 import Data.Aeson (Value (Number), (.:), (.:?), (.!=), FromJSON(..), ToJSON(..), withText, withObject)
@@ -227,7 +227,9 @@ instance FromHttpApiData (BackendKey DB.MongoContext) where
         x      <!> _ = x
 
 -- | ToPathPiece is used to convert a key to/from text
-instance PathPiece (BackendKey DB.MongoContext)
+instance PathPiece (BackendKey DB.MongoContext) where
+  toPathPiece   = toUrlPiece
+  fromPathPiece = parseUrlPieceMaybe
 
 keyToText :: BackendKey DB.MongoContext -> Text
 keyToText = T.pack . show . unMongoKey

--- a/persistent-mongoDB/persistent-mongoDB.cabal
+++ b/persistent-mongoDB/persistent-mongoDB.cabal
@@ -32,7 +32,7 @@ library
                    , network            >= 2.2.1.7
                    , cereal             >= 0.3.0.0
                    , path-pieces        >= 0.1
-                   , http-api-data
+                   , http-api-data            >= 0.1       && < 0.2
                    , monad-control      >= 0.3
                    , aeson              >= 0.6.2
                    , attoparsec

--- a/persistent-mongoDB/persistent-mongoDB.cabal
+++ b/persistent-mongoDB/persistent-mongoDB.cabal
@@ -32,7 +32,7 @@ library
                    , network            >= 2.2.1.7
                    , cereal             >= 0.3.0.0
                    , path-pieces        >= 0.1
-                   , http-api-data            >= 0.1       && < 0.2
+                   , http-api-data      >= 0.2       && < 0.3
                    , monad-control      >= 0.3
                    , aeson              >= 0.6.2
                    , attoparsec

--- a/persistent-mongoDB/persistent-mongoDB.cabal
+++ b/persistent-mongoDB/persistent-mongoDB.cabal
@@ -32,6 +32,7 @@ library
                    , network            >= 2.2.1.7
                    , cereal             >= 0.3.0.0
                    , path-pieces        >= 0.1
+                   , http-api-data
                    , monad-control      >= 0.3
                    , aeson              >= 0.6.2
                    , attoparsec

--- a/persistent-redis/Database/Persist/Redis/Store.hs
+++ b/persistent-redis/Database/Persist/Redis/Store.hs
@@ -17,8 +17,9 @@ import Data.Text (Text, pack)
 import Database.Persist.Redis.Config (RedisT, thisConnection)
 import Database.Persist.Redis.Internal
 import Database.Persist.Redis.Update
-import Web.PathPieces (PathPiece)
+import Web.PathPieces (PathPiece(..))
 import Web.HttpApiData (ToHttpApiData (..), FromHttpApiData (..))
+import Web.HttpApiData.Internal (parseUrlPieceMaybe)
 
 import Data.Aeson(FromJSON(..), ToJSON(..))
 
@@ -105,7 +106,9 @@ instance FromHttpApiData (BackendKey RedisBackend) where
     parseUrlPiece = return . RedisKey
 -- some checking that entity exists and it is in format of entityname_id is omitted
 
-instance PathPiece (BackendKey RedisBackend)
+instance PathPiece (BackendKey RedisBackend) where
+  toPathPiece   = toUrlPiece
+  fromPathPiece = parseUrlPieceMaybe
 
 instance Sql.PersistFieldSql (BackendKey RedisBackend) where
     sqlType _ = Sql.SqlOther (pack "doesn't make much sense for Redis backend")

--- a/persistent-redis/Database/Persist/Redis/Store.hs
+++ b/persistent-redis/Database/Persist/Redis/Store.hs
@@ -17,7 +17,8 @@ import Data.Text (Text, pack)
 import Database.Persist.Redis.Config (RedisT, thisConnection)
 import Database.Persist.Redis.Internal
 import Database.Persist.Redis.Update
-import Web.PathPieces (PathPiece (..))
+import Web.PathPieces (PathPiece)
+import Web.HttpApiData (ToHttpApiData (..), FromHttpApiData (..))
 
 import Data.Aeson(FromJSON(..), ToJSON(..))
 
@@ -97,10 +98,14 @@ instance PersistStore R.Connection where
                 insertKey k val
         return()
 
-instance PathPiece (BackendKey RedisBackend) where
-    toPathPiece (RedisKey txt) = txt
-    fromPathPiece txt = Just $ RedisKey txt 
+instance ToHttpApiData (BackendKey RedisBackend) where
+    toUrlPiece (RedisKey txt) = txt
+
+instance FromHttpApiData (BackendKey RedisBackend) where
+    parseUrlPiece = return . RedisKey
 -- some checking that entity exists and it is in format of entityname_id is omitted
+
+instance PathPiece (BackendKey RedisBackend)
 
 instance Sql.PersistFieldSql (BackendKey RedisBackend) where
     sqlType _ = Sql.SqlOther (pack "doesn't make much sense for Redis backend")

--- a/persistent-redis/Database/Persist/Redis/Store.hs
+++ b/persistent-redis/Database/Persist/Redis/Store.hs
@@ -18,8 +18,7 @@ import Database.Persist.Redis.Config (RedisT, thisConnection)
 import Database.Persist.Redis.Internal
 import Database.Persist.Redis.Update
 import Web.PathPieces (PathPiece(..))
-import Web.HttpApiData (ToHttpApiData (..), FromHttpApiData (..))
-import Web.HttpApiData.Internal (parseUrlPieceMaybe)
+import Web.HttpApiData (ToHttpApiData (..), FromHttpApiData (..), parseUrlPieceMaybe)
 
 import Data.Aeson(FromJSON(..), ToJSON(..))
 

--- a/persistent-template/Database/Persist/TH.hs
+++ b/persistent-template/Database/Persist/TH.hs
@@ -72,8 +72,7 @@ import Control.Applicative (pure, (<$>), (<*>))
 import Database.Persist.Sql (sqlType)
 import Data.Proxy (Proxy (Proxy))
 import Web.PathPieces (PathPiece(..))
-import Web.HttpApiData (ToHttpApiData(..), FromHttpApiData(..))
-import Web.HttpApiData.Internal (parseUrlPieceMaybe)
+import Web.HttpApiData (ToHttpApiData(..), FromHttpApiData(..), parseUrlPieceMaybe)
 import GHC.Generics (Generic)
 import qualified Data.Text.Encoding as TE
 

--- a/persistent-template/Database/Persist/TH.hs
+++ b/persistent-template/Database/Persist/TH.hs
@@ -71,8 +71,9 @@ import Data.Aeson.Compat
 import Control.Applicative (pure, (<$>), (<*>))
 import Database.Persist.Sql (sqlType)
 import Data.Proxy (Proxy (Proxy))
-import Web.PathPieces (PathPiece)
+import Web.PathPieces (PathPiece(..))
 import Web.HttpApiData (ToHttpApiData(..), FromHttpApiData(..))
+import Web.HttpApiData.Internal (parseUrlPieceMaybe)
 import GHC.Generics (Generic)
 import qualified Data.Text.Encoding as TE
 
@@ -756,7 +757,9 @@ mkKeyTypeDec mps t = do
                 toUrlPiece = toUrlPiece . $(return unKeyE)
              instance FromHttpApiData (BackendKey $(pure backendT)) => FromHttpApiData(Key $(pure recordType)) where
                 parseUrlPiece = fmap $(return keyConE) . parseUrlPiece
-             instance PathPiece (BackendKey $(pure backendT)) => PathPiece (Key $(pure recordType))
+             instance PathPiece (BackendKey $(pure backendT)) => PathPiece (Key $(pure recordType)) where
+                toPathPiece = toPathPiece . $(return unKeyE)
+                fromPathPiece = fmap $(return keyConE) . fromPathPiece
              instance PersistField (BackendKey $(pure backendT)) => PersistField (Key $(pure recordType)) where
                 toPersistValue = toPersistValue . $(return unKeyE)
                 fromPersistValue = fmap $(return keyConE) . fromPersistValue

--- a/persistent-template/persistent-template.cabal
+++ b/persistent-template/persistent-template.cabal
@@ -29,7 +29,7 @@ library
                    , unordered-containers
                    , tagged
                    , path-pieces
-                   , http-api-data            >= 0.1       && < 0.2
+                   , http-api-data            >= 0.2       && < 0.3
                    , ghc-prim
     exposed-modules: Database.Persist.TH
     ghc-options:     -Wall

--- a/persistent-template/persistent-template.cabal
+++ b/persistent-template/persistent-template.cabal
@@ -29,7 +29,7 @@ library
                    , unordered-containers
                    , tagged
                    , path-pieces
-                   , http-api-data
+                   , http-api-data            >= 0.1       && < 0.2
                    , ghc-prim
     exposed-modules: Database.Persist.TH
     ghc-options:     -Wall

--- a/persistent-template/persistent-template.cabal
+++ b/persistent-template/persistent-template.cabal
@@ -29,6 +29,7 @@ library
                    , unordered-containers
                    , tagged
                    , path-pieces
+                   , http-api-data
                    , ghc-prim
     exposed-modules: Database.Persist.TH
     ghc-options:     -Wall

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -136,7 +136,7 @@ library
                    , lifted-base              >= 0.1
                    , network
                    , path-pieces              >= 0.1
-                   , http-api-data            >= 0.1       && < 0.2
+                   , http-api-data            >= 0.2       && < 0.3
                    , text                     >= 0.8
                    , transformers             >= 0.2.1
                    , monad-control            >= 0.3

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -136,7 +136,7 @@ library
                    , lifted-base              >= 0.1
                    , network
                    , path-pieces              >= 0.1
-                   , http-api-data
+                   , http-api-data            >= 0.1       && < 0.2
                    , text                     >= 0.8
                    , transformers             >= 0.2.1
                    , monad-control            >= 0.3

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -136,6 +136,7 @@ library
                    , lifted-base              >= 0.1
                    , network
                    , path-pieces              >= 0.1
+                   , http-api-data
                    , text                     >= 0.8
                    , transformers             >= 0.2.1
                    , monad-control            >= 0.3

--- a/persistent-zookeeper/Database/Persist/Zookeeper/Store.hs
+++ b/persistent-zookeeper/Database/Persist/Zookeeper/Store.hs
@@ -25,7 +25,7 @@ import qualified Data.Aeson.Types as A
 
 import Web.PathPieces (PathPiece(..))
 import Web.HttpApiData (ToHttpApiData (..), FromHttpApiData (..))
-import Web.HttpApiData.Internal (parseUrlPieceMaybe)
+import Web.HttpApiData.Internal (parseUrlPieceMaybe, parseUrlPieceWithPrefix)
 
 instance ToHttpApiData (BackendKey Z.Zookeeper) where
     toUrlPiece key = "z" <> unZooKey key

--- a/persistent-zookeeper/Database/Persist/Zookeeper/Store.hs
+++ b/persistent-zookeeper/Database/Persist/Zookeeper/Store.hs
@@ -26,8 +26,7 @@ import qualified Data.Aeson as A
 import qualified Data.Aeson.Types as A
 
 import Web.PathPieces (PathPiece(..))
-import Web.HttpApiData (ToHttpApiData (..), FromHttpApiData (..))
-import Web.HttpApiData.Internal (parseUrlPieceMaybe, parseUrlPieceWithPrefix)
+import Web.HttpApiData (ToHttpApiData (..), FromHttpApiData (..), parseUrlPieceMaybe, parseUrlPieceWithPrefix)
 
 instance ToHttpApiData (BackendKey Z.Zookeeper) where
     toUrlPiece key = "z" <> unZooKey key

--- a/persistent-zookeeper/Database/Persist/Zookeeper/Store.hs
+++ b/persistent-zookeeper/Database/Persist/Zookeeper/Store.hs
@@ -23,8 +23,9 @@ import Control.Monad.Reader
 import qualified Data.Aeson as A
 import qualified Data.Aeson.Types as A
 
-import Web.PathPieces (PathPiece)
+import Web.PathPieces (PathPiece(..))
 import Web.HttpApiData (ToHttpApiData (..), FromHttpApiData (..))
+import Web.HttpApiData.Internal (parseUrlPieceMaybe)
 
 instance ToHttpApiData (BackendKey Z.Zookeeper) where
     toUrlPiece key = "z" <> unZooKey key
@@ -33,7 +34,9 @@ instance FromHttpApiData (BackendKey Z.Zookeeper) where
     parseUrlPiece input = ZooKey <$> parseUrlPieceWithPrefix "z" input
 
 -- | ToPathPiece is used to convert a key to/from text
-instance PathPiece (BackendKey Z.Zookeeper)
+instance PathPiece (BackendKey Z.Zookeeper) where
+  toPathPiece   = toUrlPiece
+  fromPathPiece = parseUrlPieceMaybe
 
 instance Sql.PersistFieldSql (BackendKey Z.Zookeeper) where
     sqlType _ = Sql.SqlOther "doesn't make much sense for Zookeeper"

--- a/persistent-zookeeper/Database/Persist/Zookeeper/Store.hs
+++ b/persistent-zookeeper/Database/Persist/Zookeeper/Store.hs
@@ -23,15 +23,17 @@ import Control.Monad.Reader
 import qualified Data.Aeson as A
 import qualified Data.Aeson.Types as A
 
-import Web.PathPieces (PathPiece (..))
+import Web.PathPieces (PathPiece)
+import Web.HttpApiData (ToHttpApiData (..), FromHttpApiData (..))
+
+instance ToHttpApiData (BackendKey Z.Zookeeper) where
+    toUrlPiece key = "z" <> unZooKey key
+
+instance FromHttpApiData (BackendKey Z.Zookeeper) where
+    parseUrlPiece input = ZooKey <$> parseUrlPieceWithPrefix "z" input
 
 -- | ToPathPiece is used to convert a key to/from text
-instance PathPiece (BackendKey Z.Zookeeper) where
-    toPathPiece key = "z" <> (unZooKey key)
-    fromPathPiece keyText =
-      case T.uncons keyText of
-        Just ('z', prefixed) -> Just $ ZooKey prefixed
-        _ -> mzero
+instance PathPiece (BackendKey Z.Zookeeper)
 
 instance Sql.PersistFieldSql (BackendKey Z.Zookeeper) where
     sqlType _ = Sql.SqlOther "doesn't make much sense for Zookeeper"

--- a/persistent-zookeeper/Database/Persist/Zookeeper/Store.hs
+++ b/persistent-zookeeper/Database/Persist/Zookeeper/Store.hs
@@ -10,6 +10,8 @@ module Database.Persist.Zookeeper.Store (
 , BackendKey(..)
 )where
 
+import Control.Applicative ((<$>))
+
 import Database.Persist
 import qualified Database.Persist.Sql as Sql
 import qualified Database.Zookeeper as Z

--- a/persistent-zookeeper/persistent-zookeeper.cabal
+++ b/persistent-zookeeper/persistent-zookeeper.cabal
@@ -35,7 +35,7 @@ library
                    , hzk                   >= 2.1
                    , resource-pool
                    , path-pieces
-                   , http-api-data
+                   , http-api-data            >= 0.1       && < 0.2
                    , template-haskell
                    , base64-bytestring
                    , conduit
@@ -78,7 +78,7 @@ test-suite  basic
                    , hzk                   >= 2.1
                    , resource-pool
                    , path-pieces
-                   , http-api-data
+                   , http-api-data            >= 0.1       && < 0.2
                    , base64-bytestring
                    , hspec
                    , conduit

--- a/persistent-zookeeper/persistent-zookeeper.cabal
+++ b/persistent-zookeeper/persistent-zookeeper.cabal
@@ -35,7 +35,7 @@ library
                    , hzk                   >= 2.1
                    , resource-pool
                    , path-pieces
-                   , http-api-data            >= 0.1       && < 0.2
+                   , http-api-data            >= 0.2       && < 0.3
                    , template-haskell
                    , base64-bytestring
                    , conduit
@@ -78,7 +78,7 @@ test-suite  basic
                    , hzk                   >= 2.1
                    , resource-pool
                    , path-pieces
-                   , http-api-data            >= 0.1       && < 0.2
+                   , http-api-data            >= 0.2       && < 0.3
                    , base64-bytestring
                    , hspec
                    , conduit

--- a/persistent-zookeeper/persistent-zookeeper.cabal
+++ b/persistent-zookeeper/persistent-zookeeper.cabal
@@ -78,6 +78,7 @@ test-suite  basic
                    , hzk                   >= 2.1
                    , resource-pool
                    , path-pieces
+                   , http-api-data
                    , base64-bytestring
                    , hspec
                    , conduit

--- a/persistent-zookeeper/persistent-zookeeper.cabal
+++ b/persistent-zookeeper/persistent-zookeeper.cabal
@@ -35,6 +35,7 @@ library
                    , hzk                   >= 2.1
                    , resource-pool
                    , path-pieces
+                   , http-api-data
                    , template-haskell
                    , base64-bytestring
                    , conduit

--- a/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
@@ -34,6 +34,7 @@ import Control.Monad.Trans.Reader (ReaderT, ask)
 import Data.Acquire (with)
 import Data.Int (Int64)
 import Web.PathPieces (PathPiece)
+import Web.HttpApiData (ToHttpApiData, FromHttpApiData)
 import Database.Persist.Sql.Class (PersistFieldSql)
 import qualified Data.Aeson as A
 import Control.Exception.Lifted (throwIO)
@@ -105,7 +106,7 @@ fieldDBName = fieldDB . persistFieldDef
 
 instance PersistStore SqlBackend where
     newtype BackendKey SqlBackend = SqlBackendKey { unSqlBackendKey :: Int64 }
-        deriving (Show, Read, Eq, Ord, Num, Integral, PersistField, PersistFieldSql, PathPiece, Real, Enum, Bounded, A.ToJSON, A.FromJSON)
+        deriving (Show, Read, Eq, Ord, Num, Integral, PersistField, PersistFieldSql, PathPiece, ToHttpApiData, FromHttpApiData, Real, Enum, Bounded, A.ToJSON, A.FromJSON)
 
     update _ [] = return ()
     update k upds = do

--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -17,6 +17,7 @@ import Data.Text.Encoding.Error (lenientDecode)
 import qualified Data.ByteString.Base64 as B64
 import qualified Data.Vector as V
 import Control.Arrow (second)
+import Control.Applicative ((<$>))
 import Data.Time (Day, TimeOfDay, UTCTime)
 import Data.Int (Int64)
 import qualified Data.Text.Read

--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -5,9 +5,9 @@ module Database.Persist.Types.Base where
 
 import qualified Data.Aeson as A
 import Control.Exception (Exception)
-import Web.PathPieces (PathPiece)
+import Web.PathPieces (PathPiece(..))
 import Web.HttpApiData (ToHttpApiData (..), FromHttpApiData (..))
-import Web.HttpApiData.Internal (parseBoundedCaseInsensitiveTextData, showTextData, readEitherTextData)
+import Web.HttpApiData.Internal (parseBoundedCaseInsensitiveTextData, showTextData, readEitherTextData, parseUrlPieceMaybe)
 import Control.Monad.Trans.Error (Error (..))
 import Data.Typeable (Typeable)
 import Data.Text (Text, pack)
@@ -320,7 +320,9 @@ instance FromHttpApiData PersistValue where
         Left _ <!> y = y
         x      <!> _ = x
 
-instance PathPiece PersistValue
+instance PathPiece PersistValue where
+  toPathPiece   = toUrlPiece
+  fromPathPiece = parseUrlPieceMaybe
 
 fromPersistValueText :: PersistValue -> Either Text Text
 fromPersistValueText (PersistText s) = Right s

--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -6,8 +6,7 @@ module Database.Persist.Types.Base where
 import qualified Data.Aeson as A
 import Control.Exception (Exception)
 import Web.PathPieces (PathPiece(..))
-import Web.HttpApiData (ToHttpApiData (..), FromHttpApiData (..))
-import Web.HttpApiData.Internal (parseBoundedCaseInsensitiveTextData, showTextData, readEitherTextData, parseUrlPieceMaybe)
+import Web.HttpApiData (ToHttpApiData (..), FromHttpApiData (..), parseUrlPieceMaybe, showTextData, readTextData, parseBoundedTextData)
 import Control.Monad.Trans.Error (Error (..))
 import Data.Typeable (Typeable)
 import Data.Text (Text, pack)
@@ -89,7 +88,7 @@ instance ToHttpApiData Checkmark where
     toUrlPiece = showTextData
 
 instance FromHttpApiData Checkmark where
-    parseUrlPiece = parseBoundedCaseInsensitiveTextData
+    parseUrlPiece = parseBoundedTextData
 
 instance PathPiece Checkmark
 
@@ -314,7 +313,7 @@ instance ToHttpApiData PersistValue where
 instance FromHttpApiData PersistValue where
     parseUrlPiece input =
           PersistInt64 <$> parseUrlPiece input
-      <!> PersistList  <$> readEitherTextData input
+      <!> PersistList  <$> readTextData input
       <!> PersistText  <$> return input
       where
         infixl 3 <!>

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -36,7 +36,7 @@ library
                    , lifted-base              >= 0.1
                    , resource-pool            >= 0.2.2.0
                    , path-pieces              >= 0.1
-                   , http-api-data            >= 0.1       && < 0.2
+                   , http-api-data            >= 0.2       && < 0.3
                    , aeson                    >= 0.5
                    , monad-logger             >= 0.3
                    , transformers-base
@@ -99,7 +99,7 @@ test-suite test
                    , attoparsec
                    , transformers
                    , path-pieces
-                   , http-api-data            >= 0.1       && < 0.2
+                   , http-api-data            >= 0.2       && < 0.3
                    , aeson
                    , resourcet
                    , monad-logger

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -36,7 +36,7 @@ library
                    , lifted-base              >= 0.1
                    , resource-pool            >= 0.2.2.0
                    , path-pieces              >= 0.1
-                   , http-api-data
+                   , http-api-data            >= 0.1       && < 0.2
                    , aeson                    >= 0.5
                    , monad-logger             >= 0.3
                    , transformers-base
@@ -99,7 +99,7 @@ test-suite test
                    , attoparsec
                    , transformers
                    , path-pieces
-                   , http-api-data
+                   , http-api-data            >= 0.1       && < 0.2
                    , aeson
                    , resourcet
                    , monad-logger

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -36,6 +36,7 @@ library
                    , lifted-base              >= 0.1
                    , resource-pool            >= 0.2.2.0
                    , path-pieces              >= 0.1
+                   , http-api-data
                    , aeson                    >= 0.5
                    , monad-logger             >= 0.3
                    , transformers-base
@@ -98,6 +99,7 @@ test-suite test
                    , attoparsec
                    , transformers
                    , path-pieces
+                   , http-api-data
                    , aeson
                    , resourcet
                    , monad-logger

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,4 +14,4 @@ extra-deps:
   - aeson-extra-0.2.1.0
   - aeson-0.10.0.0
   - attoparsec-0.13.0.1
-  - http-api-data-0.1.1.1
+  - http-api-data-0.2

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,6 +11,7 @@ packages:
   #- ./persistent-zookeeper
 
 extra-deps:
-  - aeson-extra-0.2.0.0
+  - aeson-extra-0.2.1.0
   - aeson-0.10.0.0
   - attoparsec-0.13.0.1
+  - http-api-data-0.1.1.1


### PR DESCRIPTION
This adds `ToHttpApiData` and `FromHttpApiData` instances and replaces `PathPieces` instance bodies with `toUrlPiece` and `parseUrlPieceMaybe`.

From user's POV this changes instance for `CheckMark` to encode in lower-case and parse case-insensitively.