### PR TITLE
Change the query for checking existence of Table

### DIFF
--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -406,7 +406,8 @@ doesTableExist getter (DBName name) = do
     stmt <- getter sql
     with (stmtQuery stmt vals) ($$ start)
   where
-    sql = "SELECT COUNT(*) FROM information_schema.tables WHERE table_name=?"
+    sql = "SELECT COUNT(*) FROM pg_catalog.pg_tables WHERE schemaname != 'pg_catalog'"
+          <> " AND schemaname != 'information_schema' AND tablename=?"
     vals = [PersistText name]
 
     start = await >>= maybe (error "No results when checking doesTableExist") start'


### PR DESCRIPTION
The old query doesn't work in the scenario where the table is present
but under the ownership of a different user. This query fixes it.
Also it improves the error message related to issue #390.

Instead of an error message like this:

```
SqlError {sqlState = "42P07", sqlExecStatus = FatalError, sqlErrorMsg =
"relation \"person\" already exists", sqlErrorDetail = "",
sqlErrorHint = ""}
```

You get this:

```
SqlError {sqlState = "42501", sqlExecStatus = FatalError, sqlErrorMsg =
"must be owner of relation person", sqlErrorDetail = "", sqlErrorHint =
""}```