### PR TITLE
Build on SmartOS

### DIFF
--- a/persistent-sqlite/persistent-sqlite.cabal
+++ b/persistent-sqlite/persistent-sqlite.cabal
@@ -43,7 +43,7 @@ library
     else
         c-sources:   cbits/sqlite3.c
         include-dirs: cbits
-        cc-options:  -fPIC
+        cc-options:  -fPIC -std=c99
 
     c-sources: cbits/config.c
 


### PR DESCRIPTION
 - GCC on SmartOS needs explicit -std=c99 to build cbits/sqlite3.c