### PR TITLE
Update to use aeson-compat >= 0.3

### DIFF
--- a/persistent-template/persistent-template.cabal
+++ b/persistent-template/persistent-template.cabal
@@ -24,7 +24,7 @@ library
                    , transformers             >= 0.2       && < 0.5
                    , containers
                    , aeson                    >= 0.7       && < 0.11
-                   , aeson-extra              >= 0.2.1.0   && < 0.3
+                   , aeson-compat             >= 0.3
                    , monad-logger
                    , unordered-containers
                    , tagged


### PR DESCRIPTION
Data.Aeson.Compat has been moved into aeson-compat, and no longer available in aeson-extra since 0.3.0.0. Let's switch to the new package.