### PR TITLE
Document combinator (=.) along with examples.

### DIFF
--- a/persistent/Database/Persist.hs
+++ b/persistent/Database/Persist.hs
@@ -70,7 +70,7 @@ infixr 3 =., +=., -=., *=., /=.
 -- updateAge = updateWhere [UserName ==. \"SPJ\" ] [UserAge =. 45]
 -- @
 --
--- Similar to `updateWhere` you can use other functions present in the module "Database.Persist.Class". Note that the first attribute of `updateWhere` is [`Filter` val] and second attribute is [`Update` val]. By comparing this with the type of `==.` and `=.`, you can see that they match up in the above usage.
+-- Similar to `updateWhere` which is shown in the above example you can use other functions present in the module "Database.Persist.Class". Note that the first parameter of `updateWhere` is [`Filter` val] and second parameter is [`Update` val]. By comparing this with the type of `==.` and `=.`, you can see that they match up in the above usage.
 --
 -- The above query when applied on "dataset-1", will produce this:
 -- 

--- a/persistent/Database/Persist.hs
+++ b/persistent/Database/Persist.hs
@@ -6,7 +6,7 @@ module Database.Persist
     ( module Database.Persist.Class
     , module Database.Persist.Types
 
-    -- * #dataset# Reference Schema & Dataset
+    -- * Reference Schema & Dataset
     -- |
     --
     -- All the combinators present here will be explained based on this schema:
@@ -18,8 +18,7 @@ module Database.Persist
     -- >     deriving Show
     -- > |]
     --
-    -- and this dataset. From here on we will call this as dataset-1
-    -- #foobar#
+    -- and this dataset. The examples below will refer to this as dataset-1.
     --
     -- > +-----+-----+-----+
     -- > |id   |name |age  |
@@ -64,7 +63,7 @@ infixr 3 =., +=., -=., *=., /=.
 
 -- | Assign a field a value.
 --
--- Example usage:
+-- === __Example usage__
 --
 -- @
 -- updateAge :: MonadIO m => ReaderT SqlBackend m ()

--- a/persistent/Database/Persist.hs
+++ b/persistent/Database/Persist.hs
@@ -6,7 +6,30 @@ module Database.Persist
     ( module Database.Persist.Class
     , module Database.Persist.Types
 
-      -- * Query update combinators
+    -- * #dataset# Reference Schema & Dataset
+    -- |
+    --
+    -- All the combinators present here will be explained based on this schema:
+    --
+    -- > share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistLowerCase|
+    -- > User
+    -- >     name String
+    -- >     age Int
+    -- >     deriving Show
+    -- > |]
+    --
+    -- and this dataset. From here on we will call this as dataset-1
+    -- #foobar#
+    --
+    -- > +-----+-----+-----+
+    -- > |id   |name |age  |
+    -- > +-----+-----+-----+
+    -- > |1    |SPJ  |40   |
+    -- > +-----+-----+-----+
+    -- > |2    |Simon|41   |
+    -- > +-----+-----+-----+
+
+    -- * Query update combinators
     , (=.), (+=.), (-=.), (*=.), (/=.)
 
       -- * Query filter combinators
@@ -40,6 +63,26 @@ infixr 3 =., +=., -=., *=., /=.
   forall v typ.  PersistField typ => EntityField v typ -> typ -> Update v
 
 -- | Assign a field a value.
+--
+-- Example usage:
+--
+-- @
+-- updateAge :: MonadIO m => ReaderT SqlBackend m ()
+-- updateAge = updateWhere [UserName ==. \"SPJ\" ] [UserAge =. 45]
+-- @
+--
+-- Similar to `updateWhere` you can use other functions present in the module "Database.Persist.Class". Note that the first attribute of `updateWhere` is [`Filter` val] and second attribute is [`Update` val]. By comparing this with the type of `==.` and `=.`, you can see that they match up in the above usage.
+--
+-- The above query when applied on "dataset-1", will produce this:
+-- 
+-- > +-----+-----+-----+
+-- > |id   |name |age  |
+-- > +-----+-----+-----+
+-- > |1    |SPJ  |45   |
+-- > +-----+-----+-----+
+-- > |2    |Simon|41   |
+-- > +-----+-----+-----+
+
 f =. a = Update f a Assign
 
 -- | Assign a field by addition (@+=@).


### PR DESCRIPTION
Adds documentation to basic query combinators with an example schema along with a sample data. I'm planning to add similar line of examples to other combinators as well. So if there is any concern/request/criticism, I would like to hear it in a very early stage! The major motivation for adding this is after my personal experience with haskell newbies who were finding this difficult to use.

CC: @snoyberg , @gregwebs 