### PR TITLE
add a PersistRecordBackend type alias

### DIFF
--- a/persistent/Database/Persist/Class.hs
+++ b/persistent/Database/Persist/Class.hs
@@ -9,6 +9,7 @@ module Database.Persist.Class
     , PersistStoreRead (..)
     , PersistStoreWrite (..)
     , BaseBackend(..)
+    , PersistRecordBackend
     , getJust
     , belongsTo
     , belongsToJust

--- a/persistent/Database/Persist/Class/PersistUnique.hs
+++ b/persistent/Database/Persist/Class/PersistUnique.hs
@@ -92,7 +92,7 @@ class (PersistUniqueRead backend, PersistStoreWrite backend) => PersistUniqueWri
 -- | Insert a value, checking for conflicts with any unique constraints.  If a
 -- duplicate exists in the database, it is returned as 'Left'. Otherwise, the
 -- new 'Key is returned as 'Right'.
-insertBy :: (MonadIO m, PersistEntity record, PersistUniqueWrite backend, PersistEntityBackend record ~ BaseBackend backend)
+insertBy :: (MonadIO m, PersistUniqueWrite backend, PersistRecordBackend record backend)
          => record -> ReaderT backend m (Either (Entity record) (Key record))
 insertBy val = do
     res <- getByValue val
@@ -103,7 +103,7 @@ insertBy val = do
 -- | Insert a value, checking for conflicts with any unique constraints. If a
 -- duplicate exists in the database, it is left untouched. The key of the
 -- existing or new entry is returned
-insertOrGet :: (MonadIO m, PersistEntity record, PersistUniqueWrite backend, PersistEntityBackend record ~ BaseBackend backend)
+insertOrGet :: (MonadIO m, PersistUniqueWrite backend, PersistRecordBackend record backend)
             => record -> ReaderT backend m (Key record)
 insertOrGet val = do
     res <- getByValue val


### PR DESCRIPTION
@pseudonom I am trying to combat the increased size of type signatures from the read/write split (not released to hackage yet). Do you think it would be good to use this alias everywhere?