### PR TITLE
Fix for issue #412

### DIFF
--- a/persistent-template/Database/Persist/TH.hs
+++ b/persistent-template/Database/Persist/TH.hs
@@ -86,7 +86,7 @@ import qualified Data.Text.Encoding as TE
 -- <https://github.com/yesodweb/persistent/issues/412>
 unHaskellNameForJSON :: HaskellName -> Text
 unHaskellNameForJSON = fixTypeUnderscore . unHaskellName
-  where fixTypeUnderscore "type_" = "type"
+  where fixTypeUnderscore "type" = "type_"
         fixTypeUnderscore name = name
 
 -- | Converts a quasi-quoted syntax into a list of entity definitions, to be
@@ -1531,7 +1531,7 @@ mkJSON mps def = do
     obj <- newName "obj"
     mzeroE <- [|mzero|]
 
-    xs <- mapM (newName . unpack . unHaskellName . fieldHaskell)
+    xs <- mapM (newName . unpack . unHaskellNameForJSON . fieldHaskell)
         $ entityFields def
 
     let conName = mkName $ unpack $ unHaskellName $ entityHaskell def
@@ -1542,7 +1542,7 @@ mkJSON mps def = do
             (objectE `AppE` ListE pairs)
         pairs = zipWith toPair (entityFields def) xs
         toPair f x = InfixE
-            (Just (packE `AppE` LitE (StringL $ unpack $ unHaskellNameForJSON $ fieldHaskell f)))
+            (Just (packE `AppE` LitE (StringL $ unpack $ unHaskellName $ fieldHaskell f)))
             dotEqualE
             (Just $ VarE x)
         fromJSONI = typeInstanceD ''FromJSON (mpsGeneric mps) typ [parseJSON']
@@ -1559,7 +1559,7 @@ mkJSON mps def = do
         toPull f = InfixE
             (Just $ VarE obj)
             (if maybeNullable f then dotColonQE else dotColonE)
-            (Just $ AppE packE $ LitE $ StringL $ unpack $ unHaskellNameForJSON $ fieldHaskell f)
+            (Just $ AppE packE $ LitE $ StringL $ unpack $ unHaskellName $ fieldHaskell f)
     case mpsEntityJSON mps of
         Nothing -> return [toJSONI, fromJSONI]
         Just entityJSON -> do

--- a/persistent-template/persistent-template.cabal
+++ b/persistent-template/persistent-template.cabal
@@ -1,5 +1,5 @@
 name:            persistent-template
-version:         2.5.1.1
+version:         2.5.1.2
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
It seems as if the original fix somehow confused the issue, since the issue was that type_0 is reserved, in 7.10.2, but adding an extra `_` makes it ok (i.e. `type__0`). This pull request applies the previous fix in the correct place, and works in my case. See issue #412 for more details on the bug.