### PR TITLE
Fix the problem caused by the upgrading of SQLite 3.12.1

### DIFF
--- a/persistent-sqlite/cbits/fix.c
+++ b/persistent-sqlite/cbits/fix.c
@@ -1,0 +1,11 @@
+int stat64(){
+    return 0;
+}
+
+int fstat64(){
+    return 0;
+}
+
+int lstat64(){
+    return 0;
+}

--- a/persistent-sqlite/persistent-sqlite.cabal
+++ b/persistent-sqlite/persistent-sqlite.cabal
@@ -46,7 +46,9 @@ library
         include-dirs: cbits
         cc-options:  -fPIC -std=c99
 
-    c-sources: cbits/config.c
+    c-sources: 
+        cbits/config.c
+        cbits/fix.c
 
     if !os(windows)
         extra-libraries: pthread


### PR DESCRIPTION
ghc-mod failed to check haskell source file, which complains:
    
    unknown symbol `stat64'

    unknown symbol `fstat64'

    unknown symbol `lstat64'