### PR TITLE
persistent-redis with version 2.5

### DIFF
--- a/persistent-redis/Database/Persist/Redis/Internal.hs
+++ b/persistent-redis/Database/Persist/Redis/Internal.hs
@@ -1,13 +1,13 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Database.Persist.Redis.Internal
-	( toKey
+    ( toKey
     , unKey
     , mkEntity
     , toKeyId
     , toKeyText
     , toInsertFields
     , toB
-	) where
+    ) where
 
 import Data.Text (Text, unpack)
 import qualified Data.Text as T

--- a/persistent-redis/persistent-redis.cabal
+++ b/persistent-redis/persistent-redis.cabal
@@ -20,7 +20,7 @@ library
     build-depends:   base                  >= 4.6        && < 5
                    , hedis                 >= 0.6.0   
                    , bytestring            >= 0.10.0.0 && < 0.11.0.0
-                   , persistent            >= 2.1      && < 3
+                   , persistent            >= 2.5      && < 3
                    , text                  >= 1.2.0.0
                    , aeson                 >= 0.8
                    , time                  >= 1.4      && < 1.6

--- a/persistent-redis/persistent-redis.cabal
+++ b/persistent-redis/persistent-redis.cabal
@@ -1,5 +1,5 @@
 name:            persistent-redis
-version:         0.3.3
+version:         2.5.0
 license:         BSD3
 license-file:    LICENSE
 author:          Pavel Ryzhov <paul@paulrz.cz>
@@ -18,20 +18,21 @@ source-repository head
 
 library
     build-depends:   base                  >= 4.6        && < 5
-                   , hedis                 >= 0.6.0    && < 0.7.0
+                   , hedis                 >= 0.6.0   
                    , bytestring            >= 0.10.0.0 && < 0.11.0.0
-                   , persistent            >= 2.1      && < 2.2
+                   , persistent            >= 2.1      && < 3
                    , text                  >= 1.2.0.0
                    , aeson                 >= 0.8
                    , time                  >= 1.4      && < 1.6
                    , attoparsec            >= 0.12.0.0
                    , mtl                   >= 2.2.0    && < 2.3
                    , transformers          >= 0.4.0.0  && < 0.5.0.0
-                   , monad-control         >= 0.3.2.0  && < 0.4
-                   , utf8-string           >= 0.3.7    && < 0.4.0
+                   , monad-control         >= 0.3.2.0
+                   , utf8-string           >= 0.3.7   
                    , binary                >= 0.7      && < 0.8
                    , scientific            >= 0.3.1    && < 0.4
                    , path-pieces           >= 0.1
+                   , http-api-data
 
     exposed-modules: Database.Persist.Redis
 

--- a/stack-docker.yaml
+++ b/stack-docker.yaml
@@ -7,7 +7,7 @@ packages:
   - ./persistent-mongoDB
   - ./persistent-mysql
   - ./persistent-postgresql
-  # - ./persistent-redis
+  - ./persistent-redis
   # - ./persistent-zookeeper
 
 extra-deps:

--- a/stack.yaml
+++ b/stack.yaml
@@ -7,7 +7,7 @@ packages:
   - ./persistent-mongoDB
   - ./persistent-mysql
   - ./persistent-postgresql
-  # - ./persistent-redis
+  - ./persistent-redis
   # - ./persistent-zookeeper
 
 extra-deps:


### PR DESCRIPTION
For #567. Persistent-redis supports a type class split in 2.5 version of persistent.