### PR TITLE
Fixed dependencies to satisfy GHC 8.0.1 constraints

### DIFF
--- a/persistent-redis/persistent-redis.cabal
+++ b/persistent-redis/persistent-redis.cabal
@@ -1,5 +1,5 @@
 name:            persistent-redis
-version:         2.5.0
+version:         2.5.1
 license:         BSD3
 license-file:    LICENSE
 author:          Pavel Ryzhov <paul@paulrz.cz>
@@ -23,10 +23,10 @@ library
                    , persistent            >= 2.5      && < 3
                    , text                  >= 1.2.0.0
                    , aeson                 >= 0.8
-                   , time                  >= 1.4      && < 1.6
+                   , time                  >= 1.4      && < 1.7
                    , attoparsec            >= 0.12.0.0
                    , mtl                   >= 2.2.0    && < 2.3
-                   , transformers          >= 0.4.0.0  && < 0.5.0.0
+                   , transformers          >= 0.4.0.0  && < 0.6.0.0
                    , monad-control         >= 0.3.2.0
                    , utf8-string           >= 0.3.7   
                    , binary                >= 0.7      && < 0.8

--- a/persistent-redis/persistent-redis.cabal
+++ b/persistent-redis/persistent-redis.cabal
@@ -18,7 +18,7 @@ source-repository head
 
 library
     build-depends:   base                  >= 4.6        && < 5
-                   , hedis                 >= 0.6.0   
+                   , hedis                 >= 0.6.0
                    , bytestring            >= 0.10.0.0 && < 0.11.0.0
                    , persistent            >= 2.5      && < 3
                    , text                  >= 1.2.0.0
@@ -27,9 +27,9 @@ library
                    , attoparsec            >= 0.12.0.0
                    , mtl                   >= 2.2.0    && < 2.3
                    , transformers          >= 0.4.0.0  && < 0.6.0.0
-                   , monad-control         >= 0.3.2.0
-                   , utf8-string           >= 0.3.7   
-                   , binary                >= 0.7      && < 0.8
+                   , monad-control         >= 0.3.2.0  && < 1.2.0.0
+                   , utf8-string           >= 0.3.7    && < 1.1.0
+                   , binary                >= 0.7      && < 0.9
                    , scientific            >= 0.3.1    && < 0.4
                    , path-pieces           >= 0.1
                    , http-api-data


### PR DESCRIPTION
Dependency constraints are lifted for compatibility with GHC 8.0.1.