### PR TITLE
Redis backend fixes for GHC 8.0.1 and Persistent 2.5

### DIFF
--- a/persistent-redis/Database/Persist/Redis/Store.hs
+++ b/persistent-redis/Database/Persist/Redis/Store.hs
@@ -1,10 +1,9 @@
 {-# LANGUAGE FlexibleContexts, UndecidableInstances #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
-module Database.Persist.Redis.Store 
+module Database.Persist.Redis.Store
     ( execRedisT
     , RedisBackend
     )where
@@ -44,6 +43,10 @@ execRedisT action = do
     case r of
         (Right x) -> return x
         (Left x)  -> fail x
+
+instance HasPersistBackend R.Connection where
+  type BaseBackend R.Connection = R.Connection
+  persistBackend = id
 
 instance PersistCore R.Connection where
     newtype BackendKey R.Connection = RedisKey Text
@@ -113,4 +116,3 @@ instance PathPiece (BackendKey RedisBackend) where
 
 instance Sql.PersistFieldSql (BackendKey RedisBackend) where
     sqlType _ = Sql.SqlOther (pack "doesn't make much sense for Redis backend")
-

--- a/persistent-redis/persistent-redis.cabal
+++ b/persistent-redis/persistent-redis.cabal
@@ -1,5 +1,5 @@
 name:            persistent-redis
-version:         2.5.1
+version:         2.5.2
 license:         BSD3
 license-file:    LICENSE
 author:          Pavel Ryzhov <paul@paulrz.cz>
@@ -20,7 +20,7 @@ library
     build-depends:   base                  >= 4.6        && < 5
                    , hedis                 >= 0.6.0
                    , bytestring            >= 0.10.0.0 && < 0.11.0.0
-                   , persistent            >= 2.5      && < 3
+                   , persistent            >= 2.5      && < 3.0
                    , text                  >= 1.2.0.0
                    , aeson                 >= 0.8
                    , time                  >= 1.4      && < 1.7
@@ -49,21 +49,21 @@ test-suite  basic
     type: exitcode-stdio-1.0
     main-is: tests/basic-test.hs
     build-depends:   base                  >= 4.6        && < 5
-                   , hedis                 >= 0.6.0    && < 0.7.0
-                   , persistent            >= 2.1      && < 2.2
-                   , persistent-template   >= 2.1      && < 2.2
+                   , hedis                 >= 0.6.0
+                   , persistent            >= 2.5      && < 3.0
+                   , persistent-template   >= 2.5      && < 3.0
                    , mtl                   >= 2.2.0    && < 2.3
-                   , transformers          >= 0.4.0.0  && < 0.5
-                   , utf8-string           >= 0.3.7    && < 0.4.0
+                   , transformers          >= 0.4.0.0  && < 0.6.0.0
+                   , utf8-string           >= 0.3.7    && < 1.1.0
                    , bytestring            >= 0.10.0.0 && < 0.11.0.0
                    , text                  >= 1.2.0.0
                    , aeson                 >= 0.8
-                   , binary                >= 0.7      && < 0.8
-                   , time                  >= 1.4      && < 1.5
+                   , binary                >= 0.7      && < 0.9
+                   , time                  >= 1.4      && < 1.7
                    , attoparsec            >= 0.12.0.0
                    , template-haskell
-                   , monad-control         >= 0.3.2.0  && < 0.4
-                   , utf8-string           >= 0.3.7    && < 0.4.0
+                   , monad-control         >= 0.3.2.0  && < 1.2.0.0
                    , path-pieces           >= 0.1
                    , scientific
+                   , http-api-data
                    , persistent-redis


### PR DESCRIPTION
Fixed test dependency constraints
Added missing instance of HasPersistBackend
Version bump to 2.5.2

For #567