### PR TITLE
Atomic upsert support for Postgresql

### DIFF
--- a/persistent-mysql/ChangeLog.md
+++ b/persistent-mysql/ChangeLog.md
@@ -1,3 +1,7 @@
+## 2.6
+
+* Changes for `connUpsertSql` support.
+
 ## 2.5
 
 * changes for read/write typeclass split

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -111,6 +111,7 @@ open' ci logFunc = do
         , connStmtMap    = smap
         , connInsertSql  = insertSql'
         , connInsertManySql = Nothing
+        , connUpsertSql = Nothing
         , connClose      = MySQL.close conn
         , connMigrateSql = migrate' ci
         , connBegin      = const $ MySQL.execute_ conn "start transaction" >> return ()

--- a/persistent-postgresql/ChangeLog.md
+++ b/persistent-postgresql/ChangeLog.md
@@ -1,3 +1,7 @@
+## 2.6
+
+* Atomic upsert support for postgreSQL backend
+
 ## 2.5
 
 * changes for read/write typeclass split

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -215,11 +215,15 @@ upsertSql' ent vals updateVal = T.concat
                                 , " where "
                                 , wher
                                 , " returning ??"
-                      ]
+                                ]
     where
       wher = T.intercalate " AND " $ map singleCondition $ entityUniques ent
-      singleCondition :: UniqueDef ->  Text
-      singleCondition udef = escape (entityDB ent) <> "." <> T.concat (map escape (map snd $ uniqueFields udef)) <> " =?"
+
+      singleCondition :: UniqueDef -> Text
+      singleCondition udef = T.intercalate " AND " (map singleClause $ map snd (uniqueFields udef))
+
+      singleClause :: DBName -> Text
+      singleClause field = escape (entityDB ent) <> "." <> (escape field) <> " =?"
 
 -- | SQL for inserting multiple rows at once and returning their primary keys.
 insertManySql' :: EntityDef -> [[PersistValue]] -> InsertSqlResult

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 
 -- | A postgresql backend for persistent.
 module Database.Persist.Postgresql
@@ -44,7 +45,7 @@ import Control.Monad.Trans.Resource
 import Control.Exception (throw)
 import Control.Monad.IO.Class (MonadIO (..))
 import Data.Data
-import Data.Typeable
+import Data.Typeable (Typeable)
 import Data.IORef
 import qualified Data.Map as Map
 import Data.Maybe
@@ -61,6 +62,7 @@ import qualified Data.IntMap as I
 import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as B8
 import qualified Data.Text as T
+import Data.Text.Read (rational)
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.IO as T
 import qualified Blaze.ByteString.Builder.Char8 as BBB
@@ -77,6 +79,7 @@ import Data.Int (Int64)
 import Data.Monoid ((<>))
 import Data.Pool (Pool)
 import Data.Time (utc, localTimeToUTC)
+import Control.Exception (Exception, throwIO)
 
 -- | A @libpq@ connection string.  A simple example of connection
 -- string would be @\"host=localhost port=5432 user=test
@@ -86,6 +89,14 @@ import Data.Time (utc, localTimeToUTC)
 -- for more details on how to create such strings.
 type ConnectionString = ByteString
 
+-- | PostgresServerVersionError exception. This is thrown when persistent
+-- is unable to find the version of the postgreSQL server.
+data PostgresServerVersionError = PostgresServerVersionError String deriving Typeable
+
+instance Show PostgresServerVersionError where
+    show (PostgresServerVersionError uniqueMsg) =
+      "Unexpected PostgreSQL server version, got " <> uniqueMsg
+instance Exception PostgresServerVersionError
 
 -- | Create a PostgreSQL connection pool and run the given
 -- action.  The pool is properly released after the action
@@ -148,17 +159,38 @@ open' modConn cstr logFunc = do
     modConn conn
     openSimpleConn logFunc conn
 
+-- | Gets the PostgreSQL server version
+getServerVersion :: PG.Connection -> IO (Maybe Double)
+getServerVersion conn = do
+  [PG.Only version] <- PG.query_ conn "show server_version";
+  let version' = rational version
+  --- λ> rational "9.8.3"
+  --- Right (9.8,".3")
+  --- λ> rational "9.8.3.5"
+  --- Right (9.8,".3.5")
+  case version' of
+    Right (a,_) -> return $ Just a
+    Left err -> throwIO $ PostgresServerVersionError err
+
+-- | Choose upsert sql generation function based on postgresql version.
+-- PostgreSQL version >= 9.5 supports native upsert feature,
+-- so depending upon that we have to choose how the sql query is generated.
+upsertFunction :: Double -> Maybe (EntityDef -> Text -> Text)
+upsertFunction version = if (version >= 9.5)
+                         then Just upsertSql'
+                         else Nothing
 
 -- | Generate a 'Connection' from a 'PG.Connection'
 openSimpleConn :: (IsSqlBackend backend) => LogFunc -> PG.Connection -> IO backend
 openSimpleConn logFunc conn = do
     smap <- newIORef $ Map.empty
+    serverVersion <- getServerVersion conn
     return . mkPersistBackend $ SqlBackend
         { connPrepare    = prepare' conn
         , connStmtMap    = smap
         , connInsertSql  = insertSql'
         , connInsertManySql = Just insertManySql'
-        , connUpsertSql = Just upsertSql'
+        , connUpsertSql = maybe Nothing upsertFunction serverVersion
         , connClose      = PG.close conn
         , connMigrateSql = migrate'
         , connBegin      = const $ PG.begin    conn
@@ -200,22 +232,23 @@ insertSql' ent vals =
        Just _pdef -> ISRManyKeys sql vals
        Nothing -> ISRSingle (sql <> " RETURNING " <> escape (fieldDB (entityId ent)))
 
-upsertSql' :: EntityDef -> [PersistValue] -> Text -> Text
-upsertSql' ent vals updateVal = T.concat
-                                [ "insert into "
-                                , escape (entityDB ent)
-                                , "("
-                                , T.intercalate "," $ map (escape . fieldDB) $ entityFields ent
-                                , ") VALUES ("
-                                , T.intercalate "," $ map (const "?") (entityFields ent)
-                                , ") on conflict ("
-                                , T.intercalate "," $ concat $ map (\x -> map escape (map snd $ uniqueFields x)) (entityUniques ent)
-                                , ") do update set "
-                                , updateVal
-                                , " where "
-                                , wher
-                                , " returning ??"
-                                ]
+
+upsertSql' :: EntityDef -> Text -> Text
+upsertSql' ent updateVal = T.concat
+                           [ "INSERT INTO "
+                           , escape (entityDB ent)
+                           , "("
+                           , T.intercalate "," $ map (escape . fieldDB) $ entityFields ent
+                           , ") VALUES ("
+                           , T.intercalate "," $ map (const "?") (entityFields ent)
+                           , ") ON CONFLICT ("
+                           , T.intercalate "," $ concat $ map (\x -> map escape (map snd $ uniqueFields x)) (entityUniques ent)
+                           , ") DO UPDATE SET "
+                           , updateVal
+                           , " WHERE "
+                           , wher
+                           , " RETURNING ??"
+                           ]
     where
       wher = T.intercalate " AND " $ map singleCondition $ entityUniques ent
 
@@ -239,51 +272,6 @@ insertManySql' ent valss =
                 , T.intercalate ", " $ dbIdColumnsEsc escape ent
                 ]
   in ISRSingle sql
-
--- upsertSql' :: EntityDef  -> [PersistValue] -> [Update record] -> Sql
--- upsertSql' ent vals upds = T.concat 
---                          [ "INSERT INTO "
---                          , escape (entityDB ent)
---                          , "("
---                          , T.intercalate "," $ map (escape . fieldDB ) $ entityFields ent
---                          , ") VALUES ("
---                          , T.intercalate "," (map (const "?") $ entityFields ent)
---                          , ") on conflict ("
---                          , T.intercalate "," uniqueFields
---                          , ") do update set ("
---                          , T.intercalate "," updateFields
---                          , " ) = ("
---                          , T.intercalate "," $ map (go' conn . go) upds
---                          , ") where "
---                          , escape (entityDB ent)
---                          , "udndef."
---                          ]
-
---     where
---       dat = map updatePersistValue upds
-      
---       updateFields = map (\x -> escape $ fieldDB $ persistFieldDef $ getPersistField x) upds
---       uniqueFields = map (escape . uniqueDBName) $ entityUniques ent
---       conn = undefined
-
---       go x = (fieldDB $ updateFieldDef x, updateUpdate x)
-             
---       go'' n Assign = n <> "=?"
---       go'' n Add = mconcat [n, "=", n, "+?"]
---       go'' n Subtract = mconcat [n, "=", n, "-?"]
---       go'' n Multiply = mconcat [n, "=", n, "*?"]
---       go'' n Divide = mconcat [n, "=", n, "/?"]
---       go'' _ (BackendSpecificUpdate up) = error $ T.unpack $ "BackendSpecificUpdate" `mappend` up `mappend` "not supported"
-
---       go' (x, pu) = go'' (connEscapeName conn x) pu
-
--- getPersistField :: Update v -> Text
--- getPersistField (Update _ v _) = v
--- getPersistField (BackendUpdate {}) = error "getPersistField did not expect BackendUpdate"
-
--- updatePersistValue :: Update v -> PersistValue
--- updatePersistValue (Update _ v _) = toPersistValue v
--- updatePersistValue (BackendUpdate {}) = error "updatePersistValue did not expect BackendUpdate"
 
 execute' :: PG.Connection -> PG.Query -> [PersistValue] -> IO Int64
 execute' conn query vals = PG.execute conn query (map P vals)
@@ -1112,6 +1100,7 @@ mockMigration mig = do
                                                         },
                              connInsertManySql = Nothing,
                              connInsertSql = undefined,
+                             connUpsertSql = Nothing,
                              connStmtMap = smap,
                              connClose = undefined,
                              connMigrateSql = mockMigrate,

--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -109,6 +109,7 @@ wrapConnectionWal enableWal conn logFunc = do
         { connPrepare = prepare' conn
         , connStmtMap = smap
         , connInsertSql = insertSql'
+        , connUpsertSql = Nothing
         , connInsertManySql = Nothing
         , connClose = Sqlite.close conn
         , connMigrateSql = migrate'

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,3 +1,7 @@
+## 2.6
+
+* Add `connUpsertSql` type for providing native upsert sql support.
+
 ## 2.5
 
 * read/write typeclass split

--- a/persistent/Database/Persist/Class/PersistUnique.hs
+++ b/persistent/Database/Persist/Class/PersistUnique.hs
@@ -78,6 +78,9 @@ class (PersistUniqueRead backend, PersistStoreWrite backend) => PersistUniqueWri
            -- unique key)
            -> ReaderT backend m (Entity record)
            -- ^ the record in the database after the operation
+    upsert record updates = do
+        uniqueKey <- onlyUnique record
+        upsertBy uniqueKey record updates
 
     -- | Update based on a given uniqueness constraint or insert:
     --

--- a/persistent/Database/Persist/Class/PersistUnique.hs
+++ b/persistent/Database/Persist/Class/PersistUnique.hs
@@ -78,16 +78,6 @@ class (PersistUniqueRead backend, PersistStoreWrite backend) => PersistUniqueWri
            -- unique key)
            -> ReaderT backend m (Entity record)
            -- ^ the record in the database after the operation
-    upsert record updates = do
-        uniqueKey <- onlyUnique record
-        mExists <- getBy uniqueKey
-        k <- case mExists of
-            Just (Entity k _) -> do
-              when (null updates) (replace k record)
-              return k
-            Nothing           -> insert record
-        Entity k `liftM` updateGet k updates
-
 
 -- | Insert a value, checking for conflicts with any unique constraints.  If a
 -- duplicate exists in the database, it is returned as 'Left'. Otherwise, the

--- a/persistent/Database/Persist/Sql/Orphan/PersistUnique.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistUnique.hs
@@ -10,7 +10,7 @@ import Control.Monad.Trans.Reader (ReaderT)
 import Database.Persist
 import Database.Persist.Sql.Types
 import Database.Persist.Sql.Raw
-import Database.Persist.Sql.Orphan.PersistStore (withRawQuery, updateFieldDef, updatePersistValue)
+import Database.Persist.Sql.Orphan.PersistStore (withRawQuery)
 import Database.Persist.Sql.Util (dbColumns, parseEntityValues)
 import qualified Data.Text as T
 import Data.Monoid (mappend, (<>))
@@ -108,3 +108,12 @@ instance PersistUniqueRead SqlWriteBackend where
 
 dummyFromUnique :: Unique v -> Maybe v
 dummyFromUnique _ = Nothing
+
+
+updateFieldDef :: PersistEntity v => Update v -> FieldDef
+updateFieldDef (Update f _ _) = persistFieldDef f
+updateFieldDef (BackendUpdate {}) = error "updateFieldDef did not expect BackendUpdate"
+
+updatePersistValue :: Update v -> PersistValue
+updatePersistValue (Update _ v _) = toPersistValue v
+updatePersistValue (BackendUpdate {}) = error "updatePersistValue did not expect BackendUpdate"

--- a/persistent/Database/Persist/Sql/Orphan/PersistUnique.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistUnique.hs
@@ -32,13 +32,14 @@ instance PersistUniqueWrite SqlBackend where
 
     upsert record updates = do
       conn <- ask
+      uniqueKey <- onlyUnique record
       case connUpsertSql conn of
         Just upsertSql -> case updates of
                             [] -> defaultUpsert record updates
                             xs -> do
                                 let upds = T.intercalate "," $ map (go' . go) updates
                                     sql = upsertSql t vals upds
-                                    vals = (map toPersistValue $ toPersistFields record) ++ (map updatePersistValue updates) ++ unqs
+                                    vals = (map toPersistValue $ toPersistFields record) ++ (map updatePersistValue updates) ++ (unqs uniqueKey)
                                            
                                     go'' n Assign = n <> "=?"
                                     go'' n Add = T.concat [n, "=", n, "+?"]
@@ -55,7 +56,7 @@ instance PersistUniqueWrite SqlBackend where
         Nothing -> defaultUpsert record updates
         where
           t = entityDef $ Just record
-          unqs = concat $ map (persistUniqueToValues) (persistUniqueKeys record)
+          unqs uniqueKey = concat $ map (persistUniqueToValues) [uniqueKey]
 
     deleteBy uniq = do
         conn <- ask

--- a/persistent/Database/Persist/Sql/Orphan/PersistUnique.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistUnique.hs
@@ -16,8 +16,26 @@ import qualified Data.Text as T
 import Data.Monoid (mappend)
 import qualified Data.Conduit.List as CL
 import Control.Monad.Trans.Reader (ask, withReaderT)
+import Control.Monad (when, liftM)
+
+defaultUpsert record updates = do
+  uniqueKey <- onlyUnique record
+  mExists <- getBy uniqueKey
+  k <- case mExists of
+         Just (Entity k _) -> do
+                      when (null updates) (replace k record)
+                      return k
+         Nothing           -> insert record
+  Entity k `liftM` updateGet k updates
+
+x = Just 3
 
 instance PersistUniqueWrite SqlBackend where
+
+    upsert record updates = case x of
+        Nothing -> defaultUpsert record updates
+        (Just 3) -> undefined
+
     deleteBy uniq = do
         conn <- ask
         let sql' = sql conn

--- a/persistent/Database/Persist/Sql/Types/Internal.hs
+++ b/persistent/Database/Persist/Sql/Types/Internal.hs
@@ -65,7 +65,7 @@ data SqlBackend = SqlBackend
     -- | table name, column names, id name, either 1 or 2 statements to run
     , connInsertSql :: EntityDef -> [PersistValue] -> InsertSqlResult
     , connInsertManySql :: Maybe (EntityDef -> [[PersistValue]] -> InsertSqlResult) -- ^ SQL for inserting many rows and returning their primary keys, for backends that support this functioanlity. If 'Nothing', rows will be inserted one-at-a-time using 'connInsertSql'.
-    , connUpsertSql :: Maybe (EntityDef -> [PersistValue] -> Text -> Text)
+    , connUpsertSql :: Maybe (EntityDef -> Text -> Text)
     , connStmtMap :: IORef (Map Text Statement)
     , connClose :: IO ()
     , connMigrateSql

--- a/persistent/Database/Persist/Sql/Types/Internal.hs
+++ b/persistent/Database/Persist/Sql/Types/Internal.hs
@@ -65,6 +65,7 @@ data SqlBackend = SqlBackend
     -- | table name, column names, id name, either 1 or 2 statements to run
     , connInsertSql :: EntityDef -> [PersistValue] -> InsertSqlResult
     , connInsertManySql :: Maybe (EntityDef -> [[PersistValue]] -> InsertSqlResult) -- ^ SQL for inserting many rows and returning their primary keys, for backends that support this functioanlity. If 'Nothing', rows will be inserted one-at-a-time using 'connInsertSql'.
+    , connUpsertSql :: Maybe (EntityDef -> [PersistValue] -> Text -> Text)
     , connStmtMap :: IORef (Map Text Statement)
     , connClose :: IO ()
     , connMigrateSql

--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -218,8 +218,20 @@ toEmbedEntityDef ent = embDef
                         _ -> Nothing
                     }
 
+-- Type for storing the Uniqueness constraint in the Schema.
+-- Assume you have the following schema with a uniqueness
+-- constraint:
+-- Person
+--   name String
+--   age Int
+--   UniqueAge age
+--
+-- This will be represented as:
+-- UniqueDef (HaskellName (packPTH "UniqueAge"))
+-- (DBName (packPTH "unique_age")) [(HaskellName (packPTH "age"), DBName (packPTH "age"))] []
+--
 data UniqueDef = UniqueDef
-    { uniqueHaskell :: !HaskellName
+    { uniqueHaskell :: !HaskellName 
     , uniqueDBName  :: !DBName
     , uniqueFields  :: ![(HaskellName, DBName)]
     , uniqueAttrs   :: ![Attr]


### PR DESCRIPTION
I have created this PR for getting review.

Things that work now:

* Atomic upsert for postgresql work

Things that have to be done:

* Raise exception when there is more than one uniqueness constraint for an `EntityDef`.
* Fix other backend errors - Right now works only for postgresql

Question I have:

In what scenario will the field `uniqueFields` have more than one element in the list. Why it is modelled as a List data strcuture instead of a tuple like `(HaskellName, DBName)` ?

The `UniqueDef` type for reference:

``` haskell
data UniqueDef = UniqueDef
    { uniqueHaskell :: !HaskellName 
    , uniqueDBName  :: !DBName
    , uniqueFields  :: ![(HaskellName, DBName)] -- why list instead of single tuple ?
    , uniqueAttrs   :: ![Attr]
    }
    deriving (Show, Eq, Read, Ord)
```

