### PR TITLE
Allow composite Primary keys for tables that contain nullable fields.

### DIFF
--- a/persistent-test/src/CompositeTest.hs
+++ b/persistent-test/src/CompositeTest.hs
@@ -85,6 +85,13 @@ share [mkPersist persistSettings { mpsGeneric = False }, mkMigrate "compositeMig
     address AddressId
     Primary citizen address
     deriving Eq Show
+
+  PrimaryCompositeWithOtherNullableFields
+    foo String
+    bar String
+    baz String Maybe
+    Primary foo bar
+    deriving Eq Show
 |]
 
 

--- a/persistent/Database/Persist/Quasi.hs
+++ b/persistent/Database/Persist/Quasi.hs
@@ -456,8 +456,10 @@ takeComposite fields pkcols
     (_, attrs) = break ("!" `T.isPrefixOf`) pkcols
     getDef [] t = error $ "Unknown column in primary key constraint: " ++ show t
     getDef (d:ds) t
-        | nullable (fieldAttrs d) /= NotNullable = error $ "primary key column cannot be nullable: " ++ show t
-        | fieldHaskell d == HaskellName t = d
+        | fieldHaskell d == HaskellName t =
+            if nullable (fieldAttrs d) /= NotNullable
+                then error $ "primary key column cannot be nullable: " ++ show t
+                else d
         | otherwise = getDef ds t
 
 -- Unique UppercaseConstraintName list of lowercasefields    


### PR DESCRIPTION
The `takeComposite` function in `persistent/Database/Persist/Quasi.hs` was incorrectly disallowing composite Primary keys for tables that contain nullable fields.

A definition like this:

```
PrimaryCompositeWithOtherNullableFields
   foo String
   baz String Maybe
   bar String
   Primary foo bar
```

Would generate an error:

```
/path/to/some/haskell/file/Foo.hs:15:23:
    Exception when trying to run compile-time code:
      primary key column cannot be nullable: "bar"
    Code: template-haskell-2.10.0.0:Language.Haskell.TH.Quote.quoteExp
            persistLowerCase
            "\n\
            \    Primary CompositeWithOtherNullableFields\n\
            \        foo String\n\
            \        baz String Maybe\n\
            \        bar String\n\
            \        Primary foo bar\n\
```

This PR fixes the logic in `takeComposite` so that it only requires the columns being used in the primary key be non-nullable.

A small test table is also added.