### PR TITLE
Add MonadBaseControl as part of type signature

### DIFF
--- a/persistent-mongoDB/persistent-mongoDB.cabal
+++ b/persistent-mongoDB/persistent-mongoDB.cabal
@@ -27,7 +27,7 @@ library
                    , bytestring         >= 0.9
                    , conduit            >= 0.5.3
                    , resourcet          >= 0.3
-                   , mongoDB            >= 2.0.3   && < 3.0
+                   , mongoDB            >= 2.1.0   && < 3.0
                    , bson               >= 0.3.1   && < 0.4
                    , network            >= 2.2.1.7
                    , cereal             >= 0.3.0.0

--- a/persistent-template/persistent-template.cabal
+++ b/persistent-template/persistent-template.cabal
@@ -24,7 +24,7 @@ library
                    , transformers             >= 0.2       && < 0.6
                    , containers
                    , aeson                    >= 0.7       && < 0.12
-                   , aeson-compat             >= 0.3.2.0   && < 0.4
+                   , aeson-compat             >= 0.3.5.1   && < 0.4
                    , monad-logger
                    , unordered-containers
                    , tagged

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -94,8 +94,7 @@ library
                    , file-location >= 0.4
                    , template-haskell
                    , aeson                    >= 0.7
-                   , aeson-compat             >= 0.3.2.0   && < 0.4
-                   , aeson-extra              >= 0.3
+                   , aeson-compat             >= 0.3.5.1   && < 0.4
                    , lifted-base              >= 0.1
                    , network
                    , path-pieces              >= 0.1
@@ -156,7 +155,7 @@ library
 
    if flag(mongodb)
      build-depends:  persistent-mongoDB
-                   , mongoDB            >= 2.0.4 && < 3.0
+                   , mongoDB            >= 2.1.0   && < 3.0
                    , cereal
                    , bson               >= 0.3.1
                    , process

--- a/persistent-test/src/CompositeTest.hs
+++ b/persistent-test/src/CompositeTest.hs
@@ -23,6 +23,7 @@ import Test.Hspec.Expectations ()
 
 #  if MIN_VERSION_monad_control(0, 3, 0)
 import qualified Control.Monad.Trans.Control
+import Control.Monad.Trans.Control (MonadBaseControl)
 #  else
 import qualified Control.Monad.IO.Control
 #  endif
@@ -95,7 +96,7 @@ share [mkPersist persistSettings { mpsGeneric = False }, mkMigrate "compositeMig
 
 
 #ifdef WITH_NOSQL
-cleanDB :: (PersistQuery backend, PersistEntityBackend TestChild ~ backend, MonadIO m) => ReaderT backend m ()
+cleanDB :: (PersistQuery backend, MonadBaseControl IO m, PersistEntityBackend TestChild ~ backend, MonadIO m) => ReaderT backend m ()
 cleanDB = do
   deleteWhere ([] :: [Filter TestChild])
   deleteWhere ([] :: [Filter TestParent])

--- a/persistent-test/src/CustomPrimaryKeyReferenceTest.hs
+++ b/persistent-test/src/CustomPrimaryKeyReferenceTest.hs
@@ -3,7 +3,7 @@
 -- This test is based on this issue: https://github.com/yesodweb/persistent/issues/421
 -- The primary thing this is testing is the migration, thus the test code itself being mostly negligible.
 module CustomPrimaryKeyReferenceTest where
-
+import Control.Monad.Trans.Control (MonadBaseControl)
 import Init
 
 -- mpsGeneric = False is due to a bug or at least lack of a feature in mkKeyTypeDec TH.hs
@@ -26,7 +26,7 @@ share [mkPersist persistSettings { mpsGeneric = False }, mkMigrate "migration"] 
     deriving Show
 |]
 #ifdef WITH_NOSQL
-cleanDB :: (MonadIO m, PersistQuery backend, PersistEntityBackend Tweet ~ backend) => ReaderT backend m ()
+cleanDB :: (MonadIO m, MonadBaseControl IO m, PersistQuery backend, PersistEntityBackend Tweet ~ backend) => ReaderT backend m ()
 cleanDB = do
   deleteWhere ([] :: [Filter Tweet])
   deleteWhere ([] :: [Filter TweetUrl])

--- a/persistent-test/src/DataTypeTest.hs
+++ b/persistent-test/src/DataTypeTest.hs
@@ -16,7 +16,7 @@ import Data.Time.Clock (picosecondsToDiffTime)
 import Data.Time.LocalTime (TimeOfDay (TimeOfDay))
 import Data.IntMap (IntMap)
 import Data.Fixed (Pico,Micro)
-
+import Control.Monad.Trans.Control (MonadBaseControl)
 import Init
 
 type Tuple a b = (a, b)
@@ -46,7 +46,7 @@ DataTypeTable no-json
     utc UTCTime
 |]
 
-cleanDB :: (MonadIO m, PersistQuery backend, backend ~ PersistEntityBackend DataTypeTable) => ReaderT backend m ()
+cleanDB :: (MonadIO m, MonadBaseControl IO m, PersistQuery backend, backend ~ PersistEntityBackend DataTypeTable) => ReaderT backend m ()
 cleanDB = deleteWhere ([] :: [Filter DataTypeTable])
 
 specs :: Spec

--- a/persistent-test/src/EmbedOrderTest.hs
+++ b/persistent-test/src/EmbedOrderTest.hs
@@ -10,8 +10,9 @@ embedOrderMigrate
 
 import Init
 import Data.Map hiding (insert)
-
+import Control.Monad.Trans.Control (MonadBaseControl)
 import Debug.Trace (trace)
+
 debug :: Show s => s -> s
 debug x = trace (show x) x
 
@@ -31,7 +32,7 @@ Bar sql=bar_embed_order
 |]
 
 #ifdef WITH_NOSQL
-cleanDB :: (PersistQuery backend, PersistEntityBackend Foo ~ backend, MonadIO m) => ReaderT backend m ()
+cleanDB :: (PersistQuery backend, MonadBaseControl IO m, PersistEntityBackend Foo ~ backend, MonadIO m) => ReaderT backend m ()
 cleanDB = do
   deleteWhere ([] :: [Filter Foo])
   deleteWhere ([] :: [Filter Bar])

--- a/persistent-test/src/EmbedTest.hs
+++ b/persistent-test/src/EmbedTest.hs
@@ -24,6 +24,7 @@ import EntityEmbedTest
 import System.Process (readProcess)
 #endif
 import Data.List.NonEmpty hiding (insert, length)
+import Control.Monad.Trans.Control (MonadBaseControl)
 
 data TestException = TestException
     deriving (Show, Typeable, Eq)
@@ -151,7 +152,7 @@ share [mkPersist sqlSettings,  mkMigrate "embedMigrate"] [persistUpperCase|
     deriving Show Eq Read Ord
 |]
 #ifdef WITH_NOSQL
-cleanDB :: (PersistQuery backend, PersistEntityBackend HasMap ~ backend, MonadIO m) => ReaderT backend m ()
+cleanDB :: (PersistQuery backend, MonadBaseControl IO m, PersistEntityBackend HasMap ~ backend, MonadIO m) => ReaderT backend m ()
 cleanDB = do
   deleteWhere ([] :: [Filter HasEmbed])
   deleteWhere ([] :: [Filter HasEmbeds])

--- a/persistent-test/src/EmptyEntityTest.hs
+++ b/persistent-test/src/EmptyEntityTest.hs
@@ -6,7 +6,7 @@ module EmptyEntityTest (specs) where
 import Database.Persist.Sql
 import Database.Persist.TH
 import Control.Monad.Trans.Resource (runResourceT)
-
+import Control.Monad.Trans.Control (MonadBaseControl)
 import Init
 
 #ifdef WITH_NOSQL
@@ -19,7 +19,7 @@ EmptyEntity
 |]
 
 #ifdef WITH_NOSQL
-cleanDB :: MonadIO m => ReaderT Context m ()
+cleanDB :: (MonadIO m, MonadBaseControl IO m) => ReaderT Context m ()
 cleanDB = deleteWhere ([] :: [Filter EmptyEntity])
 #endif
 

--- a/persistent-test/src/HtmlTest.hs
+++ b/persistent-test/src/HtmlTest.hs
@@ -7,7 +7,7 @@ import Data.Char (generalCategory, GeneralCategory(..))
 import qualified Data.Text as T
 import System.Random (randomIO, randomRIO, Random)
 import Control.Monad.Trans.Resource (runResourceT)
-
+import Control.Monad.Trans.Control (MonadBaseControl)
 import Init
 import Text.Blaze.Html
 import Text.Blaze.Html.Renderer.Text
@@ -19,7 +19,7 @@ HtmlTable
     deriving
 |]
 
-cleanDB :: (MonadIO m, PersistQuery backend, PersistEntityBackend HtmlTable ~ backend) => ReaderT backend m ()
+cleanDB :: (MonadIO m, MonadBaseControl IO m, PersistQuery backend, PersistEntityBackend HtmlTable ~ backend) => ReaderT backend m ()
 cleanDB = do
   deleteWhere ([] :: [Filter HtmlTable])
 

--- a/persistent-test/src/LargeNumberTest.hs
+++ b/persistent-test/src/LargeNumberTest.hs
@@ -3,6 +3,7 @@ module LargeNumberTest where
 
 import Init
 import Data.Word
+import Control.Monad.Trans.Control (MonadBaseControl)
 
 #ifdef WITH_NOSQL
 mkPersist persistSettings [persistUpperCase|
@@ -19,7 +20,7 @@ share [mkPersist sqlSettings,  mkMigrate "numberMigrate"] [persistLowerCase|
 |]
 
 #ifdef WITH_NOSQL
-cleanDB :: (MonadIO m, PersistQuery backend, PersistEntityBackend Number ~ backend) => ReaderT backend m ()
+cleanDB :: (MonadIO m, MonadBaseControl IO m, PersistQuery backend, PersistEntityBackend Number ~ backend) => ReaderT backend m ()
 cleanDB = do
   deleteWhere ([] :: [Filter Number])
 db :: Action IO () -> Assertion

--- a/persistent-test/src/PersistUniqueTest.hs
+++ b/persistent-test/src/PersistUniqueTest.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE QuasiQuotes, TemplateHaskell, CPP, GADTs, TypeFamilies, OverloadedStrings, FlexibleContexts, EmptyDataDecls, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses #-}
 module PersistUniqueTest where
-
+import Control.Monad.Trans.Control (MonadBaseControl)
 import Init
 
 -- mpsGeneric = False is due to a bug or at least lack of a feature in mkKeyTypeDec TH.hs
@@ -17,7 +17,7 @@ share [mkPersist persistSettings { mpsGeneric = False }, mkMigrate "migration"] 
       deriving Eq Show
 |]
 #ifdef WITH_NOSQL
-cleanDB :: (MonadIO m, PersistQuery backend, PersistEntityBackend Fo ~ backend) => ReaderT backend m ()
+cleanDB :: (MonadIO m, MonadBaseControl IO m, PersistQuery backend, PersistEntityBackend Fo ~ backend) => ReaderT backend m ()
 cleanDB = do
   deleteWhere ([] :: [Filter Fo])
 

--- a/persistent-test/src/PersistentTest.hs
+++ b/persistent-test/src/PersistentTest.hs
@@ -21,7 +21,7 @@ import Test.HUnit hiding (Test)
 import Control.Monad.Trans.Resource (runResourceT)
 import Test.Hspec.Expectations ()
 import Test.Hspec.QuickCheck(prop)
-
+import Control.Monad.Trans.Control (MonadBaseControl)
 import Database.Persist
 
 #ifdef WITH_NOSQL
@@ -179,7 +179,7 @@ NoPrefix2
     deriving Show Eq
 |]
 
-cleanDB :: (MonadIO m, PersistQuery backend, PersistEntityBackend EmailPT ~ backend) => ReaderT backend m ()
+cleanDB :: (MonadIO m, MonadBaseControl IO m, PersistQuery backend, PersistEntityBackend EmailPT ~ backend) => ReaderT backend m ()
 cleanDB = do
   deleteWhere ([] :: [Filter Person])
   deleteWhere ([] :: [Filter Person1])

--- a/persistent-test/src/PrimaryTest.hs
+++ b/persistent-test/src/PrimaryTest.hs
@@ -2,7 +2,7 @@
 module PrimaryTest where
 
 import Init
-
+import Control.Monad.Trans.Control (MonadBaseControl)
 -- mpsGeneric = False is due to a bug or at least lack of a feature in mkKeyTypeDec TH.hs
 #if WITH_NOSQL
 mkPersist persistSettings { mpsGeneric = False } [persistUpperCase|
@@ -22,7 +22,7 @@ share [mkPersist persistSettings { mpsGeneric = False }, mkMigrate "migration"] 
     Foreign Trees fkparent parent
 |]
 #ifdef WITH_NOSQL
-cleanDB :: (MonadIO m, PersistQuery backend, PersistEntityBackend Foo ~ backend) => ReaderT backend m ()
+cleanDB :: (MonadIO m, MonadBaseControl IO m, PersistQuery backend, PersistEntityBackend Foo ~ backend) => ReaderT backend m ()
 cleanDB = do
   deleteWhere ([] :: [Filter Foo])
   deleteWhere ([] :: [Filter Bar])

--- a/persistent-test/src/UniqueTest.hs
+++ b/persistent-test/src/UniqueTest.hs
@@ -2,6 +2,7 @@
 module UniqueTest where
 
 import Init
+import Control.Monad.Trans.Control (MonadBaseControl)
 
 #ifdef WITH_NOSQL
 mkPersist persistSettings [persistUpperCase|
@@ -27,7 +28,7 @@ share [mkPersist sqlSettings,  mkMigrate "uniqueMigrate"] [persistLowerCase|
 #endif
 |]
 #ifdef WITH_NOSQL
-cleanDB :: (MonadIO m, PersistQuery backend, PersistEntityBackend TestNonNull ~ backend) => ReaderT backend m ()
+cleanDB :: (MonadIO m, MonadBaseControl IO m, PersistQuery backend, PersistEntityBackend TestNonNull ~ backend) => ReaderT backend m ()
 cleanDB = do
   deleteWhere ([] :: [Filter TestNonNull])
   deleteWhere ([] :: [Filter TestNull])

--- a/persistent/Database/Persist/Class/DeleteCascade.hs
+++ b/persistent/Database/Persist/Class/DeleteCascade.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleContexts #-}
 module Database.Persist.Class.DeleteCascade
     ( DeleteCascade (..)
     , deleteCascadeWhere
@@ -8,7 +9,7 @@ module Database.Persist.Class.DeleteCascade
 import Database.Persist.Class.PersistStore
 import Database.Persist.Class.PersistQuery
 import Database.Persist.Class.PersistEntity
-
+import Control.Monad.Trans.Control (MonadBaseControl)
 import qualified Data.Conduit as C
 import qualified Data.Conduit.List as CL
 import Control.Monad.IO.Class (MonadIO, liftIO)
@@ -23,10 +24,10 @@ class (PersistStoreWrite backend, PersistEntity record, BaseBackend backend ~ Pe
 
     -- | Perform cascade-deletion of single database
     -- entry.
-    deleteCascade :: MonadIO m => Key record -> ReaderT backend m ()
+    deleteCascade :: (MonadIO m, MonadBaseControl IO m) => Key record -> ReaderT backend m ()
 
 -- | Cascade-deletion of entries satisfying given filters.
-deleteCascadeWhere :: (MonadIO m, DeleteCascade record backend, PersistQueryWrite backend)
+deleteCascadeWhere :: (MonadIO m, MonadBaseControl IO m, DeleteCascade record backend, PersistQueryWrite backend)
                    => [Filter record] -> ReaderT backend m ()
 deleteCascadeWhere filts = do
     srcRes <- selectKeysRes filts []

--- a/persistent/Database/Persist/Class/PersistQuery.hs
+++ b/persistent/Database/Persist/Class/PersistQuery.hs
@@ -20,6 +20,7 @@ import qualified Data.Conduit.List as CL
 import Database.Persist.Class.PersistStore
 import Database.Persist.Class.PersistEntity
 import Control.Monad.Trans.Resource (MonadResource, release)
+import Control.Monad.Trans.Control (MonadBaseControl)
 import Data.Acquire (Acquire, allocateAcquire, with)
 
 -- | Backends supporting conditional read operations.
@@ -55,11 +56,11 @@ class (PersistCore backend, PersistStoreRead backend) => PersistQueryRead backen
 -- | Backends supporting conditional write operations
 class (PersistQueryRead backend, PersistStoreWrite backend) => PersistQueryWrite backend where
     -- | Update individual fields on any record matching the given criterion.
-    updateWhere :: (MonadIO m, PersistRecordBackend record backend)
+    updateWhere :: (MonadIO m, MonadBaseControl IO m, PersistRecordBackend record backend)
                 => [Filter record] -> [Update record] -> ReaderT backend m ()
 
     -- | Delete all records matching the given criterion.
-    deleteWhere :: (MonadIO m, PersistRecordBackend record backend)
+    deleteWhere :: (MonadIO m, MonadBaseControl IO m, PersistRecordBackend record backend)
                 => [Filter record] -> ReaderT backend m ()
 
 -- | Get all records matching the given criterion in the specified order.

--- a/persistent/Database/Persist/Class/PersistStore.hs
+++ b/persistent/Database/Persist/Class/PersistStore.hs
@@ -23,6 +23,7 @@ import Control.Exception.Lifted (throwIO)
 import Control.Monad.Trans.Reader (ReaderT)
 import Control.Monad.Reader (MonadReader (ask), runReaderT)
 import Database.Persist.Class.PersistEntity
+import Control.Monad.Trans.Control (MonadBaseControl)
 import Database.Persist.Class.PersistField
 import Database.Persist.Types
 import qualified Data.Aeson as A
@@ -142,23 +143,23 @@ class
     -- | Put the record in the database with the given key.
     -- Unlike 'replace', if a record with the given key does not
     -- exist then a new record will be inserted.
-    repsert :: (MonadIO m, PersistRecordBackend record backend)
+    repsert :: (MonadIO m, MonadBaseControl IO m, PersistRecordBackend record backend)
             => Key record -> record -> ReaderT backend m ()
 
     -- | Replace the record in the database with the given
     -- key. Note that the result is undefined if such record does
     -- not exist, so you must use 'insertKey or 'repsert' in
     -- these cases.
-    replace :: (MonadIO m, PersistRecordBackend record backend)
+    replace :: (MonadIO m, MonadBaseControl IO m, PersistRecordBackend record backend)
             => Key record -> record -> ReaderT backend m ()
 
     -- | Delete a specific record by identifier. Does nothing if record does
     -- not exist.
-    delete :: (MonadIO m, PersistRecordBackend record backend)
+    delete :: (MonadIO m, MonadBaseControl IO m, PersistRecordBackend record backend)
            => Key record -> ReaderT backend m ()
 
     -- | Update individual fields on a specific record.
-    update :: (MonadIO m, PersistRecordBackend record backend)
+    update :: (MonadIO m, MonadBaseControl IO m, PersistRecordBackend record backend)
            => Key record -> [Update record] -> ReaderT backend m ()
 
     -- | Update individual fields on a specific record, and retrieve the
@@ -166,7 +167,7 @@ class
     --
     -- Note that this function will throw an exception if the given key is not
     -- found in the database.
-    updateGet :: (MonadIO m, PersistRecordBackend record backend)
+    updateGet :: (MonadIO m, MonadBaseControl IO m, PersistRecordBackend record backend)
               => Key record -> [Update record] -> ReaderT backend m record
     updateGet key ups = do
         update key ups

--- a/persistent/Database/Persist/Class/PersistUnique.hs
+++ b/persistent/Database/Persist/Class/PersistUnique.hs
@@ -18,6 +18,7 @@ import Data.List ((\\))
 import Control.Monad.Trans.Reader (ReaderT)
 import Database.Persist.Class.PersistStore
 import Database.Persist.Class.PersistEntity
+import Control.Monad.Trans.Control (MonadBaseControl)
 import Data.Monoid (mappend)
 import Data.Text (unpack, Text)
 
@@ -53,7 +54,7 @@ class (PersistUniqueRead backend, PersistStoreWrite backend) => PersistUniqueWri
 
     -- | Delete a specific record by unique key. Does nothing if no record
     -- matches.
-    deleteBy :: (MonadIO m, PersistRecordBackend record backend) => Unique record -> ReaderT backend m ()
+    deleteBy :: (MonadIO m, MonadBaseControl IO m, PersistRecordBackend record backend) => Unique record -> ReaderT backend m ()
 
     -- | Like 'insert', but returns 'Nothing' when the record
     -- couldn't be inserted because of a uniqueness constraint.
@@ -70,7 +71,7 @@ class (PersistUniqueRead backend, PersistStoreWrite backend) => PersistUniqueWri
     -- * update the existing record that matches the uniqueness contraint.
     --
     -- Throws an exception if there is more than 1 uniqueness contraint.
-    upsert :: (MonadIO m, PersistRecordBackend record backend)
+    upsert :: (MonadIO m, MonadBaseControl IO m, PersistRecordBackend record backend)
            => record          -- ^ new record to insert
            -> [Update record]
            -- ^ updates to perform if the record already exists (leaving
@@ -86,7 +87,7 @@ class (PersistUniqueRead backend, PersistStoreWrite backend) => PersistUniqueWri
     --
     -- * insert the new record if it does not exist;
     -- * update the existing record that matches the given uniqueness contraint.
-    upsertBy :: (MonadIO m, PersistRecordBackend record backend)
+    upsertBy :: (MonadIO m, MonadBaseControl IO m, PersistRecordBackend record backend)
             => Unique record -- ^ uniqueness constraint to find by
             -> record          -- ^ new record to insert
             -> [Update record]
@@ -172,7 +173,7 @@ recordName = unHaskellName . entityHaskell . entityDef . Just
 -- If uniqueness is violated, return a 'Just' with the 'Unique' violation
 --
 -- Since 1.2.2.0
-replaceUnique :: (MonadIO m, Eq record, Eq (Unique record), PersistRecordBackend record backend, PersistUniqueWrite backend)
+replaceUnique :: (MonadIO m, MonadBaseControl IO m, Eq record, Eq (Unique record), PersistRecordBackend record backend, PersistUniqueWrite backend)
               => Key record -> record -> ReaderT backend m (Maybe (Unique record))
 replaceUnique key datumNew = getJust key >>= replaceOriginal
   where

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -43,7 +43,7 @@ library
                    , base64-bytestring
                    , unordered-containers
                    , vector
-                   , attoparsec
+                   , attoparsec               
                    , template-haskell
                    , blaze-html               >= 0.5
                    , blaze-markup             >= 0.5.1


### PR DESCRIPTION
This is because of change in the package mongoDB where type signature
has changed from `MonadIO m => Selection -> Action m ()` to `(MonadIO m,
MonadBaseControl IO m) => Selection -> Action m ()`. This leads to the
additon of extra type constraint to make it compile.

Also helps in fixing the nix error:
https://hydra.nixos.org/build/37252928/nixlog/1/raw

Also Update mongoDB version constraint to 2.1.0
Bump aeson-compat version constraint.
Remove aeson-extra from persistent-test package.