### PR TITLE
Relax upper bound on mysql-simple

### DIFF
--- a/persistent-mysql/persistent-mysql.cabal
+++ b/persistent-mysql/persistent-mysql.cabal
@@ -1,5 +1,5 @@
 name:            persistent-mysql
-version:         2.6
+version:         2.6.0.1
 license:         MIT
 license-file:    LICENSE
 author:          Felipe Lessa <felipe.lessa@gmail.com>, Michael Snoyman
@@ -29,7 +29,7 @@ extra-source-files: ChangeLog.md
 library
     build-depends:   base                  >= 4.6        && < 5
                    , transformers          >= 0.2.1
-                   , mysql-simple          >= 0.2.2.3  && < 0.3
+                   , mysql-simple          >= 0.2.2.3  && < 0.4
                    , mysql                 >= 0.1.1.3  && < 0.2
                    , blaze-builder
                    , persistent            >= 2.6      && < 3

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -1,5 +1,5 @@
 name:            persistent-test
-version:         2.0.0
+version:         2.0.0.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -147,7 +147,7 @@ library
 
    if flag(mysql)
      build-depends:  persistent-mysql
-                   , mysql-simple          >= 0.2.2.3  && < 0.3
+                   , mysql-simple          >= 0.2.2.3  && < 0.4
                    , mysql                 >= 0.1.1.3  && < 0.2
      cpp-options: -DWITH_MYSQL
 


### PR DESCRIPTION
This is best done before we try to get persistent-mysql back into stackage.

The changed types/instances in mysql-simple don't seem to used at all by persistent-mysql, so I believe we only need a minor version bump here (or even a hackage revision) - there are extra tuple instances for QueryResults and an extra field in ResultError.