### PR TITLE
Relax upper bound on mysql-simple - again

### DIFF
--- a/persistent-mysql/persistent-mysql.cabal
+++ b/persistent-mysql/persistent-mysql.cabal
@@ -29,7 +29,7 @@ extra-source-files: ChangeLog.md
 library
     build-depends:   base                  >= 4.6        && < 5
                    , transformers          >= 0.2.1
-                   , mysql-simple          >= 0.2.2.3  && < 0.4
+                   , mysql-simple          >= 0.2.2.3  && < 0.5
                    , mysql                 >= 0.1.1.3  && < 0.2
                    , blaze-builder
                    , persistent            >= 2.6      && < 3

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -147,7 +147,7 @@ library
 
    if flag(mysql)
      build-depends:  persistent-mysql
-                   , mysql-simple          >= 0.2.2.3  && < 0.4
+                   , mysql-simple          >= 0.2.2.3  && < 0.5
                    , mysql                 >= 0.1.1.3  && < 0.2
      cpp-options: -DWITH_MYSQL
 


### PR DESCRIPTION
I'll release mysql-simple-0.4.0.0 soon, but I'll let you do this first to avoid unnecessary bounds issues in the next stackage build.

The theoretically-breaking change is another addition to ResultError, and as before it shouldn't affect persistent-mysql versioning.  I had missed it while working through the old PRs :-(