### PR TITLE
Proper mysql default migrations

### DIFF
--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -456,7 +456,7 @@ getColumns connectInfo getter def = do
     stmtIdClmn <- getter "SELECT COLUMN_NAME, \
                                  \IS_NULLABLE, \
                                  \DATA_TYPE, \
-                                 \COLUMN_DEFAULT \
+                                 \IF(IS_NULLABLE='YES', COALESCE(COLUMN_DEFAULT, 'NULL'), COLUMN_DEFAULT) \
                           \FROM INFORMATION_SCHEMA.COLUMNS \
                           \WHERE TABLE_SCHEMA = ? \
                             \AND TABLE_NAME   = ? \
@@ -472,7 +472,7 @@ getColumns connectInfo getter def = do
                                \CHARACTER_MAXIMUM_LENGTH, \
                                \NUMERIC_PRECISION, \
                                \NUMERIC_SCALE, \
-                               \COLUMN_DEFAULT \
+                               \IF(IS_NULLABLE='YES', COALESCE(COLUMN_DEFAULT, 'NULL'), COLUMN_DEFAULT) \
                         \FROM INFORMATION_SCHEMA.COLUMNS \
                         \WHERE TABLE_SCHEMA = ? \
                           \AND TABLE_NAME   = ? \

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -35,7 +35,6 @@ import Data.List (find, intercalate, sort, groupBy)
 import Data.Pool (Pool)
 import Data.Text (Text, pack)
 import qualified Data.Text.IO as T
-import Data.Word (Word32)
 import Text.Read (readMaybe)
 import System.Environment (getEnvironment)
 import Data.Acquire (Acquire, mkAcquire, with)


### PR DESCRIPTION
Current `peristent-mysql` code treats `DEFAULT NULL` in DB as no default value so as a result we get noop migrations setting it to `DEFAULT NULL` for columns with `default=NULL` in entity declaration.
This PR fixes it