### PR TITLE
Fix #527 by implementing chunking in insertMany_

### DIFF
--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -125,6 +125,7 @@ open' ci logFunc = do
         , connRDBMS      = "mysql"
         , connLimitOffset = decorateSQLWithLimitOffset "LIMIT 18446744073709551615"
         , connLogFunc    = logFunc
+        , connMaxParams = Nothing
         }
 
 -- | Prepare a query.  We don't support prepared statements, but
@@ -1002,7 +1003,8 @@ mockMigration mig = do
                              connNoLimit = undefined,
                              connRDBMS = undefined,
                              connLimitOffset = undefined,
-                             connLogFunc = undefined}
+                             connLogFunc = undefined,
+                             connMaxParams = Nothing}
       result = runReaderT . runWriterT . runWriterT $ mig 
   resp <- result sqlbackend
   mapM_ T.putStrLn $ map snd $ snd resp

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -201,6 +201,7 @@ openSimpleConn logFunc conn = do
         , connRDBMS      = "postgresql"
         , connLimitOffset = decorateSQLWithLimitOffset "LIMIT ALL"
         , connLogFunc = logFunc
+        , connMaxParams = Nothing
         }
 
 prepare' :: PG.Connection -> Text -> IO Statement
@@ -1111,7 +1112,8 @@ mockMigration mig = do
                              connNoLimit = undefined,
                              connRDBMS = undefined,
                              connLimitOffset = undefined,
-                             connLogFunc = undefined}
+                             connLogFunc = undefined,
+                             connMaxParams = Nothing}
       result = runReaderT $ runWriterT $ runWriterT mig
   resp <- result sqlbackend
   mapM_ T.putStrLn $ map snd $ snd resp

--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -121,6 +121,7 @@ wrapConnectionWal enableWal conn logFunc = do
         , connRDBMS = "sqlite"
         , connLimitOffset = decorateSQLWithLimitOffset "LIMIT -1"
         , connLogFunc = logFunc
+        , connMaxParams = Just 999
         }
   where
     helper t getter = do

--- a/persistent-sqlite/test/Spec.hs
+++ b/persistent-sqlite/test/Spec.hs
@@ -43,3 +43,6 @@ main = hspec $ do
         conn <- Sqlite.open (T.pack fp)
         Sqlite.close conn
         return ()
+    it "issue #527" $ asIO $ runSqlite ":memory:" $ do
+        runMigration migrateAll
+        insertMany_ $ replicate 1000 (Test $ read "2014-11-30 05:15:25.123")

--- a/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
@@ -39,7 +39,6 @@ import Web.HttpApiData (ToHttpApiData, FromHttpApiData)
 import Database.Persist.Sql.Class (PersistFieldSql)
 import qualified Data.Aeson as A
 import Control.Exception.Lifted (throwIO)
-import Data.List.Split
 
 withRawQuery :: MonadIO m
              => Text
@@ -236,6 +235,9 @@ instance PersistStoreWrite SqlBackend where
           rawExecute sql (concat valss)
 
         t = entityDef vals
+        -- Implement this here to avoid depending on the split package
+        chunksOf _ [] = []
+        chunksOf size xs = let (chunk, rest) = splitAt size xs in chunk : chunksOf size rest
 
     replace k val = do
         conn <- ask

--- a/persistent/Database/Persist/Sql/Types/Internal.hs
+++ b/persistent/Database/Persist/Sql/Types/Internal.hs
@@ -81,6 +81,7 @@ data SqlBackend = SqlBackend
     , connRDBMS :: Text
     , connLimitOffset :: (Int,Int) -> Bool -> Text -> Text
     , connLogFunc :: LogFunc
+    , connMaxParams :: Maybe Int -- ^ Some databases (probably only Sqlite) have a limit on how many question-mark parameters may be used in a statement
     }
     deriving Typeable
 instance HasPersistBackend SqlBackend where

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -52,6 +52,7 @@ library
                    , fast-logger              >= 2.1
                    , scientific
                    , tagged
+                   , split
 
     exposed-modules: Database.Persist
                      Database.Persist.Quasi

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -52,7 +52,6 @@ library
                    , fast-logger              >= 2.1
                    , scientific
                    , tagged
-                   , split
 
     exposed-modules: Database.Persist
                      Database.Persist.Quasi


### PR DESCRIPTION
This fixes #527.

- I haven't run the test suite against MySQL or PostgreSQL, but they should work.
- I added a dependency on split to avoid having to reimplement `chunksOf`, I can remove this if necessary.
- This change adds a field to the `SQLBackend` type and will require a one-line change to packages implementing SQL backends.