### PR TITLE
Enable foreign key constraints by default for Sqlite backend.

### DIFF
--- a/persistent-sqlite/ChangeLog.md
+++ b/persistent-sqlite/ChangeLog.md
@@ -1,3 +1,7 @@
+## 2.6.1.0
+
+* Removed the behaviour of toggling write-ahead log (WAL) based on a prefix in the connection string, in favour of using a record.
+
 ## 2.6
 
 Compatibility for backend-specific upsert functionality.

--- a/persistent-sqlite/ChangeLog.md
+++ b/persistent-sqlite/ChangeLog.md
@@ -1,6 +1,7 @@
 ## 2.6.1.0
 
 * Removed the behaviour of toggling write-ahead log (WAL) based on a prefix in the connection string, in favour of using a record.
+* Turned on foreign key constraints [#646](https://github.com/yesodweb/persistent/issues/646)
 
 ## 2.6
 

--- a/persistent-sqlite/persistent-sqlite.cabal
+++ b/persistent-sqlite/persistent-sqlite.cabal
@@ -1,5 +1,5 @@
 name:            persistent-sqlite
-version:         2.6
+version:         2.6.1.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -32,6 +32,7 @@ library
                    , aeson                   >= 0.6.2
                    , conduit                 >= 0.5.3
                    , monad-logger            >= 0.2.4
+                   , microlens-th            >= 0.4.1.1
                    , resourcet               >= 1.1
                    , time
                    , old-locale

--- a/persistent-sqlite/test/Spec.hs
+++ b/persistent-sqlite/test/Spec.hs
@@ -27,12 +27,12 @@ asIO = id
 
 main :: IO ()
 main = hspec $ do
-    it "issue #328" $ asIO $ runSqlite ":memory:" $ do
+    it "issue #328" $ asIO $ runSqlite (mkSqliteConnectionInfo ":memory:") $ do
         runMigration migrateAll
         insert . Test $ read "2014-11-30 05:15:25.123"
         [Single x] <- rawSql "select strftime('%s%f',time) from test" []
         liftIO $ x `shouldBe` Just ("141732452525.123" :: String)
-    it "issue #339" $ asIO $ runSqlite ":memory:" $ do
+    it "issue #339" $ asIO $ runSqlite (mkSqliteConnectionInfo ":memory:") $ do
         runMigration migrateAll
         now <- liftIO getCurrentTime
         tid <- insert $ Test now

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -136,7 +136,7 @@ library
      cpp-options: -DNO_OVERLAP
 
    if !flag(postgresql) && !flag(mysql) && !flag(mongodb) && !flag(zookeeper)
-      build-depends: persistent-sqlite
+      build-depends: persistent-sqlite     >= 2.6.1.0
      cpp-options: -DWITH_SQLITE -DDEBUG
 
    if flag(postgresql)

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -96,7 +96,7 @@ library
                    , lifted-base              >= 0.1
                    , network
                    , path-pieces              >= 0.1
-                   , http-api-data            >= 0.2       && < 0.3
+                   , http-api-data            >= 0.2       && < 0.4
                    , text                     >= 0.8
                    , transformers             >= 0.2.1
                    , monad-control            >= 0.3

--- a/persistent-test/src/Init.hs
+++ b/persistent-test/src/Init.hs
@@ -221,11 +221,17 @@ instance Arbitrary PersistValue where
 persistSettings :: MkPersistSettings
 persistSettings = sqlSettings { mpsGeneric = True }
 type BackendMonad = SqlBackend
+#  ifdef WITH_SQLITE
 sqlite_database_file :: Text
 sqlite_database_file = "test/testdb.sqlite3"
 sqlite_database :: SqliteConnectionInfo
 sqlite_database = mkSqliteConnectionInfo sqlite_database_file
--- sqlite_database = ":memory:"
+#  else
+sqlite_database_file :: Text
+sqlite_database_file = error "Sqlite tests disabled"
+sqlite_database :: ()
+sqlite_database = error "Sqlite tests disabled"
+#  endif
 runConn :: (MonadIO m, MonadBaseControl IO m) => SqlPersistT (LoggingT m) t -> m ()
 runConn f = do
   travis <- liftIO isTravis

--- a/persistent-test/src/Init.hs
+++ b/persistent-test/src/Init.hs
@@ -26,6 +26,7 @@ module Init (
 #else
   , db
   , sqlite_database
+  , sqlite_database_file
 #endif
   , BackendKey(..)
   , generateKey
@@ -220,8 +221,10 @@ instance Arbitrary PersistValue where
 persistSettings :: MkPersistSettings
 persistSettings = sqlSettings { mpsGeneric = True }
 type BackendMonad = SqlBackend
-sqlite_database :: Text
-sqlite_database = "test/testdb.sqlite3"
+sqlite_database_file :: Text
+sqlite_database_file = "test/testdb.sqlite3"
+sqlite_database :: SqliteConnectionInfo
+sqlite_database = mkSqliteConnectionInfo sqlite_database_file
 -- sqlite_database = ":memory:"
 runConn :: (MonadIO m, MonadBaseControl IO m) => SqlPersistT (LoggingT m) t -> m ()
 runConn f = do

--- a/persistent-test/test/main.hs
+++ b/persistent-test/test/main.hs
@@ -48,7 +48,7 @@ main :: IO ()
 main = do
 #ifndef WITH_NOSQL
   handle (\(_ :: IOException) -> return ())
-    $ removeFile $ fromText sqlite_database
+    $ removeFile $ fromText sqlite_database_file
 
   runConn $ do
     mapM_ setup

--- a/persistent-test/test/main.hs
+++ b/persistent-test/test/main.hs
@@ -47,8 +47,10 @@ toExitCode False = ExitFailure 1
 main :: IO ()
 main = do
 #ifndef WITH_NOSQL
+#  ifdef WITH_SQLITE
   handle (\(_ :: IOException) -> return ())
     $ removeFile $ fromText sqlite_database_file
+#  endif
 
   runConn $ do
     mapM_ setup

--- a/stack-docker.yaml
+++ b/stack-docker.yaml
@@ -18,6 +18,7 @@ extra-deps:
   - attoparsec-0.13.0.1
   - http-api-data-0.2
   - time-parsers-0.1.0.0
+  - microlens-th-0.4.1.1
 
 docker:
   enable: true

--- a/stack.yaml
+++ b/stack.yaml
@@ -21,6 +21,7 @@ extra-deps:
   - base-compat-0.9.1
   - scientific-0.3.4.9
   - semigroups-0.18.2
+  - microlens-th-0.4.1.1
 
 flags:
   semigroups:


### PR DESCRIPTION
Sqlite has foreign key constraints [disabled by default](https://www.sqlite.org/foreignkeys.html#fk_enable). This PR enables foreign key constraints by default, and provides a mechanism for restoring the previous behaviour.

As this is a breaking change, I'm not sure if we'll want to bump the version number by more.