### PR TITLE
Convenience functions: getJustEntity and insertRecord

### DIFF
--- a/persistent-test/src/PersistentTest.hs
+++ b/persistent-test/src/PersistentTest.hs
@@ -687,11 +687,23 @@ specs = describe "persistent" $ do
       Just p2 <- get k
       p2 @== p
 
+  it "insertRecord" $ db $ do
+      let record = Person "name" 1 Nothing
+      record' <- insertRecord record 
+      record' @== record
+
   it "getEntity" $ db $ do
       Entity k p <- insertEntity $ Person "name" 1 Nothing
       Just (Entity k2 p2) <- getEntity k
       p @== p2
       k @== k2
+
+  it "getJustEntity" $ db $ do
+      let p1 = Person "name" 1 Nothing
+      k1 <- insert p1
+      Entity k2 p2 <- getJustEntity k1
+      p1 @== p2
+      k1 @== k2
 
   it "repsert" $ db $ do
       k <- liftIO (PersonKey `fmap` generateKey)

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -2,6 +2,8 @@
 
 * Fix edge case for `\<-. [Nothing]`
 * Introduce `connMaxParams`
+* Add 'getJustEntity' and 'insertRecord' convenience function
+* Minor Haddock improvment
 
 ## 2.6
 

--- a/persistent/Database/Persist/Class.hs
+++ b/persistent/Database/Persist/Class.hs
@@ -10,10 +10,12 @@ module Database.Persist.Class
     , PersistStoreWrite (..)
     , PersistRecordBackend
     , getJust
+    , getJustEntity
     , getEntity
     , belongsTo
     , belongsToJust
     , insertEntity
+    , insertRecord
 
     -- * PersistUnique
     , PersistUnique

--- a/persistent/Database/Persist/Class/PersistStore.hs
+++ b/persistent/Database/Persist/Class/PersistStore.hs
@@ -176,7 +176,7 @@ class
         get key >>= maybe (liftIO $ throwIO $ KeyNotFound $ show key) return
 
 
--- | Same as get, but for a non-null (not Maybe) foreign key
+-- | Same as 'get', but for a non-null (not Maybe) foreign key
 -- Unsafe unless your database is enforcing that the foreign key is valid.
 getJust :: ( PersistStoreRead backend
            , Show (Key record)


### PR DESCRIPTION
Fixes #650 

`getJustEntity` is similar to `getJust` but returns `Entity` instead of just the record. `insertRecord` inserts the record and returns it. 