### PR TITLE
Fix language stat(s) for persistent repo.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.hs linguist-language=Haskell

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.hs linguist-language=Haskell
+**/*.hs linguist-language=Haskell

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-**/*.hs linguist-language=Haskell
+persistent-sqlite/cbits/* linguist-vendored


### PR DESCRIPTION
The repo language distribution is heavily skewed towards "C" (86%) due to the presence of  `sqlite3` library within the repo. While there are some additional fixes applied on top the public [v3.12.1 amalgamation](https://github.com/azadkuh/sqlite-amalgamation/tree/3.12.1), it is minor enough we could mark the entire directory as [linguist-vendored](https://github.com/github/linguist#using-gitattributes) so the persistent repo appears as a predominantly haskell repo.

This is what I get after adding the `.gitattributes` file and [running linguist](https://github.com/github/linguist#usage) from the project root.

```
$ linguist 
99.88%  Haskell
0.12%   Shell
```

P.S. Diff between repo sqlite .c and original from sqlite amalgamation:
```diff
$ diff  persistent-sqlite/cbits/sqlite3.c ~/Downloads/sqlite-amalgamation-3120100/sqlite3.c
27856,27869d27855
+ /* Added for Persistent to work around GHC bug */
+ int stat_local(const char *x, struct stat *y)
+ {
+       return stat(x, y);
+ }
+ int fstat_local(int x, struct stat *y)
+ {
+       return fstat(x, y);
+ }
+ int lstat_local(const char *x, struct stat *y)
+ {
+       return lstat(x, y);
+ }
+ 
27893c27879
+   { "stat",         (sqlite3_syscall_ptr)stat_local,       0  },
---
-   { "stat",         (sqlite3_syscall_ptr)stat,       0  },
27906c27892
+   { "fstat",        (sqlite3_syscall_ptr)fstat_local,      0  },
---
-   { "fstat",        (sqlite3_syscall_ptr)fstat,      0  },
28020c28006
+   { "lstat",         (sqlite3_syscall_ptr)lstat_local,          0 },
---
-   { "lstat",         (sqlite3_syscall_ptr)lstat,          0 },
```