### PR TITLE
Allow separate version check for PostgreSQL

### DIFF
--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -136,7 +136,7 @@ createPostgresqlPool = createPostgresqlPoolModified (const $ return ())
 --
 -- <https://groups.google.com/d/msg/yesodweb/qUXrEN_swEo/O0pFwqwQIdcJ>
 --
--- Since 2.1.3
+-- @since 2.1.3
 createPostgresqlPoolModified
     :: (MonadIO m, MonadBaseControl IO m, MonadLogger m, IsSqlBackend backend)
     => (PG.Connection -> IO ()) -- ^ action to perform after connection is created
@@ -149,7 +149,7 @@ createPostgresqlPoolModified = createPostgresqlPoolModifiedWithVersion getServer
 -- the server version (to workaround an Amazon Redshift bug) and connection-specific tweaking
 -- (to change the schema).
 --
--- Since 2.6.2
+-- @since 2.6.2
 createPostgresqlPoolModifiedWithVersion
     :: (MonadIO m, MonadBaseControl IO m, MonadLogger m, IsSqlBackend backend)
     => (PG.Connection -> IO (Maybe Double)) -- ^ action to perform to get the server version

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -145,6 +145,11 @@ createPostgresqlPoolModified
     -> m (Pool backend)
 createPostgresqlPoolModified = createPostgresqlPoolModifiedWithVersion getServerVersion
 
+-- | Same as other similarly-named functions in this module, but takes callbacks for obtaining
+-- the server version (to workaround an Amazon Redshift bug) and connection-specific tweaking
+-- (to change the schema).
+--
+-- Since 2.6.2
 createPostgresqlPoolModifiedWithVersion
     :: (MonadIO m, MonadBaseControl IO m, MonadLogger m, IsSqlBackend backend)
     => (PG.Connection -> IO (Maybe Double)) -- ^ action to perform to get the server version
@@ -202,6 +207,8 @@ openSimpleConn logFunc conn = do
     serverVersion <- getServerVersion conn
     return $ createBackend logFunc serverVersion smap conn
 
+-- | Create the backend given a logging function, server version, mutable statement cell,
+-- and connection
 createBackend :: IsSqlBackend backend => LogFunc -> Maybe Double
               -> IORef (Map.Map Text Statement) -> PG.Connection -> backend
 createBackend logFunc serverVersion smap conn = do


### PR DESCRIPTION
I'm using persistent-postgresql with Amazon Redshift. There's a bug in Redshift that doesn't allow any user to call `show server_version`, so all of my connections fail. I was able to workaround this initially by removing all checks for the server version (my first commit) and now I would like to pass in my own function for providing the version.