### PR TITLE
Relax constraint on `getEntity`

### DIFF
--- a/persistent/Database/Persist/Class/PersistStore.hs
+++ b/persistent/Database/Persist/Class/PersistStore.hs
@@ -238,7 +238,7 @@ insertEntity e = do
 
 -- | Like @get@, but returns the complete @Entity@.
 getEntity ::
-    ( PersistStoreWrite backend
+    ( PersistStoreRead backend
     , PersistRecordBackend e backend
     , MonadIO m
     ) => Key e -> ReaderT backend m (Maybe (Entity e))


### PR DESCRIPTION
This was probably a copy & paste error in #620. There's no need to require a `PersistStoreWrite` when only doing a get operation.