### PR TITLE
Fix #671 - revise handling of 'default null' in mysql

### DIFF
--- a/persistent-mysql/ChangeLog.md
+++ b/persistent-mysql/ChangeLog.md
@@ -1,3 +1,7 @@
+##2.6.0.2
+
+Prevent spurious no-op migrations when `default=NULL` is specified - revised version [#672](https://github.com/yesodweb/persistent/pull/672) (which fixes bug [#671](https://github.com/yesodweb/persistent/issues/671) introduced by the earlier attempt [#641](https://github.com/yesodweb/persistent/pull/641))
+
 ## 2.6
 
 Compatibility for backend-specific upsert functionality.

--- a/persistent-mysql/persistent-mysql.cabal
+++ b/persistent-mysql/persistent-mysql.cabal
@@ -1,5 +1,5 @@
 name:            persistent-mysql
-version:         2.6.0.1
+version:         2.6.0.2
 license:         MIT
 license-file:    LICENSE
 author:          Felipe Lessa <felipe.lessa@gmail.com>, Michael Snoyman


### PR DESCRIPTION
This PR undoes #641, which broke text/blob fields (#671), and fixes the handling of "default=NULL" by silently ignoring it.  Giving this default explicitly never makes any difference, since it is the implicit default for any nullable field.  The original problem addressed by #641 is that MySQL does not retain the distinction between the implicit and explicit versions, so migration could get confused, but #641 resolved the ambiguity in the direction of the explicit declaration, which causes an error for text/blob fields.  This PR goes in the other direction, and makes it implicit.

@snoyberg This is relatively serious, because the Yesod MySQL scaffolding is currently broken, but perhaps @qrilka would like a little while to confirm that the original problem is fixed.