### PR TITLE
MySQL on duplicate key update

### DIFF
--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -1095,7 +1095,7 @@ mkBulkInsertQuery records fieldValues updates =
         , ") "
         , " VALUES "
         , recordPlaceholders
-        , " ON DUPLICATE KEY UPDATE SET "
+        , " ON DUPLICATE KEY UPDATE "
         , commaSeparated (fieldSets <> upds)
         ]
 

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -1084,10 +1084,10 @@ mkBulkInsertQuery records fieldValues updates =
     tableName = T.pack . escapeDBName . entityDB $ entityDef'
     recordValues = concatMap (map toPersistValue . toPersistFields) records
     recordPlaceholders = commaSeparated $ map (parenWrapped . commaSeparated . map (const "?") . toPersistFields) records
-    fieldSets = map (\n -> mconcat [n, "=VALUES(", n, ")"]) updateFieldNames
+    fieldSets = map (\n -> T.concat [n, "=VALUES(", n, ")"]) updateFieldNames
     upds = map mkUpdateText updates
     updsValues = map (\(Update _ val _) -> toPersistValue val) updates
-    q = mconcat
+    q = T.concat
         [ "INSERT INTO "
         , tableName
         , " ("
@@ -1104,10 +1104,10 @@ mkUpdateText :: PersistEntity record => Update record -> Text
 mkUpdateText x =
   case updateUpdate x of
     Assign -> n <> "=?"
-    Add -> mconcat [n, "=", n, "+?"]
-    Subtract -> mconcat [n, "=", n, "-?"]
-    Multiply -> mconcat [n, "=", n, "*?"]
-    Divide -> mconcat [n, "=", n, "/?"]
+    Add -> T.concat [n, "=", n, "+?"]
+    Subtract -> T.concat [n, "=", n, "-?"]
+    Multiply -> T.concat [n, "=", n, "*?"]
+    Divide -> T.concat [n, "=", n, "/?"]
     BackendSpecificUpdate up ->
       error . T.unpack $ "BackendSpecificUpdate" <> up <> "not supported"
   where

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -724,7 +724,6 @@ showColumn (Column n nu t def _defConstraintName maxLen ref) = concat
         Just s -> -- Avoid DEFAULT NULL, since it is always unnecessary, and is an error for text/blob fields
                   if T.toUpper s == "NULL" then ""
                   else " DEFAULT " ++ T.unpack s
-                  {-# LANGUAGE GADTs #-}
     , case ref of
         Nothing -> ""
         Just (s, _) -> " REFERENCES " ++ escapeDBName s
@@ -1109,7 +1108,7 @@ mkUpdateText x =
     Multiply -> T.concat [n, "=", n, "*?"]
     Divide -> T.concat [n, "=", n, "/?"]
     BackendSpecificUpdate up ->
-      error . T.unpack $ "BackendSpecificUpdate" <> up <> "not supported"
+      error . T.unpack $ "BackendSpecificUpdate " <> up <> " not supported"
   where
     n = T.pack . escapeDBName . fieldDB . updateFieldDef $ x
 
@@ -1117,7 +1116,7 @@ commaSeparated :: [Text] -> Text
 commaSeparated = T.intercalate ", "
 
 parenWrapped :: Text -> Text
-parenWrapped = ("(" <>) . (<> ")")
+parenWrapped t = T.concat ["(", t, ")"]
 
 -- | Gets the 'FieldDef' for an 'Update'. Vendored from @persistent@.
 updateFieldDef :: PersistEntity v => Update v -> FieldDef

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -1060,7 +1060,7 @@ bulkInsertOnDuplicateKeyUpdate
   -> [SomeField record] -- ^ A list of the fields you want to copy over.
   -> [Update record] -- ^ A list of the updates to apply that aren't dependent on the record being inserted.
   -> SqlPersistT m ()
-bulkInsertOnDuplicateKeyUpdate [] _ _ = pure ()
+bulkInsertOnDuplicateKeyUpdate [] _ _ = return ()
 bulkInsertOnDuplicateKeyUpdate records [] [] = insertMany_ records
 bulkInsertOnDuplicateKeyUpdate records fieldValues updates =
   uncurry rawExecute $ mkBulkInsertQuery records fieldValues updates

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -1052,11 +1052,9 @@ data SomeField record where
 -- the value that is provided. You can use this to increment a counter value.
 -- These updates only occur if the original record is present in the database.
 bulkInsertOnDuplicateKeyUpdate
-  :: ( PersistEntityBackend record ~ BaseBackend backend
-     , backend ~ SqlBackend
+  :: ( PersistEntityBackend record ~ SqlBackend
      , PersistEntity record
      , MonadIO m
-     , PersistStore backend
      )
   => [record] -- ^ A list of the records you want to insert, or update
   -> [SomeField record] -- ^ A list of the fields you want to copy over.
@@ -1071,11 +1069,7 @@ bulkInsertOnDuplicateKeyUpdate records fieldValues updates =
 -- garbage results if you don't provide a list of either fields to copy or
 -- fields to update.
 mkBulkInsertQuery
-    :: ( PersistEntityBackend record ~ BaseBackend backend
-    , backend ~ SqlBackend
-    , PersistEntity record
-    , PersistStore backend
-    )
+    :: (PersistEntityBackend record ~ SqlBackend, PersistEntity record)
     => [record] -- ^ A list of the records you want to insert, or update
     -> [SomeField record] -- ^ A list of the fields you want to copy over.
     -> [Update record] -- ^ A list of the updates to apply that aren't dependent on the record being inserted.

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -16,7 +16,7 @@ module Database.Persist.MySQL
     , MySQLConf(..)
     , mockMigration
     , insertOnDuplicateKeyUpdate
-    , bulkInsertOnDuplicateKeyUpdate
+    , insertManyOnDuplicateKeyUpdate
     , SomeField(..)
     ) where
 
@@ -1033,7 +1033,7 @@ insertOnDuplicateKeyUpdate
   -> [Update record]
   -> SqlPersistT m ()
 insertOnDuplicateKeyUpdate record =
-  bulkInsertOnDuplicateKeyUpdate [record] []
+  insertManyOnDuplicateKeyUpdate [record] []
 
 -- | This wraps values of an Entity's 'EntityField', making them have the same
 -- type. This allows them to be put in lists.
@@ -1051,7 +1051,7 @@ data SomeField record where
 -- The third parameter is a list of updates to perform that are independent of
 -- the value that is provided. You can use this to increment a counter value.
 -- These updates only occur if the original record is present in the database.
-bulkInsertOnDuplicateKeyUpdate
+insertManyOnDuplicateKeyUpdate
   :: ( PersistEntityBackend record ~ SqlBackend
      , PersistEntity record
      , MonadIO m
@@ -1060,9 +1060,9 @@ bulkInsertOnDuplicateKeyUpdate
   -> [SomeField record] -- ^ A list of the fields you want to copy over.
   -> [Update record] -- ^ A list of the updates to apply that aren't dependent on the record being inserted.
   -> SqlPersistT m ()
-bulkInsertOnDuplicateKeyUpdate [] _ _ = return ()
-bulkInsertOnDuplicateKeyUpdate records [] [] = insertMany_ records
-bulkInsertOnDuplicateKeyUpdate records fieldValues updates =
+insertManyOnDuplicateKeyUpdate [] _ _ = return ()
+insertManyOnDuplicateKeyUpdate records [] [] = insertMany_ records
+insertManyOnDuplicateKeyUpdate records fieldValues updates =
   uncurry rawExecute $ mkBulkInsertQuery records fieldValues updates
 
 -- | This creates the query for 'bulkInsertOnDuplicateKeyUpdate'. It will give

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -1023,22 +1023,22 @@ mockMigration mig = do
 -- | MySQL specific 'upsert'. This will prevent multiple queries, when one will
 -- do.
 insertOnDuplicateKeyUpdate
-    :: ( PersistEntityBackend record ~ BaseBackend backend
-       , PersistEntity record
-       , MonadIO m
-       , PersistStore backend
-       , backend ~ SqlBackend
-       )
-    => record
-    -> [Update record]
-    -> SqlPersistT m ()
+  :: ( PersistEntityBackend record ~ BaseBackend backend
+     , PersistEntity record
+     , MonadIO m
+     , PersistStore backend
+     , backend ~ SqlBackend
+     )
+  => record
+  -> [Update record]
+  -> SqlPersistT m ()
 insertOnDuplicateKeyUpdate record =
   bulkInsertOnDuplicateKeyUpdate [record] []
 
 -- | This wraps values of an Entity's 'EntityField', making them have the same
 -- type. This allows them to be put in lists.
 data SomeField record where
-    SomeField :: EntityField record typ -> SomeField record
+  SomeField :: EntityField record typ -> SomeField record
 
 -- | Do a bulk insert on the given records in the first parameter. In the event
 -- that a key conflicts with a record currently in the database, the second and
@@ -1052,16 +1052,16 @@ data SomeField record where
 -- the value that is provided. You can use this to increment a counter value.
 -- These updates only occur if the original record is present in the database.
 bulkInsertOnDuplicateKeyUpdate
-    :: ( PersistEntityBackend record ~ BaseBackend backend
-       , backend ~ SqlBackend
-       , PersistEntity record
-       , MonadIO m
-       , PersistStore backend
-       )
-    => [record] -- ^ A list of the records you want to insert, or update
-    -> [SomeField record] -- ^ A list of the fields you want to copy over.
-    -> [Update record] -- ^ A list of the updates to apply that aren't dependent on the record being inserted.
-    -> SqlPersistT m ()
+  :: ( PersistEntityBackend record ~ BaseBackend backend
+     , backend ~ SqlBackend
+     , PersistEntity record
+     , MonadIO m
+     , PersistStore backend
+     )
+  => [record] -- ^ A list of the records you want to insert, or update
+  -> [SomeField record] -- ^ A list of the fields you want to copy over.
+  -> [Update record] -- ^ A list of the updates to apply that aren't dependent on the record being inserted.
+  -> SqlPersistT m ()
 bulkInsertOnDuplicateKeyUpdate [] _ _ = pure ()
 bulkInsertOnDuplicateKeyUpdate records [] [] = insertMany_ records
 bulkInsertOnDuplicateKeyUpdate records fieldValues updates =


### PR DESCRIPTION
MySQL has a native upsert in `INSERT ... ON DUPLICATE KEY UPDATE ...`. This PR introduces that functionality to `persistent-mysql`.

It also introduces a `bulkInsertOnDuplicateKeyUpdate` function, which has an API I'd like feedback on.