### PR TITLE
Update comment to reflect the state of things

### DIFF
--- a/persistent-template/Database/Persist/TH.hs
+++ b/persistent-template/Database/Persist/TH.hs
@@ -337,7 +337,7 @@ data MkPersistSettings = MkPersistSettings
     , mpsGeneric :: Bool
     -- ^ Create generic types that can be used with multiple backends. Good for
     -- reusable code, but makes error messages harder to understand. Default:
-    -- True.
+    -- False.
     , mpsPrefixFields :: Bool
     -- ^ Prefix field names with the model name. Default: True.
     , mpsEntityJSON :: Maybe EntityJSON


### PR DESCRIPTION
The comment on `mpsGeneric` in `MkPersistSettings` says it defaults to `True`, but [here](https://github.com/tvision-insights/persistent/blob/mps-generic-comment/persistent-template/Database/Persist/TH.hs#L373) we can see that it defaults to `False`.