### PR TITLE
allow non-numeric keys for selectKeys

### DIFF
--- a/persistent/Database/Persist/Sql/Orphan/PersistQuery.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistQuery.hs
@@ -116,14 +116,14 @@ instance PersistQueryRead SqlBackend where
                         case xs of
                            [PersistInt64 x] -> return [PersistInt64 x]
                            [PersistDouble x] -> return [PersistInt64 (truncate x)] -- oracle returns Double
-                           _ -> liftIO $ throwIO $ PersistMarshalError $ "Unexpected in selectKeys False: " <> T.pack (show xs)
+                           _ -> return xs
                       Just pdef ->
                            let pks = map fieldHaskell $ compositeFields pdef
                                keyvals = map snd $ filter (\(a, _) -> let ret=isJust (find (== a) pks) in ret) $ zip (map fieldHaskell $ entityFields t) xs
                            in return keyvals
             case keyFromValues keyvals of
                 Right k -> return k
-                Left _ -> error "selectKeysImpl: keyFromValues failed"
+                Left err -> error $ "selectKeysImpl: keyFromValues failed" <> show err
 instance PersistQueryRead SqlReadBackend where
     count filts = withReaderT persistBackend $ count filts
     selectSourceRes filts opts = withReaderT persistBackend $ selectSourceRes filts opts


### PR DESCRIPTION
I ran into this exception:

```
PersistMarshalError "Unexpected in selectKeys False: [PersistText \"...\"]"
```

This change fixes the issue.

It is possible this may allow a case that it shouldn't but that will just mean the exception is delayed to a few more lines later.