### PR TITLE
A few markup improvements

### DIFF
--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -118,7 +118,7 @@ open' connInfo logFunc = do
 
 -- | Wrap up a raw 'Sqlite.Connection' as a Persistent SQL 'Connection'.
 --
--- Since 1.1.5
+-- @since 1.1.5
 wrapConnection :: (IsSqlBackend backend) => Sqlite.Connection -> LogFunc -> IO backend
 wrapConnection = wrapConnectionInfo (mkSqliteConnectionInfo "")
 
@@ -178,7 +178,7 @@ wrapConnectionInfo connInfo conn logFunc = do
 -- given block, handling @MonadResource@ and @MonadLogger@ requirements. Note
 -- that all log messages are discarded.
 --
--- Since 1.1.4
+-- @since 1.1.4
 runSqlite :: (MonadBaseControl IO m, MonadIO m, IsSqlBackend backend)
           => Text -- ^ connection string
           -> ReaderT backend (NoLoggingT (ResourceT m)) a -- ^ database action

--- a/persistent-sqlite/Database/Sqlite.hs
+++ b/persistent-sqlite/Database/Sqlite.hs
@@ -70,7 +70,7 @@ newtype Statement = Statement (Ptr ())
 
 -- | A custom exception type to make it easier to catch exceptions.
 --
--- Since 2.1.3
+-- @since 2.1.3
 data SqliteException = SqliteException
     { seError        :: !Error
     , seFunctionName :: !Text
@@ -489,14 +489,14 @@ changes (Connection _ c) = fmap fromIntegral $ changesC c
 
 -- | Log function callback. Arguments are error code and log message.
 --
--- Since 2.1.4
+-- @since 2.1.4
 type RawLogFunction = Ptr () -> Int -> CString -> IO ()
 
 foreign import ccall "wrapper"
   mkRawLogFunction :: RawLogFunction -> IO (FunPtr RawLogFunction)
 
 -- |
--- Since 2.1.4
+-- @since 2.1.4
 newtype LogFunction = LogFunction (FunPtr RawLogFunction)
 
 -- | Wraps a given function to a 'LogFunction' to be further used with 'ConfigLogFn'.
@@ -509,13 +509,13 @@ mkLogFunction fn = fmap LogFunction . mkRawLogFunction $ \_ errCode cmsg -> do
 
 -- | Releases a native FunPtr for the 'LogFunction'.
 --
--- Since 2.1.4
+-- @since 2.1.4
 freeLogFunction :: LogFunction -> IO ()
 freeLogFunction (LogFunction fn) = freeHaskellFunPtr fn
 
 -- | Configuration option for SQLite to be used together with the 'config' function.
 --
--- Since 2.1.4
+-- @since 2.1.4
 data Config
   -- | A function to be used for logging
   = ConfigLogFn LogFunction
@@ -526,7 +526,7 @@ foreign import ccall "persistent_sqlite_set_log"
 -- | Sets SQLite global configuration parameter. See SQLite documentation for the <https://www.sqlite.org/c3ref/config.html sqlite3_config> function.
 -- In short, this must be called prior to any other SQLite function if you want the call to succeed.
 --
--- Since 2.1.4
+-- @since 2.1.4
 config :: Config -> IO ()
 config c = case c of
   ConfigLogFn (LogFunction rawLogFn) -> do
@@ -537,7 +537,7 @@ config c = case c of
 
 -- | Return type of the 'status' function
 --
--- Since 2.6.1
+-- @since 2.6.1
 data SqliteStatus = SqliteStatus
   { sqliteStatusCurrent   :: Maybe Int
   -- ^ The current value of the parameter. Some parameters do not record current value.
@@ -547,7 +547,7 @@ data SqliteStatus = SqliteStatus
 
 -- | Run-time status parameter that can be returned by 'status' function.
 --
--- Since 2.6.1
+-- @since 2.6.1
 data SqliteStatusVerb
   -- | This parameter is the current amount of memory checked out using sqlite3_malloc(),
   -- either directly or indirectly. The figure includes calls made to sqlite3_malloc()
@@ -623,7 +623,7 @@ foreign import ccall "sqlite3_status"
 -- True then the highest recorded value is reset after being returned from
 -- this function.
 --
--- Since 2.6.1
+-- @since 2.6.1
 status :: SqliteStatusVerb -> Bool -> IO SqliteStatus
 status verb reset' = alloca $ \pCurrent -> alloca $ \pHighwater -> do
   let (code, hasCurrent, hasHighwater) = statusVerbInfo verb
@@ -644,6 +644,6 @@ foreign import ccall "sqlite3_soft_heap_limit64"
 -- the current size of the soft heap limit can be determined by invoking
 -- this function with a negative argument.
 --
--- Since 2.6.1
+-- @since 2.6.1
 softHeapLimit :: Int64 -> IO Int64
 softHeapLimit x = fromIntegral <$> softHeapLimit64C (CLLong x)

--- a/persistent-template/Database/Persist/TH.hs
+++ b/persistent-template/Database/Persist/TH.hs
@@ -355,7 +355,7 @@ data MkPersistSettings = MkPersistSettings
     --
     -- Default: False
     --
-    -- Since 1.3.1
+    -- @since 1.3.1
     }
 
 data EntityJSON = EntityJSON
@@ -385,7 +385,7 @@ sqlSettings = mkPersistSettings $ ConT ''SqlBackend
 
 -- | Same as 'sqlSettings'.
 --
--- Since 1.1.1
+-- @since 1.1.1
 sqlOnlySettings :: MkPersistSettings
 sqlOnlySettings = sqlSettings
 {-# DEPRECATED sqlOnlySettings "use sqlSettings" #-}

--- a/persistent/Database/Persist/Class/PersistStore.hs
+++ b/persistent/Database/Persist/Class/PersistStore.hs
@@ -188,6 +188,7 @@ getJust key = get key >>= maybe
   return
 
 -- | Same as 'getJust', but returns an 'Entity' instead of just the record.
+--
 -- @since 2.6.1
 getJustEntity
   :: (PersistEntityBackend record ~ BaseBackend backend
@@ -247,6 +248,7 @@ getEntity key = do
     return $ fmap (key `Entity`) maybeModel
 
 -- | Like 'insertEntity' but just returns the record instead of 'Entity'.
+--
 -- @since 2.6.1
 insertRecord
   :: (PersistEntityBackend record ~ BaseBackend backend
@@ -257,4 +259,3 @@ insertRecord
 insertRecord record = do
   insert_ record
   return $ record
-

--- a/persistent/Database/Persist/Class/PersistUnique.hs
+++ b/persistent/Database/Persist/Class/PersistUnique.hs
@@ -192,7 +192,7 @@ recordName = unHaskellName . entityHaskell . entityDef . Just
 -- Return 'Nothing' if the replacement was made.
 -- If uniqueness is violated, return a 'Just' with the 'Unique' violation
 --
--- Since 1.2.2.0
+-- @since 1.2.2.0
 replaceUnique
     :: (MonadIO m
        ,Eq record

--- a/persistent/Database/Persist/Quasi.hs
+++ b/persistent/Database/Persist/Quasi.hs
@@ -81,13 +81,13 @@ data PersistSettings = PersistSettings
     , psStrictFields :: !Bool
     -- ^ Whether fields are by default strict. Default value: @True@.
     --
-    -- Since 1.2
+    -- @since 1.2
     , psIdName :: !Text
     -- ^ The name of the id column. Default value: @id@
     -- The name of the id column can also be changed on a per-model basis
     -- <https://github.com/yesodweb/persistent/wiki/Persistent-entity-syntax>
     --
-    -- Since 2.0
+    -- @since 2.0
     }
 
 defaultPersistSettings, upperCaseSettings, lowerCaseSettings :: PersistSettings

--- a/persistent/Database/Persist/Quasi.hs
+++ b/persistent/Database/Persist/Quasi.hs
@@ -74,7 +74,7 @@ parseFieldType t0 =
             PSSuccess x t' -> goMany (front . (x:)) t'
             PSFail err -> PSFail err
             PSDone -> PSSuccess (front []) t
-            -- _ -> 
+            -- _ ->
 
 data PersistSettings = PersistSettings
     { psToDBName :: !(Text -> Text)
@@ -321,12 +321,12 @@ mkEntityDef ps name entattribs lines =
     attribPrefix = flip lookupKeyVal entattribs
     idName | Just _ <- attribPrefix "id" = error "id= is deprecated, ad a field named 'Id' and use sql="
            | otherwise = Nothing
-            
-    (idField, primaryComposite, uniqs, foreigns) = foldl' (\(mid, mp, us, fs) attr -> 
-        let (i, p, u, f) = takeConstraint ps name' cols attr 
+
+    (idField, primaryComposite, uniqs, foreigns) = foldl' (\(mid, mp, us, fs) attr ->
+        let (i, p, u, f) = takeConstraint ps name' cols attr
             squish xs m = xs `mappend` maybeToList m
         in (just1 mid i, just1 mp p, squish us u, squish fs f)) (Nothing, Nothing, [],[]) attribs
-                                    
+
     derives = concat $ mapMaybe takeDerives attribs
 
     cols :: [FieldDef]
@@ -343,7 +343,7 @@ just1 :: (Show x) => Maybe x -> Maybe x -> Maybe x
 just1 (Just x) (Just y) = error $ "expected only one of: "
   `mappend` show x `mappend` " " `mappend` show y
 just1 x y = x `mplus` y
-                
+
 
 mkAutoIdField :: PersistSettings -> HaskellName -> Maybe DBName -> SqlType -> FieldDef
 mkAutoIdField ps entName idName idSqlType = FieldDef
@@ -412,9 +412,9 @@ takeConstraint :: PersistSettings
           -> [FieldDef]
           -> [Text]
           -> (Maybe FieldDef, Maybe CompositeDef, Maybe UniqueDef, Maybe UnboundForeignDef)
-takeConstraint ps tableName defs (n:rest) | not (T.null n) && isUpper (T.head n) = takeConstraint' 
+takeConstraint ps tableName defs (n:rest) | not (T.null n) && isUpper (T.head n) = takeConstraint'
     where
-      takeConstraint' 
+      takeConstraint'
             | n == "Unique"  = (Nothing, Nothing, Just $ takeUniq ps tableName defs rest, Nothing)
             | n == "Foreign" = (Nothing, Nothing, Nothing, Just $ takeForeign ps tableName defs rest)
             | n == "Primary" = (Nothing, Just $ takeComposite defs rest, Nothing, Nothing)
@@ -444,7 +444,7 @@ takeId ps tableName (n:rest) = fromMaybe (error "takeId: impossible!") $ setFiel
     setIdName = ["sql=" `mappend` psIdName ps]
 takeId _ tableName _ = error $ "empty Id field for " `mappend` show tableName
 
-    
+
 takeComposite :: [FieldDef]
               -> [Text]
               -> CompositeDef
@@ -462,7 +462,7 @@ takeComposite fields pkcols
                 else d
         | otherwise = getDef ds t
 
--- Unique UppercaseConstraintName list of lowercasefields    
+-- Unique UppercaseConstraintName list of lowercasefields
 takeUniq :: PersistSettings
           -> Text
           -> [FieldDef]

--- a/persistent/Database/Persist/Sql.hs
+++ b/persistent/Database/Persist/Sql.hs
@@ -36,7 +36,7 @@ import Control.Monad.Trans.Reader (ReaderT, ask)
 
 -- | Commit the current transaction and begin a new one.
 --
--- Since 1.2.0
+-- @since 1.2.0
 transactionSave :: MonadIO m => ReaderT SqlBackend m ()
 transactionSave = do
     conn <- ask
@@ -45,7 +45,7 @@ transactionSave = do
 
 -- | Roll back the current transaction and begin a new one.
 --
--- Since 1.2.0
+-- @since 1.2.0
 transactionUndo :: MonadIO m => ReaderT SqlBackend m ()
 transactionUndo = do
     conn <- ask

--- a/persistent/Database/Persist/Sql.hs
+++ b/persistent/Database/Persist/Sql.hs
@@ -28,7 +28,7 @@ import Database.Persist.Sql.Raw
 import Database.Persist.Sql.Migration
 import Database.Persist.Sql.Internal
 
-import Database.Persist.Sql.Orphan.PersistQuery 
+import Database.Persist.Sql.Orphan.PersistQuery
 import Database.Persist.Sql.Orphan.PersistStore
 import Database.Persist.Sql.Orphan.PersistUnique ()
 import Control.Monad.IO.Class

--- a/persistent/Database/Persist/Sql/Class.hs
+++ b/persistent/Database/Persist/Sql/Class.hs
@@ -95,7 +95,7 @@ instance
         nKeyFields = length $ entityKeyFields entDef
         entDef = entityDef (Nothing :: Maybe record)
 
--- | Since 1.0.1.
+-- | @since 1.0.1
 instance RawSql a => RawSql (Maybe a) where
     rawSqlCols e = rawSqlCols e . extractMaybe
     rawSqlColCountReason = rawSqlColCountReason . extractMaybe

--- a/persistent/Database/Persist/Sql/Orphan/PersistQuery.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistQuery.hs
@@ -146,7 +146,7 @@ instance PersistQueryWrite SqlWriteBackend where
 
 -- | Same as 'deleteWhere', but returns the number of rows affected.
 --
--- Since 1.1.5
+-- @since 1.1.5
 deleteWhereCount :: (PersistEntity val, MonadIO m, PersistEntityBackend val ~ SqlBackend, IsSqlBackend backend)
                  => [Filter val]
                  -> ReaderT backend m Int64
@@ -165,7 +165,7 @@ deleteWhereCount filts = withReaderT persistBackend $ do
 
 -- | Same as 'updateWhere', but returns the number of rows affected.
 --
--- Since 1.1.5
+-- @since 1.1.5
 updateWhereCount :: (PersistEntity val, MonadIO m, SqlBackend ~ PersistEntityBackend val, IsSqlBackend backend)
                  => [Filter val]
                  -> [Update val]

--- a/persistent/Database/Persist/Sql/Run.hs
+++ b/persistent/Database/Persist/Sql/Run.hs
@@ -35,7 +35,7 @@ runSqlPool r pconn = withResource pconn $ runSqlConn r
 -- | Like 'withResource', but times out the operation if resource
 -- allocation does not complete within the given timeout period.
 --
--- Since 2.0.0
+-- @since 2.0.0
 withResourceTimeout
   :: forall a m b.  (MonadBaseControl IO m)
   => Int -- ^ Timeout period in microseconds


### PR DESCRIPTION
Fixes a few wrong haddock `@since` markups, moves to always use `@since` (vs. mixed Since/`@since`), and cleans up some whitespace issues.