### PR TITLE
[persistent-mysql] Add support for conditional copying

### DIFF
--- a/persistent-mysql/ChangeLog.md
+++ b/persistent-mysql/ChangeLog.md
@@ -1,6 +1,6 @@
 ## 2.6.2
 
-* Extend the `SomeField` constructor to allow `insertManyOnDuplicateKeyUpdate` to conditionally copy values.
+* Extend the `SomeField` type to allow `insertManyOnDuplicateKeyUpdate` to conditionally copy values.
 
 ## 2.6.1
 

--- a/persistent-mysql/ChangeLog.md
+++ b/persistent-mysql/ChangeLog.md
@@ -1,3 +1,7 @@
+## 2.6.2
+
+* Extend the `SomeField` constructor to allow `insertManyOnDuplicateKeyUpdate` to conditionally copy values.
+
 ## 2.6.1
 
 * Add functions `insertOnDuplicateKeyUpdate`, `insertManyOnDuplicateKeyUpdate` to `Database.Persist.MySQL` module.

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -30,7 +30,8 @@ import Control.Monad.Trans.Except (runExceptT)
 import Control.Monad.Trans.Reader (runReaderT)
 import Control.Monad.Trans.Writer (runWriterT)
 import Data.Either (partitionEithers)
-import Data.Monoid ((<>), Monoid(..))
+import Data.Monoid ((<>))
+import qualified Data.Monoid as Monoid
 import Data.Aeson
 import Data.Aeson.Types (modifyFailure)
 import Data.ByteString (ByteString)
@@ -1063,8 +1064,8 @@ copyUnlessNull field = CopyUnlessEq field Nothing
 -- 'insertManyOnDuplicateKeyUpdate' function.
 --
 -- /since 2.6.2/
-copyUnlessEmpty :: (Monoid typ, PersistField typ) => EntityField record typ -> SomeField record
-copyUnlessEmpty field = CopyUnlessEq field mempty
+copyUnlessEmpty :: (Monoid.Monoid typ, PersistField typ) => EntityField record typ -> SomeField record
+copyUnlessEmpty field = CopyUnlessEq field Monoid.mempty
 
 -- | Do a bulk insert on the given records in the first parameter. In the event
 -- that a key conflicts with a record currently in the database, the second and

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -34,11 +34,11 @@ import Data.Monoid ((<>))
 import Data.Aeson
 import Data.Aeson.Types (modifyFailure)
 import Data.ByteString (ByteString)
-import Data.Either (partitionEithers)
 import Data.Fixed (Pico)
 import Data.Function (on)
 import Data.IORef
 import Data.List (find, intercalate, sort, groupBy)
+import Data.Monoid (Monoid(..))
 import Data.Pool (Pool)
 import Data.Text (Text, pack)
 import qualified Data.Text.IO as T

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -1047,12 +1047,12 @@ data SomeField record where
   -- ^ Copy the field directly from the record.
   CopyUnlessEq :: PersistField typ => EntityField record typ -> typ -> SomeField record
   -- ^ Only copy the field if it is not equal to the provided value.
-  -- /Since 2.6.2/
+  -- @since 2.6.2
 
 -- | Copy the field into the database only if the value in the
 -- corresponding record is non-@NULL@.
 --
--- /since 2.6.2/
+-- @since  2.6.2
 copyUnlessNull :: PersistField typ => EntityField record (Maybe typ) -> SomeField record
 copyUnlessNull field = CopyUnlessEq field Nothing
 
@@ -1063,7 +1063,7 @@ copyUnlessNull field = CopyUnlessEq field Nothing
 -- The resulting 'SomeField' type is useful for the
 -- 'insertManyOnDuplicateKeyUpdate' function.
 --
--- /since 2.6.2/
+-- @since  2.6.2
 copyUnlessEmpty :: (Monoid.Monoid typ, PersistField typ) => EntityField record typ -> SomeField record
 copyUnlessEmpty field = CopyUnlessEq field Monoid.mempty
 

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -17,9 +17,10 @@ module Database.Persist.MySQL
     , mockMigration
     , insertOnDuplicateKeyUpdate
     , insertManyOnDuplicateKeyUpdate
-    , SomeField(..)
+    , SomeField(SomeField)
     , copyUnlessNull
     , copyUnlessEmpty
+    , copyUnlessEq
     ) where
 
 import Control.Arrow
@@ -1066,6 +1067,17 @@ copyUnlessNull field = CopyUnlessEq field Nothing
 -- @since  2.6.2
 copyUnlessEmpty :: (Monoid.Monoid typ, PersistField typ) => EntityField record typ -> SomeField record
 copyUnlessEmpty field = CopyUnlessEq field Monoid.mempty
+
+-- | Copy the field into the database only if the field is not equal to the
+-- provided value. This is useful to avoid copying weird nullary data into
+-- the database.
+--
+-- The resulting 'SomeField' type is useful for the
+-- 'insertManyOnDuplicateKeyUpdate' function.
+--
+-- @since  2.6.2
+copyUnlessEq :: PersistField typ => EntityField record typ -> typ -> SomeField record
+copyUnlessEq = CopyUnlessEq
 
 -- | Do a bulk insert on the given records in the first parameter. In the event
 -- that a key conflicts with a record currently in the database, the second and

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -34,6 +34,7 @@ import Data.Monoid ((<>))
 import Data.Aeson
 import Data.Aeson.Types (modifyFailure)
 import Data.ByteString (ByteString)
+import Data.Either (partitionEithers)
 import Data.Fixed (Pico)
 import Data.Function (on)
 import Data.IORef
@@ -1108,7 +1109,7 @@ mkBulkInsertQuery records fieldValues updates =
         [ n
         , "=COALESCE("
         ,   "NULLIF("
-        ,     "VALUES(", n, ")"
+        ,     "VALUES(", n, "),"
         ,     "?"
         ,   "),"
         ,   n

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -30,7 +30,7 @@ import Control.Monad.Trans.Except (runExceptT)
 import Control.Monad.Trans.Reader (runReaderT)
 import Control.Monad.Trans.Writer (runWriterT)
 import Data.Either (partitionEithers)
-import Data.Monoid ((<>))
+import Data.Monoid ((<>), Monoid(..))
 import Data.Aeson
 import Data.Aeson.Types (modifyFailure)
 import Data.ByteString (ByteString)
@@ -38,7 +38,6 @@ import Data.Fixed (Pico)
 import Data.Function (on)
 import Data.IORef
 import Data.List (find, intercalate, sort, groupBy)
-import Data.Monoid (Monoid(..))
 import Data.Pool (Pool)
 import Data.Text (Text, pack)
 import qualified Data.Text.IO as T

--- a/persistent-mysql/persistent-mysql.cabal
+++ b/persistent-mysql/persistent-mysql.cabal
@@ -1,5 +1,5 @@
 name:            persistent-mysql
-version:         2.6.1
+version:         2.6.2
 license:         MIT
 license-file:    LICENSE
 author:          Felipe Lessa <felipe.lessa@gmail.com>, Michael Snoyman

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -76,6 +76,7 @@ library
                      CustomPersistField
                      CustomPersistFieldTest
                      CustomPrimaryKeyReferenceTest
+                     InsertDuplicateUpdate
 
     hs-source-dirs: src, test
 

--- a/persistent-test/src/DataTypeTest.hs
+++ b/persistent-test/src/DataTypeTest.hs
@@ -82,7 +82,7 @@ specs = describe "data type specs" $
                 check "day" dataTypeTableDay
 #ifndef WITH_NOSQL
                 check' "pico" dataTypeTablePico
-                check "time" (truncateTimeOfDay . dataTypeTableTime)
+                check "time" (roundTime . dataTypeTableTime)
 #endif
 #if !(defined(WITH_NOSQL)) || (defined(WITH_NOSQL) && defined(HIGH_PRECISION_DATE))
                 check "utc" (roundUTCTime . dataTypeTableUtc)
@@ -100,7 +100,7 @@ specs = describe "data type specs" $
 
 roundTime :: TimeOfDay -> TimeOfDay
 #ifdef WITH_MYSQL
-roundTime (TimeOfDay h m s) = TimeOfDay h m (fromIntegral (truncate s :: Integer))
+roundTime (TimeOfDay h m s) = TimeOfDay h m (fromIntegral (round s :: Integer))
 #else
 roundTime = id
 #endif

--- a/persistent-test/src/DataTypeTest.hs
+++ b/persistent-test/src/DataTypeTest.hs
@@ -82,7 +82,7 @@ specs = describe "data type specs" $
                 check "day" dataTypeTableDay
 #ifndef WITH_NOSQL
                 check' "pico" dataTypeTablePico
-                check "time" (roundTime . dataTypeTableTime)
+                check "time" (truncateTimeOfDay . dataTypeTableTime)
 #endif
 #if !(defined(WITH_NOSQL)) || (defined(WITH_NOSQL) && defined(HIGH_PRECISION_DATE))
                 check "utc" (roundUTCTime . dataTypeTableUtc)
@@ -132,7 +132,7 @@ instance Arbitrary DataTypeTable where
      <*> arbitrary              -- day
 #ifndef WITH_NOSQL
      <*> arbitrary              -- pico
-     <*> (truncateTimeOfDay =<< arbitrary) -- time
+     <*> (fmap truncateTimeOfDay arbitrary) -- time
 #endif
      <*> (truncateUTCTime   =<< arbitrary) -- utc
 
@@ -154,9 +154,9 @@ truncateToMicro p = let
   p' = fromRational . toRational $ p  :: Micro
   in   fromRational . toRational $ p' :: Pico
 
-truncateTimeOfDay :: TimeOfDay -> Gen TimeOfDay
+truncateTimeOfDay :: TimeOfDay -> TimeOfDay
 truncateTimeOfDay (TimeOfDay h m s) =
-  return $ TimeOfDay h m $ truncateToMicro s
+  TimeOfDay h m $ truncateToMicro s
 
 truncateUTCTime :: UTCTime -> Gen UTCTime
 truncateUTCTime (UTCTime d dift) = do

--- a/persistent-test/src/DataTypeTest.hs
+++ b/persistent-test/src/DataTypeTest.hs
@@ -100,7 +100,7 @@ specs = describe "data type specs" $
 
 roundTime :: TimeOfDay -> TimeOfDay
 #ifdef WITH_MYSQL
-roundTime (TimeOfDay h m s) = TimeOfDay h m (fromIntegral (round s :: Integer))
+roundTime (TimeOfDay h m s) = TimeOfDay h m (fromIntegral (truncate s :: Integer))
 #else
 roundTime = id
 #endif
@@ -132,7 +132,7 @@ instance Arbitrary DataTypeTable where
      <*> arbitrary              -- day
 #ifndef WITH_NOSQL
      <*> arbitrary              -- pico
-     <*> (fmap truncateTimeOfDay arbitrary) -- time
+     <*> (truncateTimeOfDay =<< arbitrary) -- time
 #endif
      <*> (truncateUTCTime   =<< arbitrary) -- utc
 
@@ -154,9 +154,9 @@ truncateToMicro p = let
   p' = fromRational . toRational $ p  :: Micro
   in   fromRational . toRational $ p' :: Pico
 
-truncateTimeOfDay :: TimeOfDay -> TimeOfDay
+truncateTimeOfDay :: TimeOfDay -> Gen TimeOfDay
 truncateTimeOfDay (TimeOfDay h m s) =
-  TimeOfDay h m $ truncateToMicro s
+  return $ TimeOfDay h m $ truncateToMicro s
 
 truncateUTCTime :: UTCTime -> Gen UTCTime
 truncateUTCTime (UTCTime d dift) = do

--- a/persistent-test/src/InsertDuplicateUpdate.hs
+++ b/persistent-test/src/InsertDuplicateUpdate.hs
@@ -14,7 +14,6 @@
 
 module InsertDuplicateUpdate where
 
-import           Data.List (sort)
 import           Init
 
 share [mkPersist sqlSettings, mkMigrate "duplicateMigrate"] [persistUpperCase|
@@ -84,8 +83,8 @@ specs = describe "DuplicateKeyUpdate" $ do
       dbItems <- sort . fmap entityVal <$> selectList [] []
       dbItems @== sort postUpdate
 #else
-spec :: Spec
-spec = describe "DuplicateKeyUpdate" $ do
+specs :: Spec
+specs = describe "DuplicateKeyUpdate" $ do
   it "Is only supported on MySQL currently." $ do
     True `shouldBe` True
 #endif

--- a/persistent-test/src/InsertDuplicateUpdate.hs
+++ b/persistent-test/src/InsertDuplicateUpdate.hs
@@ -1,0 +1,81 @@
+{-# OPTIONS_GHC -fno-warn-unused-binds -fno-warn-orphans -O0 #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE QuasiQuotes, TemplateHaskell, CPP, GADTs, TypeFamilies, OverloadedStrings, FlexibleContexts, EmptyDataDecls, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses #-}
+
+module InsertDuplicateUpdate where
+
+import Init
+import Data.List (sort)
+
+share [mkPersist sqlSettings, mkMigrate "duplicateMigrate"] [persistUpperCase|
+  Item
+     name        Text
+     description Text
+     price       Double Maybe
+     quantity    Int Maybe
+
+     Primary name
+     deriving Eq Show Ord
+    
+|]
+
+#ifdef WITH_MYSQL
+specs :: Spec
+specs = describe "DuplicateKeyUpdate" $ do
+  let item1 = Item "item1" "" (Just 3) Nothing
+      item2 = Item "item2" "hello world" Nothing (Just 2)
+      items = [item1, item2]
+  describe "insertOnDuplicateKeyUpdate" $ do
+    it "inserts appropriately" $ db $ do
+      deleteWhere ([] :: [Filter Item])
+      insertOnDuplicateKeyUpdate item1 [ItemDescription =. "i am item 1"]
+      Just item <- get (ItemKey "item1")
+      item @== item1
+
+    it "performs only updates given if record already exists" $ db $ do
+      deleteWhere ([] :: [Filter Item])
+      let newDescription = "I am a new description"
+      _ <- insert item1
+      insertOnDuplicateKeyUpdate 
+        (Item "item1" "i am a description" (Just 1) (Just 2))
+        [ItemDescription =. newDescription]
+      Just item <- get (ItemKey "item1")
+      item @== Item "item1" newDescription Nothing Nothing
+
+  describe "insertManyOnDuplicateKeyUpdate" $ do
+    it "inserts fresh records" $ db $ do
+      deleteWhere ([] :: [Filter Item])
+      insertMany_ items
+      let newItem = Item "item3" "fresh" Nothing Nothing
+      insertManyOnDuplicateKeyUpdate 
+        (newItem : items)
+        [SomeField ItemDescription]
+        []
+      dbItems <- map entityVal <$> selectList [] []
+      sort dbItems @== sort (newItem : items)
+    it "updates existing records" $ db $ do
+      deleteWhere ([] :: [Filter Item])
+      insertMany_ items
+      insertManyOnDuplicateKeyUpdate 
+        items
+        []
+        [ItemQuantity +=. 1]
+    it "only copies passing values" $ db $ do
+      deleteWhere ([] :: [Filter Item])
+      insertMany_ items
+      let newItems = map (\i -> i { itemQuantity = Just 0, itemPrice = fmap (*2) (itemPrice i) }) items
+          postUpdate = map (\i -> i { itemPrice = fmap (*2) (itemPrice i) }) items
+      insertManyOnDuplicateKeyUpdate
+        newItems
+        [ CopyUnlessEq ItemQuantity (Just 0)
+        , SomeField ItemPrice
+        ]
+        []
+      dbItems <- sort . fmap entityVal <$> selectList [] []
+      dbItems @== sort postUpdate
+#else
+spec :: Spec
+spec = describe "DuplicateKeyUpdate" $ do
+  it "Is only supported on MySQL currently." $ do
+    True `shouldBe` True
+#endif

--- a/persistent-test/test/main.hs
+++ b/persistent-test/test/main.hs
@@ -69,7 +69,8 @@ main = do
       , CustomPersistFieldTest.customFieldMigrate
 #  ifndef WITH_MYSQL
       , PrimaryTest.migration
-#  else
+#  endif
+#  ifdef WITH_MYSQL
       , InsertDuplicateUpdate.duplicateMigrate
 #  endif
       , CustomPrimaryKeyReferenceTest.migration

--- a/persistent-test/test/main.hs
+++ b/persistent-test/test/main.hs
@@ -54,7 +54,6 @@ main = do
       [ PersistentTest.testMigrate
       , PersistentTest.noPrefixMigrate
       , EmbedTest.embedMigrate
-      , InsertDuplicateUpdate.duplicateMigrate
       , EmbedOrderTest.embedOrderMigrate
       , LargeNumberTest.numberMigrate
       , UniqueTest.uniqueMigrate

--- a/persistent-test/test/main.hs
+++ b/persistent-test/test/main.hs
@@ -69,6 +69,8 @@ main = do
       , CustomPersistFieldTest.customFieldMigrate
 #  ifndef WITH_MYSQL
       , PrimaryTest.migration
+#  else
+      , InsertDuplicateUpdate.duplicateMigrate
 #  endif
       , CustomPrimaryKeyReferenceTest.migration
       ]

--- a/persistent-test/test/main.hs
+++ b/persistent-test/test/main.hs
@@ -19,6 +19,7 @@ import qualified PrimaryTest
 import qualified Recursive
 import qualified RenameTest
 import qualified SumTypeTest
+import qualified InsertDuplicateUpdate
 import qualified UniqueTest
 
 #ifndef WITH_NOSQL
@@ -53,6 +54,7 @@ main = do
       [ PersistentTest.testMigrate
       , PersistentTest.noPrefixMigrate
       , EmbedTest.embedMigrate
+      , InsertDuplicateUpdate.duplicateMigrate
       , EmbedOrderTest.embedOrderMigrate
       , LargeNumberTest.numberMigrate
       , UniqueTest.uniqueMigrate
@@ -92,6 +94,7 @@ main = do
     PrimaryTest.specs
     CustomPersistFieldTest.specs
     CustomPrimaryKeyReferenceTest.specs
+    InsertDuplicateUpdate.specs
 
 #ifdef WITH_SQLITE
     MigrationTest.specs


### PR DESCRIPTION
This PR extends the `insertManyOnDuplicateKeyUpdate` function to allow conditional copying of data from the input record.

Use case: Suppose you're importing a report that sometimes has partial data, and you want to copy the report into the database. The result record may have many `Nothing` fields. If we copy this using the current `SomeField`, then we will overwrite the existing data with `NULL`s. Oops.

The new constructor and functions permit us to avoid copying bad data, including `NULL` and empty strings, into the database, potentially overriding already present data.