### PR TITLE
expose parseReferences for the creation of custom QuasiQuoters

### DIFF
--- a/persistent-template/ChangeLog.md
+++ b/persistent-template/ChangeLog.md
@@ -1,3 +1,7 @@
+## 2.5.3
+
+* Exposed `parseReferences` to allow custom QuasiQuoters
+
 ## 2.5.2
 
 * Fix incorrect `ToJSON`/`FromJSON` instance generation for generic

--- a/persistent-template/Database/Persist/TH.hs
+++ b/persistent-template/Database/Persist/TH.hs
@@ -42,6 +42,7 @@ module Database.Persist.TH
     , derivePersistField
     , derivePersistFieldJSON
     , persistFieldFromEntity
+    , parseReferences
       -- * Internal
     , packPTH
     , lensPTH

--- a/persistent-template/Database/Persist/TH.hs
+++ b/persistent-template/Database/Persist/TH.hs
@@ -42,10 +42,10 @@ module Database.Persist.TH
     , derivePersistField
     , derivePersistFieldJSON
     , persistFieldFromEntity
-    , parseReferences
       -- * Internal
     , packPTH
     , lensPTH
+    , parseReferences
     ) where
 
 import Prelude hiding ((++), take, concat, splitAt, exp)

--- a/persistent-template/Database/Persist/TH.hs
+++ b/persistent-template/Database/Persist/TH.hs
@@ -122,6 +122,7 @@ persistFileWith ps fp = do
 
 -- calls parse to Quasi.parse individual entities in isolation
 -- afterwards, sets references to other entities
+-- | @since 2.5.3
 parseReferences :: PersistSettings -> Text -> Q Exp
 parseReferences ps s = lift $
      map (mkEntityDefSqlTypeExp embedEntityMap entMap) noCycleEnts

--- a/persistent-template/persistent-template.cabal
+++ b/persistent-template/persistent-template.cabal
@@ -1,5 +1,5 @@
 name:            persistent-template
-version:         2.5.2
+version:         2.5.3
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
Exposed parseReferences so that custom QuasiQuoters could be made. If there is a reason not to do this please reject the PR.