### PR TITLE
WIP/RFC: Add a phantom type to SqlBackend to track which database it is for

### DIFF
--- a/persistent/Database/Persist/Sql.hs
+++ b/persistent/Database/Persist/Sql.hs
@@ -37,7 +37,7 @@ import Control.Monad.Trans.Reader (ReaderT, ask)
 -- | Commit the current transaction and begin a new one.
 --
 -- @since 1.2.0
-transactionSave :: MonadIO m => ReaderT SqlBackend m ()
+transactionSave :: MonadIO m => ReaderT (SqlBackend db) m ()
 transactionSave = do
     conn <- ask
     let getter = getStmtConn conn
@@ -46,7 +46,7 @@ transactionSave = do
 -- | Roll back the current transaction and begin a new one.
 --
 -- @since 1.2.0
-transactionUndo :: MonadIO m => ReaderT SqlBackend m ()
+transactionUndo :: MonadIO m => ReaderT (SqlBackend db) m ()
 transactionUndo = do
     conn <- ask
     let getter = getStmtConn conn

--- a/persistent/Database/Persist/Sql/Orphan/PersistUnique.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistUnique.hs
@@ -37,7 +37,7 @@ escape (DBName s) = T.pack $ '"' : escapeQuote (T.unpack s) ++ "\""
     escapeQuote ('"':xs) = "\"\"" ++ escapeQuote xs
     escapeQuote (x:xs) = x : escapeQuote xs
 
-instance PersistUniqueWrite SqlBackend where
+instance PersistUniqueWrite (SqlBackend db) where
     upsert record updates = do
       conn <- ask
       uniqueKey <- onlyUnique record
@@ -82,10 +82,10 @@ instance PersistUniqueWrite SqlBackend where
                 , " WHERE "
                 , T.intercalate " AND " $ map (go' conn) $ go uniq]
 
-instance PersistUniqueWrite SqlWriteBackend where
+instance PersistUniqueWrite (SqlWriteBackend db) where
     deleteBy uniq = withReaderT persistBackend $ deleteBy uniq
 
-instance PersistUniqueRead SqlBackend where
+instance PersistUniqueRead (SqlBackend db) where
     getBy uniq = do
         conn <- ask
         let sql =
@@ -114,10 +114,10 @@ instance PersistUniqueRead SqlBackend where
         t = entityDef $ dummyFromUnique uniq
         toFieldNames' = map snd . persistUniqueToFieldNames
 
-instance PersistUniqueRead SqlReadBackend where
+instance PersistUniqueRead (SqlReadBackend db) where
     getBy uniq = withReaderT persistBackend $ getBy uniq
 
-instance PersistUniqueRead SqlWriteBackend where
+instance PersistUniqueRead (SqlWriteBackend db) where
     getBy uniq = withReaderT persistBackend $ getBy uniq
 
 dummyFromUnique :: Unique v -> Maybe v

--- a/persistent/Database/Persist/Sql/Types.hs
+++ b/persistent/Database/Persist/Sql/Types.hs
@@ -48,7 +48,7 @@ data PersistentSqlException = StatementAlreadyFinalized Text
     deriving (Typeable, Show)
 instance Exception PersistentSqlException
 
-type SqlPersistT = ReaderT SqlBackend
+type SqlPersistT = forall db. ReaderT (SqlBackend db)
 
 type SqlPersist = SqlPersistT
 {-# DEPRECATED SqlPersist "Please use SqlPersistT instead" #-}
@@ -60,9 +60,9 @@ type Sql = Text
 -- Bool indicates if the Sql is safe
 type CautiousMigration = [(Bool, Sql)]
 
-type Migration = WriterT [Text] (WriterT CautiousMigration (ReaderT SqlBackend IO)) ()
+type Migration db = WriterT [Text] (WriterT CautiousMigration (ReaderT (SqlBackend db) IO)) ()
 
-type ConnectionPool = Pool SqlBackend
+type ConnectionPool db = Pool (SqlBackend db)
 
 -- $rawSql
 --

--- a/persistent/Database/Persist/Sql/Util.hs
+++ b/persistent/Database/Persist/Sql/Util.hs
@@ -23,13 +23,13 @@ import Database.Persist (
   , DBName)
 import Database.Persist.Sql.Types (Sql, SqlBackend, connEscapeName)
 
-entityColumnNames :: EntityDef -> SqlBackend -> [Sql]
+entityColumnNames :: EntityDef -> SqlBackend db -> [Sql]
 entityColumnNames ent conn =
      (if hasCompositeKey ent
       then [] else [connEscapeName conn $ fieldDB (entityId ent)])
   <> map (connEscapeName conn . fieldDB) (entityFields ent)
 
-keyAndEntityColumnNames :: EntityDef -> SqlBackend -> [Sql]
+keyAndEntityColumnNames :: EntityDef -> SqlBackend db -> [Sql]
 keyAndEntityColumnNames ent conn = map (connEscapeName conn . fieldDB) (keyAndEntityFields ent)
 
 entityColumnCount :: EntityDef -> Int
@@ -39,13 +39,13 @@ entityColumnCount e = length (entityFields e)
 hasCompositeKey :: EntityDef -> Bool
 hasCompositeKey = isJust . entityPrimary
 
-dbIdColumns :: SqlBackend -> EntityDef -> [Text]
+dbIdColumns :: SqlBackend db -> EntityDef -> [Text]
 dbIdColumns conn = dbIdColumnsEsc (connEscapeName conn)
 
 dbIdColumnsEsc :: (DBName -> Text) -> EntityDef -> [Text]
 dbIdColumnsEsc esc t = map (esc . fieldDB) $ entityKeyFields t
 
-dbColumns :: SqlBackend -> EntityDef -> [Text]
+dbColumns :: SqlBackend db -> EntityDef -> [Text]
 dbColumns conn t = case entityPrimary t of
     Just _  -> flds
     Nothing -> escapeDB (entityId t) : flds


### PR DESCRIPTION
This PR adds a phantom type to the SqlBackend type, addressing #698 . See that issue for motivation etc.

# Why?

I already wrote a library for this. Why am I upstreaming it? My library is 99% vendored code from Persistent. Additionally, Esqueleto has a hard constraint on `SqlBackend`, so the library version of the code can't work without *entirely forking Esqueleto*. Upstreaming the code allows for Esqueleto to continue working with Persistent in a way that's nice

# Why not?

This is a breaking change, and also probably not the best way to approach it. I would like to improve the design so that the extension isn't noisy or unnecessary for the common/sane case (a single schema), but as-is, it's going to be pretty heavy weight.

# Your thoughts?

I'm curious if 1) there are better ways to approach this, 2) the likelihood of this getting merged, and 3) any objections or work to be done that would make merging this easier.