### PR TITLE
WIP: Generalize Sql Backend

### DIFF
--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -25,7 +25,7 @@ import Control.Monad.Logger (MonadLogger, runNoLoggingT)
 import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except (runExceptT)
-import Control.Monad.Trans.Reader (runReaderT)
+import Control.Monad.Trans.Reader (runReaderT, ReaderT)
 import Control.Monad.Trans.Writer (runWriterT)
 import Data.Monoid ((<>))
 import Data.Aeson
@@ -1034,7 +1034,7 @@ insertOnDuplicateKeyUpdate
      )
   => record
   -> [Update record]
-  -> SqlPersistT m ()
+  -> ReaderT SqlBackend m ()
 insertOnDuplicateKeyUpdate record =
   insertManyOnDuplicateKeyUpdate [record] []
 

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -1100,7 +1100,7 @@ mkInsertIgnoreQuery records = (q, concat vals)
 -- garbage results if you don't provide a list of either fields to copy or
 -- fields to update.
 mkBulkInsertQuery
-    :: PersistEntity record 
+    :: PersistEntity record
     => [record] -- ^ A list of the records you want to insert, or update
     -> [SomeField record] -- ^ A list of the fields you want to copy over.
     -> [Update record] -- ^ A list of the updates to apply that aren't dependent on the record being inserted.

--- a/persistent/Database/Persist/Class.hs
+++ b/persistent/Database/Persist/Class.hs
@@ -52,6 +52,7 @@ module Database.Persist.Class
     , HasPersistBackend (..)
     , IsPersistBackend ()
     , liftPersist
+    , BackendCompatible (..)
 
     -- * JSON utilities
     , keyValueEntityToJSON, keyValueEntityFromJSON

--- a/persistent/Database/Persist/Class/DeleteCascade.hs
+++ b/persistent/Database/Persist/Class/DeleteCascade.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies #-}
 module Database.Persist.Class.DeleteCascade
@@ -18,7 +19,7 @@ import Data.Acquire (with)
 -- | For combinations of backends and entities that support
 -- cascade-deletion. “Cascade-deletion” means that entries that depend on
 -- other entries to be deleted will be deleted as well.
-class (PersistStoreWrite backend, PersistEntity record, BaseBackend backend ~ PersistEntityBackend record)
+class (PersistStoreWrite backend, PersistRecordBackend record backend)
   => DeleteCascade record backend where
 
     -- | Perform cascade-deletion of single database

--- a/persistent/Database/Persist/Class/PersistQuery.hs
+++ b/persistent/Database/Persist/Class/PersistQuery.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE ConstraintKinds #-}

--- a/persistent/Database/Persist/Class/PersistStore.hs
+++ b/persistent/Database/Persist/Class/PersistStore.hs
@@ -18,6 +18,7 @@ module Database.Persist.Class.PersistStore
     , insertEntity
     , insertRecord
     , ToBackendKey(..)
+    , BackendCompatible(..)
     ) where
 
 import qualified Data.Text as T
@@ -47,6 +48,14 @@ class (HasPersistBackend backend) => IsPersistBackend backend where
     -- It should be used carefully and only when actually constructing a @backend@. Careless use allows us
     -- to accidentally run a write query against a read-only database.
     mkPersistBackend :: BaseBackend backend -> backend
+
+-- | This class witnesses that two backend are compatible, and that you can
+-- convert from the @sub@ backend into the @sup@ backend. This is similar
+-- to the 'HasPersistBackend' and 'IsPersistBackend' classes, but where you
+-- don't want to fix the type associated with the 'PersistEntityBackend' of
+-- a record.
+class BackendCompatible sup sub where
+    projectBackend :: sub -> sup
 
 -- | A convenient alias for common type signatures
 type PersistRecordBackend record backend = (PersistEntity record, PersistEntityBackend record ~ BaseBackend backend)

--- a/persistent/Database/Persist/Sql/Orphan/PersistQuery.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistQuery.hs
@@ -125,13 +125,13 @@ instance PersistQueryRead SqlBackend where
                 Right k -> return k
                 Left err -> error $ "selectKeysImpl: keyFromValues failed" <> show err
 instance PersistQueryRead SqlReadBackend where
-    count filts = withReaderT persistBackend $ count filts
-    selectSourceRes filts opts = withReaderT persistBackend $ selectSourceRes filts opts
-    selectKeysRes filts opts = withReaderT persistBackend $ selectKeysRes filts opts
+    count filts = withReaderT projectBackend $ count filts
+    selectSourceRes filts opts = withReaderT projectBackend $ selectSourceRes filts opts
+    selectKeysRes filts opts = withReaderT projectBackend $ selectKeysRes filts opts
 instance PersistQueryRead SqlWriteBackend where
-    count filts = withReaderT persistBackend $ count filts
-    selectSourceRes filts opts = withReaderT persistBackend $ selectSourceRes filts opts
-    selectKeysRes filts opts = withReaderT persistBackend $ selectKeysRes filts opts
+    count filts = withReaderT projectBackend $ count filts
+    selectSourceRes filts opts = withReaderT projectBackend $ selectSourceRes filts opts
+    selectKeysRes filts opts = withReaderT projectBackend $ selectKeysRes filts opts
 
 instance PersistQueryWrite SqlBackend where
     deleteWhere filts = do
@@ -141,8 +141,8 @@ instance PersistQueryWrite SqlBackend where
         _ <- updateWhereCount filts upds
         return ()
 instance PersistQueryWrite SqlWriteBackend where
-    deleteWhere filts = withReaderT persistBackend $ deleteWhere filts
-    updateWhere filts upds = withReaderT persistBackend $ updateWhere filts upds
+    deleteWhere filts = withReaderT projectBackend $ deleteWhere filts
+    updateWhere filts upds = withReaderT projectBackend $ updateWhere filts upds
 
 -- | Same as 'deleteWhere', but returns the number of rows affected.
 --

--- a/persistent/Database/Persist/Sql/Orphan/PersistQuery.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistQuery.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -9,6 +11,7 @@ module Database.Persist.Sql.Orphan.PersistQuery
     , decorateSQLWithLimitOffset
     ) where
 
+import Control.Monad (liftM)
 import Database.Persist hiding (updateField)
 import Database.Persist.Sql.Util (
   entityColumnNames, parseEntityValues, isIdField)
@@ -150,7 +153,7 @@ instance PersistQueryWrite SqlWriteBackend where
 deleteWhereCount :: (PersistEntity val, MonadIO m, PersistEntityBackend val ~ SqlBackend, IsSqlBackend backend)
                  => [Filter val]
                  -> ReaderT backend m Int64
-deleteWhereCount filts = withReaderT persistBackend $ do
+deleteWhereCount filts = withReaderT projectBackend $ do
     conn <- ask
     let t = entityDef $ dummyFromFilts filts
     let wher = if null filts
@@ -166,13 +169,21 @@ deleteWhereCount filts = withReaderT persistBackend $ do
 -- | Same as 'updateWhere', but returns the number of rows affected.
 --
 -- @since 1.1.5
-updateWhereCount :: (PersistEntity val, MonadIO m, SqlBackend ~ PersistEntityBackend val, IsSqlBackend backend)
-                 => [Filter val]
-                 -> [Update val]
-                 -> ReaderT backend m Int64
+updateWhereCount 
+    :: forall backend val m
+    . ( backend ~ PersistEntityBackend val
+      , PersistEntity val
+      , MonadIO m
+      -- , BackendCompatible SqlBackend backend
+      , IsSqlBackend backend
+      )
+    => [Filter val]
+    -> [Update val]
+    -> ReaderT backend m Int64
 updateWhereCount _ [] = return 0
-updateWhereCount filts upds = withReaderT persistBackend $ do
-    conn <- ask
+updateWhereCount filts upds = do
+    conn <- projectBackend `liftM` ask
+    connGen <- ask
     let wher = if null filts
                 then ""
                 else filterClause False conn filts
@@ -194,25 +205,28 @@ updateWhereCount filts upds = withReaderT persistBackend $ do
     go'' n Multiply = mconcat [n, "=", n, "*?"]
     go'' n Divide = mconcat [n, "=", n, "/?"]
     go'' _ (BackendSpecificUpdate up) = error $ T.unpack $ "BackendSpecificUpdate" `mappend` up `mappend` "not supported"
-    go' conn (x, pu) = go'' (connEscapeName conn x) pu
+    go' :: SqlBackend -> (DBName, PersistUpdate) -> Text
+    go' conn (x, pu) = go'' (connEscapeName (projectBackend conn) x) pu
+    go :: Update val -> (DBName, PersistUpdate)
     go x = (updateField x, updateUpdate x)
 
+    updateField :: Update val -> DBName
     updateField (Update f _ _) = fieldName f
     updateField _ = error "BackendUpdate not implemented"
 
-fieldName ::  forall record typ.  (PersistEntity record, PersistEntityBackend record ~ SqlBackend) => EntityField record typ -> DBName
+fieldName :: forall record typ. (PersistEntity record, BackendCompatible SqlBackend (PersistEntityBackend record)) => EntityField record typ -> DBName
 fieldName f = fieldDB $ persistFieldDef f
 
 dummyFromFilts :: [Filter v] -> Maybe v
 dummyFromFilts _ = Nothing
 
-getFiltsValues :: forall val. (PersistEntity val, PersistEntityBackend val ~ SqlBackend)
+getFiltsValues :: forall val. (PersistEntity val, BackendCompatible SqlBackend (PersistEntityBackend val))
                => SqlBackend -> [Filter val] -> [PersistValue]
 getFiltsValues conn = snd . filterClauseHelper False False conn OrNullNo
 
 data OrNull = OrNullYes | OrNullNo
 
-filterClauseHelper :: (PersistEntity val, PersistEntityBackend val ~ SqlBackend)
+filterClauseHelper :: (backend ~ PersistEntityBackend val, PersistEntity val, BackendCompatible SqlBackend (PersistEntityBackend val))
              => Bool -- ^ include table name?
              -> Bool -- ^ include WHERE?
              -> SqlBackend
@@ -368,14 +382,17 @@ updatePersistValue :: Update v -> PersistValue
 updatePersistValue (Update _ v _) = toPersistValue v
 updatePersistValue _ = error "BackendUpdate not implemented"
 
-filterClause :: (PersistEntity val, PersistEntityBackend val ~ SqlBackend)
+filterClause :: ( backend ~ PersistEntityBackend val
+                , BackendCompatible SqlBackend backend
+                , PersistEntity val
+                , PersistEntityBackend val ~ backend)
              => Bool -- ^ include table name?
              -> SqlBackend
              -> [Filter val]
              -> Text
 filterClause b c = fst . filterClauseHelper b True c OrNullNo
 
-orderClause :: (PersistEntity val, PersistEntityBackend val ~ SqlBackend)
+orderClause :: (backend ~ PersistEntityBackend val, PersistEntity val, BackendCompatible SqlBackend (PersistEntityBackend val))
             => Bool -- ^ include the table name
             -> SqlBackend
             -> SelectOpt val
@@ -391,7 +408,7 @@ orderClause includeTable conn o =
 
     tn = connEscapeName conn $ entityDB $ entityDef $ dummyFromOrder o
 
-    name :: (PersistEntityBackend record ~ SqlBackend, PersistEntity record)
+    name :: (BackendCompatible SqlBackend (PersistEntityBackend record), PersistEntity record)
          => EntityField record typ -> Text
     name x =
         (if includeTable

--- a/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
@@ -77,7 +77,7 @@ getTableName :: forall record m backend.
              , IsSqlBackend backend
              , Monad m
              ) => record -> ReaderT backend m Text
-getTableName rec = withReaderT persistBackend $ do
+getTableName rec = withReaderT projectBackend $ do
     conn <- ask
     return $ connEscapeName conn $ tableDBName rec
 
@@ -97,7 +97,7 @@ getFieldName :: forall record typ m backend.
              , Monad m
              )
              => EntityField record typ -> ReaderT backend m Text
-getFieldName rec = withReaderT persistBackend $ do
+getFieldName rec = withReaderT projectBackend $ do
     conn <- ask
     return $ connEscapeName conn $ fieldDBName rec
 

--- a/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -39,6 +40,7 @@ import Web.HttpApiData (ToHttpApiData, FromHttpApiData)
 import Database.Persist.Sql.Class (PersistFieldSql)
 import qualified Data.Aeson as A
 import Control.Exception.Lifted (throwIO)
+import Database.Persist.Class (BackendCompatible(..))
 
 withRawQuery :: MonadIO m
              => Text
@@ -113,6 +115,15 @@ instance PersistCore SqlReadBackend where
 instance PersistCore SqlWriteBackend where
     newtype BackendKey SqlWriteBackend = SqlWriteBackendKey { unSqlWriteBackendKey :: Int64 }
         deriving (Show, Read, Eq, Ord, Num, Integral, PersistField, PersistFieldSql, PathPiece, ToHttpApiData, FromHttpApiData, Real, Enum, Bounded, A.ToJSON, A.FromJSON)
+
+instance BackendCompatible SqlBackend SqlBackend where
+    projectBackend = id
+
+instance BackendCompatible SqlBackend SqlReadBackend where
+    projectBackend = unSqlReadBackend
+
+instance BackendCompatible SqlBackend SqlWriteBackend where
+    projectBackend = unSqlWriteBackend
 
 instance PersistStoreWrite SqlBackend where
     update _ [] = return ()

--- a/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
@@ -116,15 +116,6 @@ instance PersistCore SqlWriteBackend where
     newtype BackendKey SqlWriteBackend = SqlWriteBackendKey { unSqlWriteBackendKey :: Int64 }
         deriving (Show, Read, Eq, Ord, Num, Integral, PersistField, PersistFieldSql, PathPiece, ToHttpApiData, FromHttpApiData, Real, Enum, Bounded, A.ToJSON, A.FromJSON)
 
-instance BackendCompatible SqlBackend SqlBackend where
-    projectBackend = id
-
-instance BackendCompatible SqlBackend SqlReadBackend where
-    projectBackend = unSqlReadBackend
-
-instance BackendCompatible SqlBackend SqlWriteBackend where
-    projectBackend = unSqlWriteBackend
-
 instance PersistStoreWrite SqlBackend where
     update _ [] = return ()
     update k upds = do
@@ -287,14 +278,14 @@ instance PersistStoreWrite SqlBackend where
             , wher conn
             ]
 instance PersistStoreWrite SqlWriteBackend where
-    insert v = withReaderT persistBackend $ insert v
-    insertMany vs = withReaderT persistBackend $ insertMany vs
-    insertMany_ vs = withReaderT persistBackend $ insertMany_ vs
-    insertKey k v = withReaderT persistBackend $ insertKey k v
-    repsert k v = withReaderT persistBackend $ repsert k v
-    replace k v = withReaderT persistBackend $ replace k v
-    delete k = withReaderT persistBackend $ delete k
-    update k upds = withReaderT persistBackend $ update k upds
+    insert v = withReaderT projectBackend $ insert v
+    insertMany vs = withReaderT projectBackend $ insertMany vs
+    insertMany_ vs = withReaderT projectBackend $ insertMany_ vs
+    insertKey k v = withReaderT projectBackend $ insertKey k v
+    repsert k v = withReaderT projectBackend $ repsert k v
+    replace k v = withReaderT projectBackend $ replace k v
+    delete k = withReaderT projectBackend $ delete k
+    update k upds = withReaderT projectBackend $ update k upds
 
 
 instance PersistStoreRead SqlBackend where
@@ -323,9 +314,9 @@ instance PersistStoreRead SqlBackend where
                         Left e -> error $ "get " ++ show k ++ ": " ++ unpack e
                         Right v -> return $ Just v
 instance PersistStoreRead SqlReadBackend where
-    get k = withReaderT persistBackend $ get k
+    get k = withReaderT projectBackend $ get k
 instance PersistStoreRead SqlWriteBackend where
-    get k = withReaderT persistBackend $ get k
+    get k = withReaderT projectBackend $ get k
 
 dummyFromKey :: Key record -> Maybe record
 dummyFromKey = Just . recordTypeFromKey

--- a/persistent/Database/Persist/Sql/Orphan/PersistUnique.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistUnique.hs
@@ -24,7 +24,7 @@ defaultUpsert
     :: (MonadIO m
        ,PersistEntity record
        ,PersistUniqueWrite backend
-       ,PersistEntityBackend record ~ BaseBackend backend)
+       ,PersistRecordBackend record backend)
     => record -> [Update record] -> ReaderT backend m (Entity record)
 defaultUpsert record updates = do
     uniqueKey <- onlyUnique record
@@ -83,7 +83,7 @@ instance PersistUniqueWrite SqlBackend where
                 , T.intercalate " AND " $ map (go' conn) $ go uniq]
 
 instance PersistUniqueWrite SqlWriteBackend where
-    deleteBy uniq = withReaderT persistBackend $ deleteBy uniq
+    deleteBy uniq = withReaderT projectBackend $ deleteBy uniq
 
 instance PersistUniqueRead SqlBackend where
     getBy uniq = do
@@ -115,10 +115,10 @@ instance PersistUniqueRead SqlBackend where
         toFieldNames' = map snd . persistUniqueToFieldNames
 
 instance PersistUniqueRead SqlReadBackend where
-    getBy uniq = withReaderT persistBackend $ getBy uniq
+    getBy uniq = withReaderT projectBackend $ getBy uniq
 
 instance PersistUniqueRead SqlWriteBackend where
-    getBy uniq = withReaderT persistBackend $ getBy uniq
+    getBy uniq = withReaderT projectBackend $ getBy uniq
 
 dummyFromUnique :: Unique v -> Maybe v
 dummyFromUnique _ = Nothing

--- a/persistent/Database/Persist/Sql/Raw.hs
+++ b/persistent/Database/Persist/Sql/Raw.hs
@@ -62,7 +62,7 @@ rawExecuteCount :: (MonadIO m, IsSqlBackend backend)
                 -> [PersistValue]  -- ^ Values to fill the placeholders.
                 -> ReaderT backend m Int64
 rawExecuteCount sql vals = do
-    conn <- persistBackend `liftM` ask
+    conn <- projectBackend `liftM` ask
     runLoggingT (logDebugNS (pack "SQL") $ T.append sql $ pack $ "; " ++ show vals)
         (connLogFunc conn)
     stmt <- getStmt sql
@@ -74,7 +74,7 @@ getStmt
   :: (MonadIO m, IsSqlBackend backend)
   => Text -> ReaderT backend m Statement
 getStmt sql = do
-    conn <- persistBackend `liftM` ask
+    conn <- projectBackend `liftM` ask
     liftIO $ getStmtConn conn sql
 
 getStmtConn :: SqlBackend -> Text -> IO Statement

--- a/persistent/Database/Persist/Sql/Raw.hs
+++ b/persistent/Database/Persist/Sql/Raw.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -21,7 +23,7 @@ import qualified Data.Text as T
 import Data.Conduit
 import Control.Monad.Trans.Resource (MonadResource,release)
 
-rawQuery :: (MonadResource m, MonadReader env m, HasPersistBackend env, BaseBackend env ~ SqlBackend)
+rawQuery :: (MonadResource m, MonadReader env m, HasPersistBackend env, BackendCompatible SqlBackend env)
          => Text
          -> [PersistValue]
          -> Source m [PersistValue]
@@ -32,12 +34,12 @@ rawQuery sql vals = do
     release releaseKey
 
 rawQueryRes
-    :: (MonadIO m1, MonadIO m2, IsSqlBackend env)
+    :: forall m1 m2. (MonadIO m1, MonadIO m2) --, BackendCompatible SqlBackend env)
     => Text
     -> [PersistValue]
-    -> ReaderT env m1 (Acquire (Source m2 [PersistValue]))
+    -> ReaderT SqlBackend m1 (Acquire (Source m2 [PersistValue]))
 rawQueryRes sql vals = do
-    conn <- persistBackend `liftM` ask
+    conn <- (id) `liftM` ask
     let make = do
             runLoggingT (logDebugNS (pack "SQL") $ T.append sql $ pack $ "; " ++ show vals)
                 (connLogFunc conn)

--- a/persistent/Database/Persist/Sql/Run.hs
+++ b/persistent/Database/Persist/Sql/Run.hs
@@ -56,7 +56,7 @@ withResourceTimeout ms pool act = control $ \runInIO -> mask $ \restore -> do
 
 runSqlConn :: (MonadBaseControl IO m, IsSqlBackend backend) => ReaderT backend m a -> backend -> m a
 runSqlConn r conn = control $ \runInIO -> mask $ \restore -> do
-    let conn' = persistBackend conn
+    let conn' = projectBackend conn
         getter = getStmtConn conn'
     restore $ connBegin conn' getter
     x <- onException
@@ -122,5 +122,5 @@ withSqlConn open f = do
 
 close' :: (IsSqlBackend backend) => backend -> IO ()
 close' conn = do
-    readIORef (connStmtMap $ persistBackend conn) >>= mapM_ stmtFinalize . Map.elems
-    connClose $ persistBackend conn
+    readIORef (connStmtMap $ projectBackend conn) >>= mapM_ stmtFinalize . Map.elems
+    connClose $ projectBackend conn

--- a/persistent/Database/Persist/Sql/Types/Internal.hs
+++ b/persistent/Database/Persist/Sql/Types/Internal.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -152,4 +153,4 @@ type SqlReadT m a = forall backend. (SqlBackendCanRead backend) => ReaderT backe
 -- | Like @SqlPersistT@ but compatible with any SQL backend which can handle read and write queries.
 type SqlWriteT m a = forall backend. (SqlBackendCanWrite backend) => ReaderT backend m a
 -- | A backend which is a wrapper around @SqlBackend@.
-type IsSqlBackend backend = (IsPersistBackend backend, BaseBackend backend ~ SqlBackend)
+type IsSqlBackend backend = (IsPersistBackend backend, BackendCompatible SqlBackend backend)

--- a/persistent/Database/Persist/Sql/Types/Internal.hs
+++ b/persistent/Database/Persist/Sql/Types/Internal.hs
@@ -94,6 +94,9 @@ instance HasPersistBackend SqlBackend where
 instance IsPersistBackend SqlBackend where
     mkPersistBackend = id
 
+instance BackendCompatible SqlBackend SqlBackend where
+    projectBackend = id
+
 -- | An SQL backend which can only handle read queries
 newtype SqlReadBackend = SqlReadBackend { unSqlReadBackend :: SqlBackend } deriving Typeable
 instance HasPersistBackend SqlReadBackend where
@@ -102,6 +105,9 @@ instance HasPersistBackend SqlReadBackend where
 instance IsPersistBackend SqlReadBackend where
     mkPersistBackend = SqlReadBackend
 
+instance BackendCompatible SqlBackend SqlReadBackend where
+    projectBackend = unSqlReadBackend
+
 -- | An SQL backend which can handle read or write queries
 newtype SqlWriteBackend = SqlWriteBackend { unSqlWriteBackend :: SqlBackend } deriving Typeable
 instance HasPersistBackend SqlWriteBackend where
@@ -109,6 +115,9 @@ instance HasPersistBackend SqlWriteBackend where
     persistBackend = unSqlWriteBackend
 instance IsPersistBackend SqlWriteBackend where
     mkPersistBackend = SqlWriteBackend
+
+instance BackendCompatible SqlBackend SqlWriteBackend where
+    projectBackend = unSqlWriteBackend
 
 -- | Useful for running a write query against an untagged backend with unknown capabilities.
 writeToUnknown :: Monad m => ReaderT SqlWriteBackend m a -> ReaderT SqlBackend m a

--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -33,6 +34,14 @@ import qualified Data.Scientific
 #else
 import qualified Data.Attoparsec.Number as AN
 #endif
+
+-- | This class witnesses that two backend are compatible, and that you can
+-- convert from the @sub@ backend into the @sup@ backend. This is similar
+-- to the 'HasPersistBackend' and 'IsPersistBackend' classes, but where you
+-- don't want to fix the type associated with the 'PersistEntityBackend' of
+-- a record.
+class BackendCompatible sup sub where
+    projectBackend :: sub -> sup
 
 -- | A 'Checkmark' should be used as a field type whenever a
 -- uniqueness constraint should guarantee that a certain kind of


### PR DESCRIPTION
This PR allows users of the library to use backends other than `SqlBackend` with SQL datatabases, provided that the backend is compatible.

The motivation and notes are provided in #698 

I believe that we could further simplify the code and design by unifying the `HasPersistBackend` and `IsPersistBackend` with the `BackendCompatible` class. I'm wary of introducing a breaking change for this though :)