### PR TITLE
Introduce `BackendCompatible` class

### DIFF
--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -1031,7 +1031,7 @@ insertOnDuplicateKeyUpdate
      , PersistEntity record
      , MonadIO m
      , PersistStore backend
-     , BackendCompatible SqlBackend backend 
+     , BackendCompatible SqlBackend backend
      )
   => record
   -> [Update record]
@@ -1056,24 +1056,24 @@ data SomeField record where
 -- the value that is provided. You can use this to increment a counter value.
 -- These updates only occur if the original record is present in the database.
 insertManyOnDuplicateKeyUpdate
-  :: forall record backend m. 
-  ( backend ~ PersistEntityBackend record
-  , BackendCompatible SqlBackend backend
-  , PersistEntity record
-  , MonadIO m
-  )
-  => [record] -- ^ A list of the records you want to insert, or update
-  -> [SomeField record] -- ^ A list of the fields you want to copy over.
-  -> [Update record] -- ^ A list of the updates to apply that aren't dependent on the record being inserted.
-  -> ReaderT backend m ()
+    :: forall record backend m.
+    ( backend ~ PersistEntityBackend record
+    , BackendCompatible SqlBackend backend
+    , PersistEntity record
+    , MonadIO m
+    )
+    => [record] -- ^ A list of the records you want to insert, or update
+    -> [SomeField record] -- ^ A list of the fields you want to copy over.
+    -> [Update record] -- ^ A list of the updates to apply that aren't dependent on the record being inserted.
+    -> ReaderT backend m ()
 insertManyOnDuplicateKeyUpdate [] _ _ = return ()
-insertManyOnDuplicateKeyUpdate records [] [] = 
-    withReaderT projectBackend 
-    . uncurry rawExecute 
+insertManyOnDuplicateKeyUpdate records [] [] =
+    withReaderT projectBackend
+    . uncurry rawExecute
     $ mkInsertIgnoreQuery records
 insertManyOnDuplicateKeyUpdate records fieldValues updates =
-    withReaderT projectBackend 
-    . uncurry rawExecute 
+    withReaderT projectBackend
+    . uncurry rawExecute
     $ mkBulkInsertQuery records fieldValues updates
 
 -- | This makes a special query that inserts the given rows into the

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -25,7 +25,7 @@ import Control.Monad.Logger (MonadLogger, runNoLoggingT)
 import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except (runExceptT)
-import Control.Monad.Trans.Reader (runReaderT)
+import Control.Monad.Trans.Reader (runReaderT, ReaderT)
 import Control.Monad.Trans.Writer (runWriterT)
 import Data.Monoid ((<>))
 import Data.Aeson
@@ -1034,7 +1034,7 @@ insertOnDuplicateKeyUpdate
      )
   => record
   -> [Update record]
-  -> SqlPersistT m ()
+  -> ReaderT SqlBackend m ()
 insertOnDuplicateKeyUpdate record =
   insertManyOnDuplicateKeyUpdate [record] []
 

--- a/persistent/Database/Persist/Class.hs
+++ b/persistent/Database/Persist/Class.hs
@@ -52,6 +52,7 @@ module Database.Persist.Class
     , HasPersistBackend (..)
     , IsPersistBackend ()
     , liftPersist
+    , BackendCompatible (..)
 
     -- * JSON utilities
     , keyValueEntityToJSON, keyValueEntityFromJSON

--- a/persistent/Database/Persist/Class/PersistStore.hs
+++ b/persistent/Database/Persist/Class/PersistStore.hs
@@ -54,6 +54,40 @@ class (HasPersistBackend backend) => IsPersistBackend backend where
 -- to the 'HasPersistBackend' and 'IsPersistBackend' classes, but where you
 -- don't want to fix the type associated with the 'PersistEntityBackend' of
 -- a record.
+--
+-- Generally speaking, where you might have:
+--
+-- @
+-- foo ::
+--   ( 'PersistEntity' record
+--   , 'PeristEntityBackend' record ~ 'BaseBackend' backend
+--   , 'IsSqlBackend' backend
+--   )
+-- @
+--
+-- this can be replaced with:
+--
+-- @
+-- foo ::
+--   ( 'PersistEntity' record,
+--   , 'PersistEntityBackend' record ~ backend
+--   , 'BackendCompatible' 'SqlBackend' backend
+--   )
+-- @
+--
+-- This works for 'SqlReadBackend' because of the @instance 'BackendCompatible' 'SqlBackend' 'SqlReadBackend'@, without needing to go through the 'BaseBackend' type family.
+--
+-- Likewise, functions that are currently hardcoded to use 'SqlBackend' can be generalized:
+--
+-- @
+-- -- before:
+-- asdf :: 'ReaderT' 'SqlBackend' m ()
+-- asdf = pure ()
+--
+-- -- after:
+-- asdf' :: 'BackendCompatible' SqlBackend backend => ReaderT backend m ()
+-- asdf' = withReaderT 'projectBackend' asdf
+-- @
 class BackendCompatible sup sub where
     projectBackend :: sub -> sup
 

--- a/persistent/Database/Persist/Class/PersistStore.hs
+++ b/persistent/Database/Persist/Class/PersistStore.hs
@@ -18,6 +18,7 @@ module Database.Persist.Class.PersistStore
     , insertEntity
     , insertRecord
     , ToBackendKey(..)
+    , BackendCompatible(..)
     ) where
 
 import qualified Data.Text as T
@@ -47,6 +48,14 @@ class (HasPersistBackend backend) => IsPersistBackend backend where
     -- It should be used carefully and only when actually constructing a @backend@. Careless use allows us
     -- to accidentally run a write query against a read-only database.
     mkPersistBackend :: BaseBackend backend -> backend
+
+-- | This class witnesses that two backend are compatible, and that you can
+-- convert from the @sub@ backend into the @sup@ backend. This is similar
+-- to the 'HasPersistBackend' and 'IsPersistBackend' classes, but where you
+-- don't want to fix the type associated with the 'PersistEntityBackend' of
+-- a record.
+class BackendCompatible sup sub where
+    projectBackend :: sub -> sup
 
 -- | A convenient alias for common type signatures
 type PersistRecordBackend record backend = (PersistEntity record, PersistEntityBackend record ~ BaseBackend backend)

--- a/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
@@ -40,7 +40,7 @@ import Web.HttpApiData (ToHttpApiData, FromHttpApiData)
 import Database.Persist.Sql.Class (PersistFieldSql)
 import qualified Data.Aeson as A
 import Control.Exception.Lifted (throwIO)
-import Database.Persist.Class (BackendCompatible(..))
+import Database.Persist.Class ()
 
 withRawQuery :: MonadIO m
              => Text

--- a/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -39,6 +40,7 @@ import Web.HttpApiData (ToHttpApiData, FromHttpApiData)
 import Database.Persist.Sql.Class (PersistFieldSql)
 import qualified Data.Aeson as A
 import Control.Exception.Lifted (throwIO)
+import Database.Persist.Class (BackendCompatible(..))
 
 withRawQuery :: MonadIO m
              => Text
@@ -113,6 +115,15 @@ instance PersistCore SqlReadBackend where
 instance PersistCore SqlWriteBackend where
     newtype BackendKey SqlWriteBackend = SqlWriteBackendKey { unSqlWriteBackendKey :: Int64 }
         deriving (Show, Read, Eq, Ord, Num, Integral, PersistField, PersistFieldSql, PathPiece, ToHttpApiData, FromHttpApiData, Real, Enum, Bounded, A.ToJSON, A.FromJSON)
+
+instance BackendCompatible SqlBackend SqlBackend where
+    projectBackend = id
+
+instance BackendCompatible SqlBackend SqlReadBackend where
+    projectBackend = unSqlReadBackend
+
+instance BackendCompatible SqlBackend SqlWriteBackend where
+    projectBackend = unSqlWriteBackend
 
 instance PersistStoreWrite SqlBackend where
     update _ [] = return ()


### PR DESCRIPTION
This PR introduces some machinery for generalizing the SQL backend requirement, and uses that to generalize the `insertOnDuplicateKeyUpdate` functions.

This PR enables support for the [`persistent-typed-db`](https://github.com/parsonsmatt/persistent-typed-db) library which wraps the `SqlBackend` with a phantom type to indicate which database models are associated with. This turns mixing up your connection and models in a multi-db environment into a compile time error.

This PR is based on [work done in a PR to `esqueleto`](https://github.com/bitemyapp/esqueleto/pull/53). I was able to get esqueleto queries working by incorporating the `BackendCompatible` class to Esqueleto and instantiating it appropriately in the application.

The `BackendCompatible` class and the `HasPersistBackend` / `IsPersistBackend` classes are very similar, and it's likely that the functionality can be merged in some way.