### PR TITLE
Update tests to allow for MySQL behaviour changes

### DIFF
--- a/persistent-mysql/ChangeLog.md
+++ b/persistent-mysql/ChangeLog.md
@@ -1,6 +1,7 @@
 ## 2.6.2
 
 * Extend the `SomeField` type to allow `insertManyOnDuplicateKeyUpdate` to conditionally copy values.
+* Depend on `mysql-simple >= 0.4.3` to fix encoding and decoding of date/time values with fractional seconds (when a column is specified using something like `sqltype=TIME(6)`)
 
 ## 2.6.1
 

--- a/persistent-mysql/persistent-mysql.cabal
+++ b/persistent-mysql/persistent-mysql.cabal
@@ -29,7 +29,7 @@ extra-source-files: ChangeLog.md
 library
     build-depends:   base                  >= 4.6        && < 5
                    , transformers          >= 0.2.1
-                   , mysql-simple          >= 0.2.2.3  && < 0.5
+                   , mysql-simple          >= 0.4.3    && < 0.5
                    , mysql                 >= 0.1.1.3  && < 0.2
                    , blaze-builder
                    , persistent            >= 2.6.1    && < 3

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -1,5 +1,5 @@
 name:            persistent-test
-version:         2.0.0.1
+version:         2.0.0.2
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -147,7 +147,7 @@ library
 
    if flag(mysql)
      build-depends:  persistent-mysql
-                   , mysql-simple          >= 0.2.2.3  && < 0.5
+                   , mysql-simple          >= 0.4.3    && < 0.5
                    , mysql                 >= 0.1.1.3  && < 0.2
      cpp-options: -DWITH_MYSQL
 


### PR DESCRIPTION
This handles tests of fractional seconds in date/time types (introduced in MySQL 5.6.4) and a change to a strict SQL mode (introduced as the default in MySQL 5.7.5).  A lower-bound update on `mysql-simple` is needed for the fractional seconds.