### PR TITLE
Link against sqlite using pkgconfig by default.

### DIFF
--- a/persistent-sqlite/ChangeLog.md
+++ b/persistent-sqlite/ChangeLog.md
@@ -1,3 +1,7 @@
+## 2.6.3
+
+* Add 'use-pkgconfig' flag to use pkg-config to find system SQLite library.
+
 ## 2.6.2.1
 
 * Update `sqlite` cbit sources to 3.19.3 from 3.12.1

--- a/persistent-sqlite/persistent-sqlite.cabal
+++ b/persistent-sqlite/persistent-sqlite.cabal
@@ -1,5 +1,5 @@
 name:            persistent-sqlite
-version:         2.6.2.1
+version:         2.6.3
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -16,6 +16,9 @@ extra-source-files: ChangeLog.md cbits/*.c cbits/*.h
 
 flag systemlib
   description: Use the system-wide sqlite library
+  default: False
+flag use-pkgconfig
+  description: Use pkg-config to find system sqlite library
   default: False
 flag build-sanity-exe
   description: Build a sanity check test executable
@@ -42,7 +45,10 @@ library
                      Database.Persist.Sqlite
     ghc-options:     -Wall
     if flag(systemlib)
-        extra-libraries: sqlite3
+        if flag(use-pkgconfig)
+            pkgconfig-depends: sqlite3
+        else
+            extra-libraries: sqlite3
     else
         c-sources:   cbits/sqlite3.c
         include-dirs: cbits


### PR DESCRIPTION
There are two reasons for this:
1. The cabal user guide recommends [preferring pkg-config dependencies if available](https://www.haskell.org/cabal/users-guide/developing-packages.html#pkg-field-pkgconfig-depends)
2. Building a dependent package against persistent-sqlite that uses system libraries fails to fine `libsqlite3.so.0`. I don't quite understand the internals of why this occurs, but it works when using pkg-config.

I also added an extra flag to switch back to the previous behaviour, though I'm not so sure it's even necessary.