### PR TITLE
Implement rawSql as a QuasiQuoter

### DIFF
--- a/persistent-test/src/CompositeTest.hs
+++ b/persistent-test/src/CompositeTest.hs
@@ -272,8 +272,16 @@ specs = describe "composite" $
       newp2 @== Just p2
     it "RawSql Key instance" $ db $ do
       key <- insert p1
+
       keyFromRaw <- rawSql "SELECT name, name2, age FROM test_parent LIMIT 1" []
       [key] @== keyFromRaw
+
+      keyFromRaw' <- [sqlQQ|
+          SELECT @{TestParentName}, @{TestParentName2}, @{TestParentAge}
+            FROM ^{TestParent}
+            LIMIT 1
+      |]
+      [key] @== keyFromRaw'
     it "RawSql Entity instance" $ db $ do
       key <- insert p1
 

--- a/persistent-test/src/CompositeTest.hs
+++ b/persistent-test/src/CompositeTest.hs
@@ -272,22 +272,25 @@ specs = describe "composite" $
       newp2 @== Just p2
     it "RawSql Key instance" $ db $ do
       key <- insert p1
-
       keyFromRaw <- rawSql "SELECT name, name2, age FROM test_parent LIMIT 1" []
       [key] @== keyFromRaw
 
+    it "RawSql Key instance with sqlQQ" $ db $ do
+      key <- insert p1
       keyFromRaw' <- [sqlQQ|
           SELECT @{TestParentName}, @{TestParentName2}, @{TestParentAge}
             FROM ^{TestParent}
             LIMIT 1
       |]
       [key] @== keyFromRaw'
+
     it "RawSql Entity instance" $ db $ do
       key <- insert p1
-
       newp1 <- rawSql "SELECT ?? FROM test_parent LIMIT 1" []
       [Entity key p1] @== newp1
 
+    it "RawSql Entity instance with sqlQQ" $ db $ do
+      key <- insert p1
       newp1' <- [sqlQQ| SELECT ?? FROM ^{TestParent} |]
       [Entity key p1] @== newp1'
 

--- a/persistent-test/src/CompositeTest.hs
+++ b/persistent-test/src/CompositeTest.hs
@@ -276,8 +276,12 @@ specs = describe "composite" $
       [key] @== keyFromRaw
     it "RawSql Entity instance" $ db $ do
       key <- insert p1
+
       newp1 <- rawSql "SELECT ?? FROM test_parent LIMIT 1" []
       [Entity key p1] @== newp1
+
+      newp1' <- [sqlQQ| SELECT ?? FROM ^{TestParent} |]
+      [Entity key p1] @== newp1'
 
 #endif
 

--- a/persistent-test/src/PersistentTest.hs
+++ b/persistent-test/src/PersistentTest.hs
@@ -983,43 +983,46 @@ specs = describe "persistent" $ do
                        , (Entity p2k p2, Nothing) ]
 
   it "sqlQQ/entity" $ db $ do
-      let insert'
-            :: PersistStore backend
-            => PersistEntity val
-            => PersistEntityBackend val ~ BaseBackend backend
-            => MonadIO m
-            => val
-            -> ReaderT backend m (Key val, val)
-          insert' v = insert v >>= \k -> return (k, v)
-      (p1k, p1) <- insert' $ Person "Mathias"   23 Nothing
-      (p2k, p2) <- insert' $ Person "Norbert"   44 Nothing
-      (p3k, _ ) <- insert' $ Person "Cassandra" 19 Nothing
-      (_  , _ ) <- insert' $ Person "Thiago"    19 Nothing
-      (a1k, a1) <- insert' $ Pet p1k "Rodolfo" Cat
-      (a2k, a2) <- insert' $ Pet p1k "Zeno"    Cat
-      (a3k, a3) <- insert' $ Pet p2k "Lhama"   Dog
-      (_  , _ ) <- insert' $ Pet p3k "Abacate" Cat
+      -- let insert'
+      --       :: PersistStore backend
+      --       => PersistEntity val
+      --       => PersistEntityBackend val ~ BaseBackend backend
+      --       => MonadIO m
+      --       => val
+      --       -> ReaderT backend m (Key val, val)
+      --     insert' v = insert v >>= \k -> return (k, v)
+      -- (p1k, p1) <- insert' $ Person "Mathias"   23 Nothing
+      -- (p2k, p2) <- insert' $ Person "Norbert"   44 Nothing
+      -- (p3k, _ ) <- insert' $ Person "Cassandra" 19 Nothing
+      -- (_  , _ ) <- insert' $ Person "Thiago"    19 Nothing
+      -- (a1k, a1) <- insert' $ Pet p1k "Rodolfo" Cat
+      -- (a2k, a2) <- insert' $ Pet p1k "Zeno"    Cat
+      -- (a3k, a3) <- insert' $ Pet p2k "Lhama"   Dog
+      -- (_  , _ ) <- insert' $ Pet p3k "Abacate" Cat
 
-      let runQuery
-            :: (RawSql a, MonadIO m)
-            => SqlBackend
-            => Int64
-            -> ReaderT backend m [a]
-          runQuery age =
-            [sqlQQ|
-              SELECT ??, ??
-                FROM
-                  ^{Person},
-                  ^{Pet}
-                WHERE @{PersonAge} >= #{age}
-            |]
-                -- @{PersonAge} >= #{age}
-                --   AND ^{Pet}.@{PetOwnerId} = ^{Person}.@{PersonId}
-                --   ORDER BY ^{Person}.@{PersonName}
-      ret <- runQuery 20
-      liftIO $ ret @?= [ (Entity p1k p1, Entity a1k a1)
-                       , (Entity p1k p1, Entity a2k a2)
-                       , (Entity p2k p2, Entity a3k a3) ]
+      x <- getFieldName PersonAge
+      pure ()
+
+      -- let runQuery
+      --       :: (RawSql a, MonadIO m)
+      --       => Int64
+      --       -> ReaderT SqlBackend m [a]
+      --     runQuery age =
+      --       [sqlQQ|
+      --         SELECT
+      --           FROM
+      --             ^{Person},
+      --             ^{Pet}
+      --           WHERE @{PersonAge} >= #{age}
+      --       |]
+      --           -- @{PersonAge} >= #{age}
+      --           --   AND ^{Pet}.@{PetOwnerId} = ^{Person}.@{PersonId}
+      --           --   ORDER BY ^{Person}.@{PersonName}
+      -- [ret :: Single Int] <- runQuery 20
+      -- pure ()
+      -- liftIO $ ret @?= [ (Entity p1k p1, Entity a1k a1)
+      --                  , (Entity p1k p1, Entity a2k a2)
+      --                  , (Entity p2k p2, Entity a3k a3) ]
       -- ret2 <- rawSql query [PersistInt64 20]
       -- liftIO $ ret2 @?= [ (Just (Entity p1k p1), Just (Entity a1k a1))
       --                   , (Just (Entity p1k p1), Just (Entity a2k a2))

--- a/persistent-test/src/PersistentTest.hs
+++ b/persistent-test/src/PersistentTest.hs
@@ -892,12 +892,24 @@ specs = describe "persistent" $ do
       ret <- rawSql "SELECT 2+2" []
       liftIO $ ret @?= [Single (4::Int)]
 
+  it "sqlQQ/?-?" $ db $ do
+      ret <- [sqlQQ| SELECT #{2 :: Int}+#{2 :: Int} |]
+      liftIO $ ret @?= [Single (4::Int)]
+
   it "rawSql/?-?" $ db $ do
       ret <- rawSql "SELECT ?-?" [PersistInt64 5, PersistInt64 3]
       liftIO $ ret @?= [Single (2::Int)]
 
+  it "sqlQQ/?-?" $ db $ do
+      ret <- [sqlQQ| SELECT #{5 :: Int}-#{3 :: Int} |]
+      liftIO $ ret @?= [Single (2::Int)]
+
   it "rawSql/NULL" $ db $ do
       ret <- rawSql "SELECT NULL" []
+      liftIO $ ret @?= [Nothing :: Maybe (Single Int)]
+
+  it "sqlQQ/NULL" $ db $ do
+      ret <- [sqlQQ| SELECT NULL |]
       liftIO $ ret @?= [Nothing :: Maybe (Single Int)]
 
   it "rawSql/entity" $ db $ do

--- a/persistent-test/src/PersistentTest.hs
+++ b/persistent-test/src/PersistentTest.hs
@@ -982,6 +982,89 @@ specs = describe "persistent" $ do
                        , (Entity p1k p1, Just (Entity a2k a2))
                        , (Entity p2k p2, Nothing) ]
 
+  it "sqlQQ/entity" $ db $ do
+      let insert'
+            :: PersistStore backend
+            => PersistEntity val
+            => PersistEntityBackend val ~ BaseBackend backend
+            => MonadIO m
+            => val
+            -> ReaderT backend m (Key val, val)
+          insert' v = insert v >>= \k -> return (k, v)
+      (p1k, p1) <- insert' $ Person "Mathias"   23 Nothing
+      (p2k, p2) <- insert' $ Person "Norbert"   44 Nothing
+      (p3k, _ ) <- insert' $ Person "Cassandra" 19 Nothing
+      (_  , _ ) <- insert' $ Person "Thiago"    19 Nothing
+      (a1k, a1) <- insert' $ Pet p1k "Rodolfo" Cat
+      (a2k, a2) <- insert' $ Pet p1k "Zeno"    Cat
+      (a3k, a3) <- insert' $ Pet p2k "Lhama"   Dog
+      (_  , _ ) <- insert' $ Pet p3k "Abacate" Cat
+
+      let runQuery
+            :: (RawSql a, MonadIO m)
+            => SqlBackend
+            => Int64
+            -> ReaderT backend m [a]
+          runQuery age =
+            [sqlQQ|
+              SELECT ??, ??
+                FROM
+                  ^{Person},
+                  ^{Pet}
+                WHERE @{PersonAge} >= #{age}
+            |]
+                -- @{PersonAge} >= #{age}
+                --   AND ^{Pet}.@{PetOwnerId} = ^{Person}.@{PersonId}
+                --   ORDER BY ^{Person}.@{PersonName}
+      ret <- runQuery 20
+      liftIO $ ret @?= [ (Entity p1k p1, Entity a1k a1)
+                       , (Entity p1k p1, Entity a2k a2)
+                       , (Entity p2k p2, Entity a3k a3) ]
+      -- ret2 <- rawSql query [PersistInt64 20]
+      -- liftIO $ ret2 @?= [ (Just (Entity p1k p1), Just (Entity a1k a1))
+      --                   , (Just (Entity p1k p1), Just (Entity a2k a2))
+      --                   , (Just (Entity p2k p2), Just (Entity a3k a3)) ]
+      -- ret3 <- rawSql query [PersistInt64 20]
+      -- liftIO $ ret3 @?= [ Just (Entity p1k p1, Entity a1k a1)
+      --                   , Just (Entity p1k p1, Entity a2k a2)
+      --                   , Just (Entity p2k p2, Entity a3k a3) ]
+
+  -- TODO
+  -- it "rawSql/order-proof" $ db $ do
+  --     let p1 = Person "Zacarias" 93 Nothing
+  --     p1k <- insert p1
+  --     escape <- ((. DBName) . connEscapeName) `fmap` ask
+  --     let query = T.concat [ "SELECT ?? "
+  --                          , "FROM ", escape "Person"
+  --                          ]
+  --     ret1 <- rawSql query []
+  --     ret2 <- rawSql query [] :: MonadIO m => SqlPersistT m [Entity (ReverseFieldOrder Person)]
+  --     liftIO $ ret1 @?= [Entity p1k p1]
+  --     liftIO $ ret2 @?= [Entity (RFOKey $ unPersonKey $ p1k) (RFO p1)]
+  --
+  -- TODO
+  -- it "rawSql/OUTER JOIN" $ db $ do
+  --     let insert' :: (PersistStore backend, PersistEntity val, PersistEntityBackend val ~ BaseBackend backend, MonadIO m)
+  --                 => val -> ReaderT backend m (Key val, val)
+  --         insert' v = insert v >>= \k -> return (k, v)
+  --     (p1k, p1) <- insert' $ Person "Mathias"   23 Nothing
+  --     (p2k, p2) <- insert' $ Person "Norbert"   44 Nothing
+  --     (a1k, a1) <- insert' $ Pet p1k "Rodolfo" Cat
+  --     (a2k, a2) <- insert' $ Pet p1k "Zeno"    Cat
+  --     escape <- ((. DBName) . connEscapeName) `fmap` ask
+  --     let query = T.concat [ "SELECT ??, ?? "
+  --                          , "FROM ", person
+  --                          , "LEFT OUTER JOIN ", pet
+  --                          , " ON ", person, ".", escape "id"
+  --                          , " = ", pet, ".", escape "ownerId"
+  --                          , " ORDER BY ", person, ".", escape "name"]
+  --         person = escape "Person"
+  --         pet    = escape "Pet"
+  --     ret <- rawSql query []
+  --     liftIO $ ret @?= [ (Entity p1k p1, Just (Entity a1k a1))
+  --                      , (Entity p1k p1, Just (Entity a2k a2))
+  --                      , (Entity p2k p2, Nothing) ]
+
   it "commit/rollback" (caseCommitRollback >> runResourceT (runConn cleanDB))
 
 #ifndef WITH_MYSQL

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,6 +1,7 @@
 ## 2.7.2
 
-- Many of the functions have been generalized using the `BackendCompatible` class. [#723](https://github.com/yesodweb/persistent/pull/723)
+* Many of the functions have been generalized using the `BackendCompatible` class. [#723](https://github.com/yesodweb/persistent/pull/723)
+* Add raw sql quasi quoters [#717](https://github.com/yesodweb/persistent/pull/717)
 
 ## 2.7.1
 

--- a/persistent/Database/Persist/Sql.hs
+++ b/persistent/Database/Persist/Sql.hs
@@ -9,6 +9,8 @@ module Database.Persist.Sql
     , rawQueryRes
     , rawExecute
     , rawExecuteCount
+    , sqlQQ
+    , executeQQ
     , rawSql
     , deleteWhereCount
     , updateWhereCount
@@ -25,6 +27,7 @@ import Database.Persist.Sql.Types
 import Database.Persist.Sql.Class
 import Database.Persist.Sql.Run hiding (withResourceTimeout)
 import Database.Persist.Sql.Raw
+import Database.Persist.Sql.Raw.QQ
 import Database.Persist.Sql.Migration
 import Database.Persist.Sql.Internal
 

--- a/persistent/Database/Persist/Sql/Raw/QQ.hs
+++ b/persistent/Database/Persist/Sql/Raw/QQ.hs
@@ -51,6 +51,7 @@ This directly translates to this:
 
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 
 module Database.Persist.Sql.Raw.QQ (
       -- * Sql QuasiQuoters
@@ -63,6 +64,7 @@ module Database.Persist.Sql.Raw.QQ (
 
 import Control.Arrow (first, second)
 import Data.Text (pack)
+import Data.Monoid (mempty)
 import qualified Language.Haskell.TH as TH
 import Language.Haskell.TH.Quote
 import Language.Haskell.Meta.Parse

--- a/persistent/Database/Persist/Sql/Raw/QQ.hs
+++ b/persistent/Database/Persist/Sql/Raw/QQ.hs
@@ -1,0 +1,69 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Database.Persist.Sql.Raw.QQ (
+      sqlQQ
+    , executeQQ
+    ) where
+
+import Control.Arrow (first, second)
+import Data.Text (pack)
+import qualified Language.Haskell.TH as TH
+import Language.Haskell.TH.Quote
+import Language.Haskell.Meta.Parse
+
+import Database.Persist.Class (toPersistValue)
+import qualified Database.Persist.Sql.Raw as Raw
+
+data StringPart
+  = Literal String
+  | AntiQuote String
+  deriving Show
+
+parseHaskell :: String -> String -> [StringPart]
+parseHaskell a []          = [Literal (reverse a)]
+parseHaskell a ('\\':x:xs) = parseHaskell (x:a) xs
+parseHaskell a ['\\']      = parseHaskell ('\\':a) []
+parseHaskell a ('}':xs)    = AntiQuote (reverse a) : parseStr [] xs
+parseHaskell a (x:xs)      = parseHaskell (x:a) xs
+
+parseStr :: String -> String -> [StringPart]
+parseStr a []           = [Literal (reverse a)]
+parseStr a ('\\':x:xs)  = parseStr (x:a) xs
+parseStr a ['\\']       = parseStr ('\\':a) []
+parseStr a ('#':'{':xs) = Literal (reverse a) : parseHaskell [] xs
+parseStr a (x:xs)       = parseStr (x:a) xs
+
+makeExpr :: [StringPart] -> TH.ExpQ
+makeExpr s = TH.appE [| uncurry Raw.rawSql . first pack |] (go s)
+    where
+    go [] = [| (mempty, []) |]
+    go (Literal a:xs)   = TH.appE [| first (a ++) |] (go xs)
+    go (AntiQuote a:xs) = TH.appE [| first ("?" ++) . second (toPersistValue $(reify a) :) |] (go xs)
+
+makeExpr' :: [StringPart] -> TH.ExpQ
+makeExpr' s = TH.appE [| uncurry Raw.rawExecute . first pack |] (go s)
+    where
+    go [] = [| (mempty, []) |]
+    go (Literal a:xs)   = TH.appE [| first (a ++) |] (go xs)
+    go (AntiQuote a:xs) = TH.appE [| first ("?" ++) . second (toPersistValue $(reify a) :) |] (go xs)
+
+reify :: String -> TH.Q TH.Exp
+reify s =
+    case parseExp s of
+        Left e -> TH.reportError e >> [| mempty |]
+        Right v -> return v
+
+sqlQQ :: QuasiQuoter
+sqlQQ = QuasiQuoter
+    (makeExpr . parseStr [] . filter (/= '\r'))
+    (error "Cannot use qc as a pattern")
+    (error "Cannot use qc as a type")
+    (error "Cannot use qc as a dec")
+
+executeQQ :: QuasiQuoter
+executeQQ = QuasiQuoter
+    (makeExpr' . parseStr [] . filter (/= '\r'))
+    (error "Cannot use qc as a pattern")
+    (error "Cannot use qc as a type")
+    (error "Cannot use qc as a dec")

--- a/persistent/Database/Persist/Sql/Raw/QQ.hs
+++ b/persistent/Database/Persist/Sql/Raw/QQ.hs
@@ -56,10 +56,9 @@ module Database.Persist.Sql.Raw.QQ (
     , executeCountQQ
     ) where
 
-import Prelude hiding (fail)
+import Prelude
 import Control.Arrow (first, second)
 import Control.Monad.Reader (ask)
-import Control.Monad.Fail (fail)
 import Data.Text (pack, unpack)
 import Data.Maybe (fromMaybe, Maybe(..))
 import Data.Monoid (mempty, (<>))

--- a/persistent/Database/Persist/Sql/Raw/QQ.hs
+++ b/persistent/Database/Persist/Sql/Raw/QQ.hs
@@ -127,7 +127,7 @@ makeExpr fun toks = do
         typeN <- TH.lookupTypeName a >>= \case
                 Just t  -> pure t
                 Nothing -> fail $ "Type not in scope: " ++ show a
-        tableN <- TH.newName "field"
+        tableN <- TH.newName "table"
         TH.infixE
             (Just $
                 TH.appE

--- a/persistent/Database/Persist/Sql/Raw/QQ.hs
+++ b/persistent/Database/Persist/Sql/Raw/QQ.hs
@@ -105,7 +105,7 @@ makeExpr fun toks = do
 
     where
     go :: [Token] -> TH.ExpQ
-    go [] = [| pure (mempty, mempty) |]
+    go [] = [| return (mempty, mempty) |]
     go (Literal a:xs) =
         TH.appE
             [| fmap $ first (pack a <>) |]
@@ -125,7 +125,7 @@ makeExpr fun toks = do
                     (go xs))
     go (TableName a:xs) = do
         typeN <- TH.lookupTypeName a >>= \case
-                Just t  -> pure t
+                Just t  -> return t
                 Nothing -> fail $ "Type not in scope: " ++ show a
         tableN <- TH.newName "table"
         TH.infixE

--- a/persistent/Database/Persist/Sql/Raw/QQ.hs
+++ b/persistent/Database/Persist/Sql/Raw/QQ.hs
@@ -15,6 +15,9 @@ applied to the modified query text as well as a list of all found values.
 Please note that it is not required to call 'toPersistValue' on each
 interpolated value, as this conversion is done automatically.
 
+Further, a type's table name can be safely inserted using @^{TableName}@ and
+columns can be referenced using the @\@{ColumnName}@ notation.
+
 Here is a small example:
 
 Given this model
@@ -24,6 +27,10 @@ Category
   rgt Int
   lft Int
 @
+
+We can now execute this raw query, @^{TableName}@ looks up the table's name and
+escapes it, @\@{ColumnName}@ looks up the column's name and properly escapes it
+and @#{value}@ inserts the value via the usual parameter substitution mechanism.
 
 @
 let lft = 10 :: Int

--- a/persistent/Database/Persist/Sql/Raw/QQ.hs
+++ b/persistent/Database/Persist/Sql/Raw/QQ.hs
@@ -70,6 +70,7 @@ import Language.Haskell.Meta.Parse
 import Database.Persist.Class (toPersistValue)
 import Database.Persist.Sql.Raw (rawSql, rawQuery, rawQueryRes, rawExecute, rawExecuteCount)
 import Database.Persist.Sql.Types (connEscapeName)
+import Database.Persist.Sql.Orphan.PersistStore (getFieldName, getTableName)
 
 data Token
   = Literal String

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -45,6 +45,7 @@ library
                    , vector
                    , attoparsec
                    , template-haskell
+                   , haskell-src-meta
                    , blaze-html               >= 0.5
                    , blaze-markup             >= 0.5.1
                    , silently
@@ -75,6 +76,7 @@ library
                      Database.Persist.Sql.Internal
                      Database.Persist.Sql.Types
                      Database.Persist.Sql.Raw
+                     Database.Persist.Sql.Raw.QQ
                      Database.Persist.Sql.Run
                      Database.Persist.Sql.Class
                      Database.Persist.Sql.Orphan.PersistQuery

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -46,7 +46,6 @@ library
                    , attoparsec
                    , template-haskell
                    , haskell-src-meta
-                   , fail
                    , blaze-html               >= 0.5
                    , blaze-markup             >= 0.5.1
                    , silently

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -46,6 +46,7 @@ library
                    , attoparsec
                    , template-haskell
                    , haskell-src-meta
+                   , fail
                    , blaze-html               >= 0.5
                    , blaze-markup             >= 0.5.1
                    , silently


### PR DESCRIPTION
I'm having a go at #716, now you can do:

```haskell
let lft = 10 :: Int
     rgt = 20 :: Int
     width = 50 :: Int
[executeQQ|
    DELETE FROM category WHERE lft BETWEEN #{lft} AND #{rgt};
    UPDATE category SET rgt = rgt - #{width} WHERE rgt > #{rgt};
    UPDATE category SET lft = lft - #{width} WHERE lft > #{rgt};
|]
```

Would be great if you could help me figure out how to pass a function into `makeExpr` so that I don't have to duplicate the whole block of code:

https://github.com/felixSchl/persistent/blob/7856bd3878aadb9a703360d76934a7b7e78c66a4/persistent/Database/Persist/Sql/Raw/QQ.hs#L37-L49

I've also updated the test bed to include a few basic tests for this:

https://github.com/felixSchl/persistent/blob/7856bd3878aadb9a703360d76934a7b7e78c66a4/persistent-test/src/PersistentTest.hs#L891-L913