### PR TITLE
Add insertUniqueEntity method

### DIFF
--- a/persistent-test/src/PersistUniqueTest.hs
+++ b/persistent-test/src/PersistUniqueTest.hs
@@ -36,4 +36,9 @@ specs = describe "custom primary key" $ do
     Just vk <- get k
     Just vu <- getBy (UniqueBar b)
     vu @== Entity k vk
+  it "insertUniqueEntity" $ db $ do
+    let fo = Fo 3 5
+    Just (Entity _ insertedFoValue) <- insertUniqueEntity fo
+    Nothing <- insertUniqueEntity fo
+    fo @== insertedFoValue
 #endif

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,3 +1,7 @@
+## 2.7.1
+
+* Added an `insertUniqueEntity` function [#718](https://github.com/yesodweb/persistent/pull/718)
+
 ## 2.7.0
 
 * Fix upsert behavior [#613](https://github.com/yesodweb/persistent/issues/613)

--- a/persistent/Database/Persist/Class.hs
+++ b/persistent/Database/Persist/Class.hs
@@ -23,6 +23,7 @@ module Database.Persist.Class
     , PersistUniqueWrite (..)
     , getByValue
     , insertBy
+    , insertUniqueEntity
     , replaceUnique
     , checkUnique
     , onlyUnique

--- a/persistent/Database/Persist/Class/PersistUnique.hs
+++ b/persistent/Database/Persist/Class/PersistUnique.hs
@@ -138,7 +138,8 @@ insertUniqueEntity
        ,PersistRecordBackend record backend
        ,PersistUniqueWrite backend)
     => record -> ReaderT backend m (Maybe (Entity record))
-insertUniqueEntity datum = fmap (\key -> Entity key datum) <$> insertUnique datum
+insertUniqueEntity datum =
+  fmap (\key -> Entity key datum) `liftM` insertUnique datum
 
 -- | Return the single unique key for a record.
 onlyUnique

--- a/persistent/Database/Persist/Class/PersistUnique.hs
+++ b/persistent/Database/Persist/Class/PersistUnique.hs
@@ -6,6 +6,7 @@ module Database.Persist.Class.PersistUnique
   ,PersistUniqueWrite(..)
   ,getByValue
   ,insertBy
+  ,insertUniqueEntity
   ,replaceUnique
   ,checkUnique
   ,onlyUnique)
@@ -129,6 +130,15 @@ _insertOrGet val = do
     case res of
         Nothing -> insert val
         Just (Entity key _) -> return key
+
+-- | Like 'insertEntity', but returns 'Nothing' when the record
+-- couldn't be inserted because of a uniqueness constraint.
+insertUniqueEntity
+    :: (MonadIO m
+       ,PersistRecordBackend record backend
+       ,PersistUniqueWrite backend)
+    => record -> ReaderT backend m (Maybe (Entity record))
+insertUniqueEntity datum = fmap (\key -> Entity key datum) <$> insertUnique datum
 
 -- | Return the single unique key for a record.
 onlyUnique

--- a/persistent/Database/Persist/Class/PersistUnique.hs
+++ b/persistent/Database/Persist/Class/PersistUnique.hs
@@ -133,6 +133,8 @@ _insertOrGet val = do
 
 -- | Like 'insertEntity', but returns 'Nothing' when the record
 -- couldn't be inserted because of a uniqueness constraint.
+--
+-- @since 2.7.1
 insertUniqueEntity
     :: (MonadIO m
        ,PersistRecordBackend record backend


### PR DESCRIPTION
This PR adds a `insertUniqueEntity` helper method.

This is a combination of `insertEntity` and `insertUnique`:

```haskell
insertEntity :: record -> ReaderT backend m (Entity record)

insertUnique :: record -> ReaderT backend m (Maybe (Key record))

insertUniqueEntity :: record -> ReaderT backend m (Maybe (Entity record))
```