### PR TITLE
Cache .stack-work in Travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ script: travis/run.sh
 cache:
   directories:
   - $HOME/.stack
+  - .stack-work
 
 
 # zookeeper doesn't seem to work any more


### PR DESCRIPTION
I noticed that  significant amount of the time on Travis is spent building library dependencies. This line should allow `stack` to cache the `extra-deps` libraries.