### PR TITLE
persistent-test: safer MySQL-specific rounding of time in DataTypeTest

### DIFF
--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -1,5 +1,5 @@
 name:            persistent-test
-version:         2.0.0.2
+version:         2.0.0.3
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/persistent-test/src/DataTypeTest.hs
+++ b/persistent-test/src/DataTypeTest.hs
@@ -1,5 +1,6 @@
 {-# OPTIONS_GHC -fno-warn-unused-binds #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE QuasiQuotes, TemplateHaskell, CPP, GADTs, TypeFamilies, OverloadedStrings, FlexibleContexts, EmptyDataDecls, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses #-}
 module DataTypeTest (specs) where
 

--- a/persistent-test/src/DataTypeTest.hs
+++ b/persistent-test/src/DataTypeTest.hs
@@ -11,9 +11,9 @@ import Database.Persist.TH
 import Data.Char (generalCategory, GeneralCategory(..))
 import qualified Data.Text as T
 import qualified Data.ByteString as BS
-import Data.Time (Day, UTCTime (..), fromGregorian)
-import Data.Time.Clock (picosecondsToDiffTime)
-import Data.Time.LocalTime (TimeOfDay (TimeOfDay))
+import Data.Time (Day, UTCTime (..), fromGregorian, picosecondsToDiffTime,
+                  TimeOfDay (TimeOfDay), timeToTimeOfDay, timeOfDayToTime)
+import Data.Time.Clock.POSIX (utcTimeToPOSIXSeconds, posixSecondsToUTCTime)
 import Data.IntMap (IntMap)
 import Data.Fixed (Pico,Micro)
 
@@ -122,14 +122,15 @@ roundFn = round
 
 roundTime :: TimeOfDay -> TimeOfDay
 #ifdef WITH_MYSQL
-roundTime (TimeOfDay h m s) = TimeOfDay h m (fromIntegral (roundFn s))
+roundTime t = timeToTimeOfDay $ fromIntegral $ roundFn $ timeOfDayToTime t
 #else
 roundTime = id
 #endif
 
 roundUTCTime :: UTCTime -> UTCTime
 #ifdef WITH_MYSQL
-roundUTCTime (UTCTime day time) = UTCTime day (fromIntegral (roundFn time))
+roundUTCTime t =
+    posixSecondsToUTCTime $ fromIntegral $ roundFn $ utcTimeToPOSIXSeconds t
 #else
 roundUTCTime = id
 #endif


### PR DESCRIPTION
This is just a bug fix in the test, and applies only to MySQL.  I'll merge it if/when Travis succeeds.

The bug was manifested in https://travis-ci.org/yesodweb/persistent/jobs/291041880 as

```
src/DataTypeTest.hs:74:
1) data type specs handles all types
expected: ("time",02:12:60)
but got: ("time",02:13:00)
```

and there is a similar, though much rarer, potential problem rounding UTCTime.