### PR TITLE
Fix haddocks: postfix comments on GADT fields don't work - use prefix…

### DIFF
--- a/persistent-mysql/ChangeLog.md
+++ b/persistent-mysql/ChangeLog.md
@@ -1,3 +1,7 @@
+## 2.6.2.1
+
+* Fix haddock documentation [#725](https://github.com/yesodweb/persistent/pull/725)
+
 ## 2.6.2
 
 * Extend the `SomeField` type to allow `insertManyOnDuplicateKeyUpdate` to conditionally copy values.

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -1048,12 +1048,13 @@ insertOnDuplicateKeyUpdate record =
 -- | This type is used to determine how to update rows using MySQL's
 -- @INSERT ON DUPLICATE KEY UPDATE@ functionality, exposed via
 -- 'insertManyOnDuplicateKeyUpdate' in the library.
+--
+-- @since 2.6.2
 data SomeField record where
+  -- | Copy the field directly from the record.
   SomeField :: EntityField record typ -> SomeField record
-  -- ^ Copy the field directly from the record.
+  -- | Only copy the field if it is not equal to the provided value.
   CopyUnlessEq :: PersistField typ => EntityField record typ -> typ -> SomeField record
-  -- ^ Only copy the field if it is not equal to the provided value.
-  -- @since 2.6.2
 
 -- | Copy the field into the database only if the value in the
 -- corresponding record is non-@NULL@.

--- a/persistent-mysql/persistent-mysql.cabal
+++ b/persistent-mysql/persistent-mysql.cabal
@@ -1,5 +1,5 @@
 name:            persistent-mysql
-version:         2.6.2
+version:         2.6.2.1
 license:         MIT
 license-file:    LICENSE
 author:          Felipe Lessa <felipe.lessa@gmail.com>, Michael Snoyman


### PR DESCRIPTION
Fixes #724 .  I'll release as soon as the tests complete.

It appears Haddock still has problems with postfix comments on GADT fields, but prefix style does work: https://github.com/haskell/haddock/issues/43