### PR TITLE
Make PostgreSQL `selectSource` stream results.

### DIFF
--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE BangPatterns #-}
 
 -- | A postgresql backend for persistent.
 module Database.Persist.Postgresql
@@ -356,7 +357,7 @@ withStmt' conn query vals =
     where
         closeS _= return ()
         openS  = PG.fold conn query (map P vals) CL.sourceNull processRow
-        processRow s row = return $ s >> yield (map pVal row)
+        processRow s !row = return $ s >> yield (map pVal row)
 
 -- | Avoid orphan instances.
 newtype P = P { pVal :: PersistValue }

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -356,7 +356,7 @@ withStmt' conn query vals =
     where
         closeS _= return ()
         openS  = PG.fold conn query (map P vals) CL.sourceNull processRow
-        processRow s row = return $ s >> yield (pVal <$> row)
+        processRow s row = return $ s >> yield (map pVal row)
 
 -- | Avoid orphan instances.
 newtype P = P { pVal :: PersistValue }
@@ -383,7 +383,7 @@ instance PGTF.ToField P where
 
 instance PGFF.FromField P where
     fromField _ Nothing = return . P $ PersistNull
-    fromField f mdata   = P <$> (getGetter (PGFF.typeOid f) f mdata)
+    fromField f mdata   = P `fmap` (getGetter (PGFF.typeOid f) f mdata)
 
 newtype Unknown = Unknown { unUnknown :: ByteString }
   deriving (Eq, Show, Read, Ord, Typeable)

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -352,71 +352,14 @@ withStmt' :: MonadIO m
           -> [PersistValue]
           -> Acquire (ConduitM () [PersistValue] m ())
 withStmt' conn query vals =
-    pull `fmap` mkAcquire openS closeS
-  where
-    openS = do
-      -- Construct raw query
-      rawquery <- PG.formatQuery conn query (map P vals)
-
-      -- Take raw connection
-      (rt, rr, rc, ids) <- PG.withConnection conn $ \rawconn -> do
-            -- Execute query
-            mret <- LibPQ.exec rawconn rawquery
-            case mret of
-              Nothing -> do
-                merr <- LibPQ.errorMessage rawconn
-                fail $ case merr of
-                         Nothing -> "Postgresql.withStmt': unknown error"
-                         Just e  -> "Postgresql.withStmt': " ++ B8.unpack e
-              Just ret -> do
-                -- Check result status
-                status <- LibPQ.resultStatus ret
-                case status of
-                  LibPQ.TuplesOk -> return ()
-                  _ -> PG.throwResultError "Postgresql.withStmt': bad result status " ret status
-
-                -- Get number and type of columns
-                cols <- LibPQ.nfields ret
-                oids <- forM [0..cols-1] $ \col -> fmap ((,) col) (LibPQ.ftype ret col)
-                -- Ready to go!
-                rowRef   <- newIORef (LibPQ.Row 0)
-                rowCount <- LibPQ.ntuples ret
-                return (ret, rowRef, rowCount, oids)
-      let getters
-            = map (\(col, oid) -> getGetter conn oid $ PG.Field rt col oid) ids
-      return (rt, rr, rc, getters)
-
-    closeS (ret, _, _, _) = LibPQ.unsafeFreeResult ret
-
-    pull x = do
-        y <- liftIO $ pullS x
-        case y of
-            Nothing -> return ()
-            Just z -> yield z >> pull x
-
-    pullS (ret, rowRef, rowCount, getters) = do
-        row <- atomicModifyIORef rowRef (\r -> (r+1, r))
-        if row == rowCount
-           then return Nothing
-           else fmap Just $ forM (zip getters [0..]) $ \(getter, col) -> do
-                                mbs <- LibPQ.getvalue' ret row col
-                                case mbs of
-                                  Nothing ->
-                                    -- getvalue' verified that the value is NULL.
-                                    -- However, that does not mean that there are
-                                    -- no NULL values inside the value (e.g., if
-                                    -- we're dealing with an array of optional values).
-                                    return PersistNull
-                                  Just bs -> do
-                                    ok <- PGFF.runConversion (getter mbs) conn
-                                    bs `seq` case ok of
-                                                        Errors (exc:_) -> throw exc
-                                                        Errors [] -> error "Got an Errors, but no exceptions"
-                                                        Ok v  -> return v
+    mkAcquire openS closeS
+    where
+        closeS _= return ()
+        openS  = PG.fold conn query (map P vals) CL.sourceNull processRow
+        processRow s row = return $ s >> yield (pVal <$> row)
 
 -- | Avoid orphan instances.
-newtype P = P PersistValue
-
+newtype P = P { pVal :: PersistValue }
 
 instance PGTF.ToField P where
     toField (P (PersistText t))        = PGTF.toField t
@@ -437,6 +380,10 @@ instance PGTF.ToField P where
     toField (P (PersistArray a))       = PGTF.toField $ PG.PGArray $ P <$> a
     toField (P (PersistObjectId _))    =
         error "Refusing to serialize a PersistObjectId to a PostgreSQL value"
+
+instance PGFF.FromField P where
+    fromField _ Nothing = return . P $ PersistNull
+    fromField f mdata   = P <$> (getGetter (PGFF.typeOid f) f mdata)
 
 newtype Unknown = Unknown { unUnknown :: ByteString }
   deriving (Eq, Show, Read, Ord, Typeable)
@@ -524,8 +471,8 @@ builtinGetters = I.fromList
         listOf f = convertPV (PersistList . map (nullable f) . PG.fromPGArray)
           where nullable = maybe PersistNull
 
-getGetter :: PG.Connection -> PG.Oid -> Getter PersistValue
-getGetter _conn oid
+getGetter :: PG.Oid -> Getter PersistValue
+getGetter oid
   = fromMaybe defaultGetter $ I.lookup (PG.oid2int oid) builtinGetters
   where defaultGetter = convertPV (PersistDbSpecific . unUnknown)
 


### PR DESCRIPTION
Address #657 for `persistent-postgres`.

With this, persistent effectively will support streaming results when using `selectSource` for all* sql backends.

*MySQL streaming is available in [persistent-mysql-haskell](https://hackage.haskell.org/package/persistent-mysql-haskell) backend.