### PR TITLE
Revert "Cache .stack-work in Travis script"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,6 @@ script: travis/run.sh
 cache:
   directories:
   - $HOME/.stack
-  - .stack-work
 
 
 # zookeeper doesn't seem to work any more


### PR DESCRIPTION
Reverts yesodweb/persistent#719

This change did give a useful speed up for the lts-2 tests, but actually slowed down the tests for lts-6 and later by one to one-and-a-half minutes each.  The overall gain is therefore quite small, and in any case we will probably stop testing against lts-2 fairly soon.  Therefore it seems best to err on the side of keeping the tests as clean as possible.