### PR TITLE
pass Connection into step, so it can be provided to sqlError

### DIFF
--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -136,7 +136,7 @@ wrapConnectionInfo connInfo conn logFunc = do
         -- Turn on the write-ahead log
         -- https://github.com/yesodweb/persistent/issues/363
         turnOnWal <- Sqlite.prepare conn "PRAGMA journal_mode=WAL;"
-        _ <- Sqlite.step turnOnWal
+        _ <- Sqlite.step conn turnOnWal
         Sqlite.reset conn turnOnWal
         Sqlite.finalize turnOnWal
 
@@ -144,7 +144,7 @@ wrapConnectionInfo connInfo conn logFunc = do
         -- Turn on foreign key constraints
         -- https://github.com/yesodweb/persistent/issues/646
         turnOnFK <- Sqlite.prepare conn "PRAGMA foreign_keys = on;"
-        _ <- Sqlite.step turnOnFK
+        _ <- Sqlite.step conn turnOnFK
         Sqlite.reset conn turnOnFK
         Sqlite.finalize turnOnFK
 
@@ -253,7 +253,7 @@ insertSql' ent vals =
 execute' :: Sqlite.Connection -> Sqlite.Statement -> [PersistValue] -> IO Int64
 execute' conn stmt vals = flip finally (liftIO $ Sqlite.reset conn stmt) $ do
     Sqlite.bind stmt vals
-    _ <- Sqlite.step stmt
+    _ <- Sqlite.step conn stmt
     Sqlite.changes conn
 
 withStmt'
@@ -269,7 +269,7 @@ withStmt' conn stmt vals = do
     return pull
   where
     pull = do
-        x <- liftIO $ Sqlite.step stmt
+        x <- liftIO $ Sqlite.step conn stmt
         case x of
             Sqlite.Done -> return ()
             Sqlite.Row -> do

--- a/persistent-sqlite/Database/Sqlite.hs
+++ b/persistent-sqlite/Database/Sqlite.hs
@@ -254,13 +254,13 @@ stepError :: Statement -> IO Error
 stepError (Statement statement) = do
   error <- stepC statement
   return $ decodeError error
-step :: Statement -> IO StepResult
-step statement = do
+step :: Connection -> Statement -> IO StepResult
+step database statement = do
   error <- stepError statement
   case error of
     ErrorRow -> return Row
     ErrorDone -> return Done
-    _ -> sqlError Nothing "step" error
+    _ -> sqlError (Just database) "step" error
 
 foreign import ccall "sqlite3_reset"
   resetC :: Ptr () -> IO Int


### PR DESCRIPTION
This gives us a more informative error message than "SQLite3 returned
ErrorError while attempting to perform step.", which isn't a very good
starting point for debugging.

I don't know whether there was a good reason it wasn't done this way originally - I dug a bit (across a few repositories) but wasn't able to find where that code originated.