### PR TITLE
Sqlite: do not add foreign key constraints to temporary tables

### DIFF
--- a/persistent-sqlite/ChangeLog.md
+++ b/persistent-sqlite/ChangeLog.md
@@ -1,3 +1,7 @@
+## 2.6.3.1
+
+* Fix migration to avoid creating foreign-key constraints in temporary tables [#736](https://github.com/yesodweb/persistent/pull/736)
+
 ## 2.6.3
 
 * Add 'use-pkgconfig' flag to use pkg-config to find system SQLite library.

--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -429,7 +429,7 @@ mkCreateTable isTemp entity (cols, uniqs) =
         , " TABLE "
         , escape $ entityDB entity
         , "("
-        , T.drop 1 $ T.concat $ map sqlColumn cols
+        , T.drop 1 $ T.concat $ map (sqlColumn isTemp) cols
         , ", PRIMARY KEY "
         , "("
         , T.intercalate "," $ map (escape . fieldDB) $ compositeFields pdef
@@ -447,7 +447,7 @@ mkCreateTable isTemp entity (cols, uniqs) =
         , showSqlType $ fieldSqlType $ entityId entity
         ," PRIMARY KEY"
         , mayDefault $ defaultAttribute $ fieldAttrs $ entityId entity
-        , T.concat $ map sqlColumn cols
+        , T.concat $ map (sqlColumn isTemp) cols
         , T.concat $ map sqlUnique uniqs
         , ")"
         ]
@@ -457,8 +457,8 @@ mayDefault def = case def of
     Nothing -> ""
     Just d -> " DEFAULT " <> d
 
-sqlColumn :: Column -> Text
-sqlColumn (Column name isNull typ def _cn _maxLen ref) = T.concat
+sqlColumn :: Bool -> Column -> Text
+sqlColumn noRef (Column name isNull typ def _cn _maxLen ref) = T.concat
     [ ","
     , escape name
     , " "
@@ -467,7 +467,7 @@ sqlColumn (Column name isNull typ def _cn _maxLen ref) = T.concat
     , mayDefault def
     , case ref of
         Nothing -> ""
-        Just (table, _) -> " REFERENCES " <> escape table
+        Just (table, _) -> if noRef then "" else " REFERENCES " <> escape table
     ]
 
 sqlUnique :: UniqueDef -> Text

--- a/persistent-sqlite/persistent-sqlite.cabal
+++ b/persistent-sqlite/persistent-sqlite.cabal
@@ -1,5 +1,5 @@
 name:            persistent-sqlite
-version:         2.6.3
+version:         2.6.3.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -187,6 +187,8 @@ executable persistent-test
                  , resourcet
                  , scientific
 
+  if !flag(postgresql) && !flag(mysql) && !flag(mongodb) && !flag(zookeeper)
+      cpp-options: -DWITH_SQLITE -DDEBUG
   if flag(zookeeper)
       cpp-options: -DWITH_NOSQL -DWITH_ZOOKEEPER -DDEBUG
   if flag(mongodb)


### PR DESCRIPTION
Fixes #735 

@MaxGabriel,  @psibi would one of you mind checking my logic, please?  The issue is that migration can involve creating a temporary table, and we were adding foreign key constraints that existed in the table being copied.  Sqlite doesn't handle FK constraints from temporary tables to non-temporary ones - it probably doesn't make sense to do so - and when checking is switched on, it reports them as violated.

The fix is simply to omit the FK constraint from the temporary table!