### PR TITLE
More verbose error messages when failing to parse database results in…

### DIFF
--- a/persistent-template/ChangeLog.md
+++ b/persistent-template/ChangeLog.md
@@ -1,3 +1,7 @@
+## 2.5.3.1
+
+* Slight improvement to the error message when a Persistent field can't be parsed from database results
+
 ## 2.5.3
 
 * Exposed `parseReferences` to allow custom QuasiQuoters

--- a/persistent-template/Database/Persist/TH.hs
+++ b/persistent-template/Database/Persist/TH.hs
@@ -615,7 +615,7 @@ mapLeft _ (Right r) = Right r
 mapLeft f (Left l)  = Left (f l)
 
 fieldError :: Text -> Text -> Text
-fieldError fieldName err = "field " `mappend` fieldName `mappend` ": " `mappend` err
+fieldError fieldName err = "Couldn't parse field `" `mappend` fieldName `mappend` "` from database results: " `mappend` err
 
 mkFromPersistValues :: MkPersistSettings -> EntityDef -> Q [Clause]
 mkFromPersistValues _ t@(EntityDef { entitySum = False }) =

--- a/persistent-template/persistent-template.cabal
+++ b/persistent-template/persistent-template.cabal
@@ -1,5 +1,5 @@
 name:            persistent-template
-version:         2.5.3
+version:         2.5.3.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,3 +1,8 @@
+## 2.7.3.1
+ 
+ * Improve error messages when failing to parse database results into Persistent records.
+ * A handful of `fromPersistField` implementations called `error` instead of returning a `Left Text`. All of the implementations were changed to return `Left`.
+
 ## 2.7.3 
 
 * Reverts [#723](https://github.com/yesodweb/persistent/pull/723), which generalized functions using the `BackendCompatible` class. These changes were an accidental breaking change.

--- a/persistent/Database/Persist/Class/PersistField.hs
+++ b/persistent/Database/Persist/Class/PersistField.hs
@@ -163,7 +163,7 @@ extraInputError :: (Show result)
                 -> result -- ^ Integer result
                 -> ByteString -- ^  Extra bytestring
                 -> Text -- ^ Error message
-extraInputError haskellType original result extra = mconcat
+extraInputError haskellType original result extra = T.concat
     [ "Parsed "
     , TE.decodeUtf8 original
     , " into Haskell type `"
@@ -177,7 +177,7 @@ extraInputError haskellType original result extra = mconcat
 intParseError :: Text -- ^ Haskell type
               -> ByteString -- ^ Original bytestring
               -> Text -- ^ Error message
-intParseError haskellType original = mconcat
+intParseError haskellType original = T.concat
     [ "Failed to parse Haskell type `"
     , haskellType
     , " from "

--- a/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
@@ -320,7 +320,7 @@ instance PersistStoreRead SqlBackend where
                 Nothing -> return Nothing
                 Just vals ->
                     case fromPersistValues $ if noColumns then [] else vals of
-                        Left e -> error $ "get " ++ show k ++ ": " ++ unpack e
+                        Left e -> error $ "Error when calling `get` with key: " ++ show k ++ ". Failed to create `" ++ (unpack (unHaskellName $ entityHaskell t)) ++  "` because of error: " ++ unpack e ++ " Potential solution: If your field is using a custom PersistField instance, check that it's correct."
                         Right v -> return $ Just v
 instance PersistStoreRead SqlReadBackend where
     get k = withReaderT persistBackend $ get k

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:            persistent
-version:         2.7.3
+version:         2.7.3.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
…to Persistent records

Closes  #689

Previous error message, as reported in #689:

> "get UserKey {unUserKey = SqlBackendKey {unSqlBackendKey = 1}}: field foo: int Expected Integer, received: PersistText "foo"

New error message:

> Error when calling `get` with key: UserKey {unUserKey = SqlBackendKey {unSqlBackendKey = 1}}. Failed to create `User` because of error: Couldn't parse field `foo` from database results: Tried to parse Haskell type `Int`, expected integer from database, but received: PersistText "foo". Potential solution: Check that your database schema matches your Persistent model definitions. Potential solution: If this is a custom PersistField instance, check that it's correct.

This is maybe a little bit more verbose than ideal, imo, but I lean towards a verbose error message because you should only see this error message if your PersistField instances are incorrect, or your database schema doesn't match your persist model definitions (afaik). It's also kind of hard to make a clean error message because the error is constructed from several different locations in the code.

Specific improvements:

1. In the message: `field foo: int Expected Integer, received: PersistText "foo"`, it's totally unclear what `int` is, and calling it `int` doesn't suggest that it's a Haskell type (vs Int).
2. Make recommendations about potential solutions. Afaik these are the only solutions to this problem?
3. Highlight the function being called. I think because it's just `get` it's hard to realize that function is the root of the problem.

**Behavior change**: A handful of the PersistField parsing functions called `error` instead of returning `Left Text`. I think since the vast majority returned `Left` that it's fine to change this. I also can't imagine anyone is relying on the error vs left distinction, especially because higher level functions like `get` just call `error` themselves on a `Left`.