### PR TITLE
Fix mysql sqltype migrations [#752]

### DIFF
--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -627,13 +627,9 @@ parseColumnType "decimal" ci                                   =
 -- Text
 parseColumnType "varchar" ci                                   = return (SqlString, ciMaxLength ci)
 parseColumnType "text" _                                       = return (SqlString, Nothing)
-parseColumnType "mediumtext" _                                 = return (SqlString, Nothing)
-parseColumnType "longtext" _                                   = return (SqlString, Nothing)
 -- ByteString
 parseColumnType "varbinary" ci                                 = return (SqlBlob, ciMaxLength ci)
 parseColumnType "blob" _                                       = return (SqlBlob, Nothing)
-parseColumnType "mediumblob" _                                 = return (SqlBlob, Nothing)
-parseColumnType "longblob" _                                   = return (SqlBlob, Nothing)
 -- Time-related
 parseColumnType "time" _                                       = return (SqlTime, Nothing)
 parseColumnType "datetime" _                                   = return (SqlDayTime, Nothing)

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -617,7 +617,7 @@ parseColumnType "tinyint" ci | ciColumnType ci == "tinyint(1)" = return (SqlBool
 parseColumnType "int" ci | ciColumnType ci == "int(11)"        = return (SqlInt32, Nothing)
 parseColumnType "bigint" ci | ciColumnType ci == "bigint(20)"  = return (SqlInt64, Nothing)
 -- Double
-parseColumnType "double" _                                     = return (SqlReal, Nothing)
+parseColumnType x@("double") ci | ciColumnType ci == x         = return (SqlReal, Nothing)
 parseColumnType "decimal" ci                                   =
   case (ciNumericPrecision ci, ciNumericScale ci) of
     (PersistInt64 p, PersistInt64 s) ->

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -69,6 +69,7 @@ library
                      SumTypeTest
                      MigrationOnlyTest
                      MigrationTest
+                     MigrationIdempotencyTest
                      PersistUniqueTest
                      CompositeTest
                      Init

--- a/persistent-test/src/MigrationIdempotencyTest.hs
+++ b/persistent-test/src/MigrationIdempotencyTest.hs
@@ -18,7 +18,10 @@ Idempotency
     field1 Int
     field2 T.Text sqltype=varchar(5)
     field3 T.Text sqltype=mediumtext
-    field4 Double sqltype=double(6,5)
+    field4 T.Text sqltype=longtext
+    field5 T.Text sqltype=mediumblob
+    field6 T.Text sqltype=longblob
+    field7 Double sqltype=double(6,5)
 |]
 
 

--- a/persistent-test/src/MigrationIdempotencyTest.hs
+++ b/persistent-test/src/MigrationIdempotencyTest.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE QuasiQuotes, TemplateHaskell, CPP, GADTs, TypeFamilies, OverloadedStrings, FlexibleContexts, EmptyDataDecls  #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+module MigrationIdempotencyTest where
+
+import Database.Persist.TH
+import qualified Data.Text as T
+
+import Init
+
+#ifdef WITH_NOSQL
+mkPersist persistSettings [persistUpperCase|
+#else
+share [mkPersist sqlSettings, mkMigrate "migration"] [persistLowerCase|
+#endif
+Idempotency
+    field1 Int
+    field2 T.Text sqltype=varchar(5)
+    field3 T.Text sqltype=mediumtext
+    field4 Double sqltype=double(6,5)
+|]
+
+
+specs :: Spec
+specs = describe "MySQL migration with backend-specific sqltypes" $ do
+#ifdef WITH_NOSQL
+    return ()
+#else
+  it "is idempotent" $ db $ do
+      again <- getMigration migration
+      liftIO $ again @?= []
+#endif

--- a/persistent-test/test/main.hs
+++ b/persistent-test/test/main.hs
@@ -31,6 +31,10 @@ import qualified MigrationTest
 #  endif
 #endif
 
+#ifdef WITH_MYSQL
+import qualified MigrationIdempotencyTest
+#endif
+
 
 #ifdef WITH_NOSQL
 #else
@@ -71,6 +75,7 @@ main = do
 #  endif
 #  ifdef WITH_MYSQL
       , InsertDuplicateUpdate.duplicateMigrate
+      , MigrationIdempotencyTest.migration
 #  endif
       , CustomPrimaryKeyReferenceTest.migration
       ]
@@ -100,4 +105,7 @@ main = do
 
 #ifdef WITH_SQLITE
     MigrationTest.specs
+#endif
+#ifdef WITH_MYSQL
+    MigrationIdempotencyTest.specs
 #endif


### PR DESCRIPTION
A fix and a test for MySQL migrations containing certain backend-specific sqltypes (i.e. `mediumtext`, `longtext`, `mediumblob`, `longblob` and custom precision `double`).

Closes #752