### PR TITLE
Improve error message when a SQL insert fails with a custom primary key

### DIFF
--- a/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
@@ -163,7 +163,7 @@ instance PersistStoreWrite SqlBackend where
                             Right k -> return k
                         Nothing -> error $ "SQL insert did not return a result giving the generated ID"
                         Just vals' -> case keyFromValues vals' of
-                            Left _ -> error $ "Invalid result from a SQL insert, got: " ++ show vals'
+                            Left e -> error $ "Invalid result from a SQL insert, got: " ++ show vals' ++ ". Error was: " ++ unpack e
                             Right k -> return k
 
                 ISRInsertGet sql1 sql2 -> do


### PR DESCRIPTION
My coworker was using a custom primary key like so:

```
User sql=users
    Id sqltype=uuid default=uuid_generate_v4
    email Email sqltype=text
    UniqueEmail email
    createdAt UTCTime
    modifiedAt UTCTime
    deriving Show Eq Typeable
```

But didn't specify the type of the Id to be UUID. This caused Persistent to expect an Int64, leading to a very confusing error message on insert:

```
*** Exception: runFakeHandler issue: InternalError "Invalid result from a SQL insert, got: [PersistDbSpecific \"70c2418d-fb00-43f7-818d-eaf962612030\"]
```

By providing the actual underlying error, it gets much clearer:

```
*** Exception: runFakeHandler issue: InternalError "Invalid result from a SQL insert, got: [PersistDbSpecific \"70c2418d-fb00-43f7-818d-eaf962612030\"]. Error was: \"int64 Expected Integer, received: PersistDbSpecific \\\"70c2418d-fb00-43f7-818d-eaf962612030\\\"\"
```

Not sure if a new version is necessary for this, but I'm holding off since the `master` version of Persistent is deprecated anyway.