### PR TITLE
Re-release Persistent 2.7.2 as 2.8

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,9 +1,11 @@
-## 2.7.2.1
+## 2.8
 
+* Re-releases 2.7.2 as a major version bump
 * Recommend the `PersistDbSpecific` docs if someone gets an error about converting from `PersistDbSpecific`
 
-## 2.7.2
+## 2.7.2 [DEPRECATED]
 
+* This version accidentally introduced a breaking change and is deprecated.
 * Many of the functions have been generalized using the `BackendCompatible` class. [#723](https://github.com/yesodweb/persistent/pull/723)
 * Add raw sql quasi quoters [#717](https://github.com/yesodweb/persistent/pull/717)
 

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:            persistent
-version:         2.7.2.1
+version:         2.8
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
Rolls 2.7.2.1 into 2.8, since it was never released (I don't want to release it separately then deprecate 2.7.2.1 on hackage)

Closes #740 