### PR TITLE
[persistent-mysql] Rename SomeField type to HandleUpdateCollision

### DIFF
--- a/persistent-mysql/ChangeLog.md
+++ b/persistent-mysql/ChangeLog.md
@@ -4,6 +4,9 @@
 
 -- This can be released as a minor change on the next update. Currently persistent-mysql can't be released because 2.6.2.2 depends on persistent-2.7.2 being released.
 
+* The `SomeField` type was renamed to `HandleUpdateCollision` and deprecated. Please migrate to using `HandleUpdateCollision`.
+* The `SomeField` constructor was deprecated, and a temporary pattern synonym introduced. Please migrate to using `copyField`.
+
 ## 2.6.2.2 [UNRELEASED ON HACKAGE]
 
 -- This version depends on persistent 2.7.2, which introduced breaking changes and is deprecated on hackage.

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -24,7 +24,7 @@ module Database.Persist.MySQL
 #if MIN_VERSION_base(4,7,0)
     , HandleUpdateCollision
     , pattern SomeField
-#elif MIN_VERSION_BASE(4,9,0)
+#elif MIN_VERSION_base(4,9,0)
     , HandleUpdateCollision(SomeField)
 #endif
     , SomeField

--- a/persistent-test/src/InsertDuplicateUpdate.hs
+++ b/persistent-test/src/InsertDuplicateUpdate.hs
@@ -60,7 +60,7 @@ specs = describe "DuplicateKeyUpdate" $ do
       let newItem = Item "item3" "fresh" Nothing Nothing
       insertManyOnDuplicateKeyUpdate
         (newItem : items)
-        [SomeField ItemDescription]
+        [copyField ItemDescription]
         []
       dbItems <- map entityVal <$> selectList [] []
       sort dbItems @== sort (newItem : items)
@@ -79,7 +79,7 @@ specs = describe "DuplicateKeyUpdate" $ do
       insertManyOnDuplicateKeyUpdate
         newItems
         [ copyUnlessEq ItemQuantity (Just 0)
-        , SomeField ItemPrice
+        , copyField ItemPrice
         ]
         []
       dbItems <- sort . fmap entityVal <$> selectList [] []

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,3 +8,7 @@ packages:
   - ./persistent-mysql
   - ./persistent-postgresql
   - ./persistent-redis
+
+
+extra-deps:
+- mysql-simple-0.4.4


### PR DESCRIPTION
I want to get this in before 3.0 :smile: 

`SomeField` worked as a name before the responsibility of the type grew. Renaming it makes it more clear what it does and what it is for. Hiding the constructors allows us to add additional combinators without them being breaking changes -- I want to add `copyUnlessIn`, `modifyUsing` and possibly others at some point.

I'm not 100% on the new type alias and pattern constructor for `SomeField`. They'll prevent it from breaking with a compile error and instead issue a deprecation notice for migration, which is helpful, but also extends the amount of backwards compatibility cruft we have to carry around.