### PR TITLE
Don't migrate between text and varchar in Postgres / domains

### DIFF
--- a/persistent-postgresql/ChangeLog.md
+++ b/persistent-postgresql/ChangeLog.md
@@ -1,3 +1,7 @@
+## 2.6.2.2
+
+* Because `text` and `varchar` are synonyms in Postgresql, don't attempt to migrate between them. [#762](https://github.com/yesodweb/persistent/pull/762)
+
 ## 2.6.2.1
 
 * Fix bug where, if a custom column width was set, the field would be migrated every time [#742](https://github.com/yesodweb/persistent/pull/742)

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -619,7 +619,7 @@ mayDefault def = case def of
 
 type SafeToRemove = Bool
 
-data AlterColumn = Type SqlType Text
+data AlterColumn = ChangeType SqlType Text
                  | IsNull | NotNull | Add' Column | Drop SafeToRemove
                  | Default Text | NoDefault | Update' Text
                  | AddReference DBName [DBName] [Text] | DropReference DBName
@@ -640,7 +640,7 @@ getColumns getter def = do
     let sqlv=T.concat ["SELECT "
                           ,"column_name "
                           ,",is_nullable "
-                          ,",udt_name "
+                          ,",COALESCE(domain_name, udt_name)" -- See DOMAINS below
                           ,",column_default "
                           ,",numeric_precision "
                           ,",numeric_scale "
@@ -650,6 +650,12 @@ getColumns getter def = do
                           ,"AND table_schema=current_schema() "
                           ,"AND table_name=? "
                           ,"AND column_name <> ?"]
+
+-- DOMAINS Postgres supports the concept of domains, which are data types with optional constraints.
+-- An app might make an "email" domain over the varchar type, with a CHECK that the emails are valid
+-- In this case the generated SQL should use the domain name: ALTER TABLE users ALTER COLUMN foo TYPE email
+-- This code exists to use the domain name (email), instead of the underlying type (varchar).
+-- This is tested in EquivalentTypeTest.hs
 
     stmt <- getter sqlv
     let vals =
@@ -852,12 +858,12 @@ findAlters defs _tablename col@(Column name isNull sqltype def _defConstraintNam
                     -- need to make sure that TIMESTAMP WITHOUT TIME ZONE is
                     -- treated as UTC.
                     | sqltype == SqlDayTime && sqltype' == SqlOther "timestamp" =
-                        [(name, Type sqltype $ T.concat
+                        [(name, ChangeType sqltype $ T.concat
                             [ " USING "
                             , escape name
                             , " AT TIME ZONE 'UTC'"
                             ])]
-                    | otherwise = [(name, Type sqltype "")]
+                    | otherwise = [(name, ChangeType sqltype "")]
                 modDef =
                     if def == def'
                         then []
@@ -936,7 +942,7 @@ showAlterTable table (DropConstraint cname) = T.concat
     ]
 
 showAlter :: DBName -> AlterColumn' -> Text
-showAlter table (n, Type t extra) =
+showAlter table (n, ChangeType t extra) =
     T.concat
         [ "ALTER TABLE "
         , escape table

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -801,6 +801,7 @@ getColumn getter tname [PersistText x, PersistText y, PersistText z, d, npre, ns
     getType "int4"        = Right SqlInt32
     getType "int8"        = Right SqlInt64
     getType "varchar"     = Right SqlString
+    getType "text"        = Right SqlString
     getType "date"        = Right SqlDay
     getType "bool"        = Right SqlBool
     getType "timestamptz" = Right SqlDayTime

--- a/persistent-postgresql/persistent-postgresql.cabal
+++ b/persistent-postgresql/persistent-postgresql.cabal
@@ -1,5 +1,5 @@
 name:            persistent-postgresql
-version:         2.6.2.1
+version:         2.6.2.2
 license:         MIT
 license-file:    LICENSE
 author:          Felipe Lessa, Michael Snoyman <michael@snoyman.com>

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -79,6 +79,7 @@ library
                      CustomPrimaryKeyReferenceTest
                      InsertDuplicateUpdate
                      MigrationColumnLengthTest
+                     EquivalentTypeTest
 
     hs-source-dirs: src, test
 

--- a/persistent-test/src/EquivalentTypeTest.hs
+++ b/persistent-test/src/EquivalentTypeTest.hs
@@ -5,7 +5,9 @@ module EquivalentTypeTest (specs) where
 
 import Database.Persist.TH
 import Control.Monad.Trans.Resource (runResourceT)
+#ifdef WITH_POSTGRESQL
 import qualified Data.Text as T
+#endif
 
 import Init
 

--- a/persistent-test/src/EquivalentTypeTest.hs
+++ b/persistent-test/src/EquivalentTypeTest.hs
@@ -18,6 +18,7 @@ EquivalentType sql=equivalent_types
     field1 Int
 #ifdef WITH_POSTGRESQL
     field2 T.Text sqltype=text
+    field3 T.Text sqltype=us_postal_code
 #endif
     deriving Eq Show
 |]
@@ -31,6 +32,7 @@ EquivalentType2 sql=equivalent_types
     field1 Int
 #ifdef WITH_POSTGRESQL
     field2 T.Text
+    field3 T.Text sqltype=us_postal_code
 #endif
     deriving Eq Show
 |]
@@ -38,6 +40,12 @@ EquivalentType2 sql=equivalent_types
 specs :: Spec
 specs = describe "doesn't migrate equivalent types" $ do
     it "works" $ asIO $ runResourceT $ runConn $ do
+
+#ifdef WITH_POSTGRESQL
+        _ <- rawExecute "DROP DOMAIN IF EXISTS us_postal_code" []
+        _ <- rawExecute "CREATE DOMAIN us_postal_code AS TEXT CHECK(VALUE ~ '^\\d{5}$')" []
+#endif
+
 #ifndef WITH_NOSQL
         _ <- runMigrationSilent migrateAll1
         xs <- getMigration migrateAll2

--- a/persistent-test/src/EquivalentTypeTest.hs
+++ b/persistent-test/src/EquivalentTypeTest.hs
@@ -51,10 +51,11 @@ specs = describe "doesn't migrate equivalent types" $ do
 #ifndef WITH_NOSQL
         _ <- runMigrationSilent migrateAll1
         xs <- getMigration migrateAll2
-#else
-        let xs = []
-#endif
         liftIO $ xs @?= []
+#else
+        return ()
+#endif
+        
 
 asIO :: IO a -> IO a
 asIO = id

--- a/persistent-test/test/main.hs
+++ b/persistent-test/test/main.hs
@@ -21,9 +21,8 @@ import qualified RenameTest
 import qualified SumTypeTest
 import qualified InsertDuplicateUpdate
 import qualified UniqueTest
--- #if defined(WITH_POSTGRESQL) || defined(WITH_MYSQL)
 import qualified MigrationColumnLengthTest
--- #endif
+import qualified EquivalentTypeTest
 
 #ifndef WITH_NOSQL
 #  ifdef WITH_SQLITE
@@ -107,6 +106,7 @@ main = do
     CustomPrimaryKeyReferenceTest.specs
     InsertDuplicateUpdate.specs
     MigrationColumnLengthTest.specs
+    EquivalentTypeTest.specs
 
 #ifdef WITH_SQLITE
     MigrationTest.specs


### PR DESCRIPTION
* These types are synonyms, with the exact same memory representation in Postgres
* So there's no need to suggest migrating from one to the other https://stackoverflow.com/a/4849030/1176156

My use case is that I have a database not using Persistent for migrations, and I want to use persistent to interact with it. I would also like to check that Persistent's models match the database schema by running `getMigration` and ensuring there are no changes to be made, but if there are spurious migrations then I'll have false positives.

In this database, `text` is being used instead of `varchar`, so Persistent claims it needs migrations. Since `text` and `varchar` are synonyms, this should be unnecessary.

**Edit:**

I found another, similar issue where Persistent would try to migrate a domained type to itself. This needed all the same test infrastructure and has the same theme, so I added it here. This is documented extensively in the comments; see there for details.