### PR TITLE
Fix persistent-redis for Stackage lts-10

### DIFF
--- a/persistent-redis/ChangeLog.md
+++ b/persistent-redis/ChangeLog.md
@@ -1,3 +1,7 @@
+# 2.5.2.1
+
+* Relax time constraint
+
 # 0.3.3
 
 * support http-api-data for url serialization

--- a/persistent-redis/persistent-redis.cabal
+++ b/persistent-redis/persistent-redis.cabal
@@ -1,5 +1,5 @@
 name:            persistent-redis
-version:         2.5.2
+version:         2.5.2.1
 license:         BSD3
 license-file:    LICENSE
 author:          Pavel Ryzhov <paul@paulrz.cz>
@@ -23,7 +23,7 @@ library
                    , persistent            >= 2.5      && < 3.0
                    , text                  >= 1.2.0.0
                    , aeson                 >= 0.8
-                   , time                  >= 1.4      && < 1.7
+                   , time                  >= 1.4      && < 1.9
                    , attoparsec            >= 0.12.0.0
                    , mtl                   >= 2.2.0    && < 2.3
                    , transformers          >= 0.4.0.0  && < 0.6.0.0


### PR DESCRIPTION
`persistent-redis` is out of Stackage. With this PR, I'm planning to bring it back.

@snoyberg Can you upload a new version to Hackage ( or alternatively can you give me Hackage access to that) ?