### PR TITLE
Don't require a `test` directory to exist when running SQLite tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ TAGS
 
 ## databases
 test.db3
-persistent-test/test/testdb.sqlite3
+*.sqlite3
 
 # ?
 tarballs/

--- a/persistent-test/src/Init.hs
+++ b/persistent-test/src/Init.hs
@@ -225,7 +225,7 @@ persistSettings = sqlSettings { mpsGeneric = True }
 type BackendMonad = SqlBackend
 #  ifdef WITH_SQLITE
 sqlite_database_file :: Text
-sqlite_database_file = "test/testdb.sqlite3"
+sqlite_database_file = "testdb.sqlite3"
 sqlite_database :: SqliteConnectionInfo
 sqlite_database = mkSqliteConnectionInfo sqlite_database_file
 #  else


### PR DESCRIPTION
An alternate implementation would be creating the test directory, but that seemed unnecessary and just more confusing, if there was only one file being put into that directory

Closes https://github.com/yesodweb/persistent/issues/745