### PR TITLE
Add Github templates and files to help with reproducing issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,32 @@
+<!---
+
+### Bug Reports
+
+Reporting a bug? If relevant, we recommend including:
+
+* Your OS name and version
+* The versions of tools you're using (e.g. `stack`, `ghc`).
+* The versions of dependencies you're using
+
+For your convenience, we recommend pasting this script into bash and uploading the output [as a gist](https://gist.github.com/).
+
+```
+command -v sw_vers && sw_vers # OS X only
+command -v uname && uname -a # Kernel version
+command -v stack && stack --version
+command -v stack && stack ghc -- --version
+command -v stack && stack list-dependencies
+command -v psql && psql --version
+command -v mysql && mysql --version
+command -v mongo && mongo --version
+command -v sqlite3 && sqlite3 --version
+```
+
+* Also, is there anything custom or unusual about your setup? i.e. new or prerelease versions of GHC, stack, your database, etc.
+
+* Finally, if possible, please reproduce the error in a small script; we have created [a script for each backend](https://github.com/yesodweb/persistent/tree/master/.github/reproductionTemplates) with a minimal setup to use for this purpose. These are made with [Stack's scripting support](https://docs.haskellstack.org/en/stable/GUIDE/#script-interpreter) and can be run as `./file-name.hs`. Even better, writing a failing test case is tremendously helpful.
+
+### Support
+
+Please direct support questions to [Stack Overflow](https://stackoverflow.com/questions/tagged/persistent+haskell) or the [Yesod Google Group](https://groups.google.com/forum/#!forum/yesodweb). If you don't get a response there, or you suspect there may be a bug in Persistent causing your problem, you're welcome to ask here.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+Before submitting your PR, check that you've:
+
+- [ ] Bumped the version number
+- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
+- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
+
+After submitting your PR:
+
+- [ ] Update the Changelog.md file with a link to your PR
+- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)
+
+<!---Thanks so much for contributing! :)
+
+_If these checkboxes don't apply to your PR, you can delete them_-->

--- a/.github/reproductionTemplates/mongo.hs
+++ b/.github/reproductionTemplates/mongo.hs
@@ -1,0 +1,37 @@
+#!/usr/bin/env stack
+-- stack --resolver lts-9.21 script
+{-# LANGUAGE EmptyDataDecls             #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE QuasiQuotes                #-}
+{-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE TypeFamilies               #-}
+import Control.Monad.Logger (runStdoutLoggingT)
+import Control.Monad.IO.Class  (liftIO)
+import Database.Persist
+import Database.Persist.MongoDB
+import Database.Persist.TH
+import Control.Monad.Reader
+import Language.Haskell.TH.Syntax
+
+let mongoSettings = (mkPersistSettings (ConT ''MongoContext))
+ in share [mkPersist mongoSettings]
+    [persistUpperCase|
+Person
+    name String
+    age Int Maybe
+    deriving Show Eq
+BlogPost
+    title String
+    authorId PersonId
+    deriving Show Eq
+|]
+
+main :: IO ()
+main = withMongoPool (defaultMongoConf "persistent") $ runMongoDBPool master $ do
+
+  johnId <- insert $ Person "John Doe" $ Just 35
+  delete johnId

--- a/.github/reproductionTemplates/mysql.hs
+++ b/.github/reproductionTemplates/mysql.hs
@@ -1,0 +1,35 @@
+#!/usr/bin/env stack
+-- stack --resolver lts-9.21 script --package persistent-mysql --package monad-logger --package persistent-template --package mtl --package persistent
+{-# LANGUAGE EmptyDataDecls             #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE QuasiQuotes                #-}
+{-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE TypeFamilies               #-}
+import Control.Monad.Logger (runStdoutLoggingT)
+import Control.Monad.IO.Class  (liftIO)
+import Database.Persist
+import Database.Persist.MySQL
+import Database.Persist.TH
+import Control.Monad.Reader
+
+share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistLowerCase|
+Person
+    name String
+    age Int Maybe
+    deriving Show Eq
+BlogPost
+    title String
+    authorId PersonId
+    deriving Show Eq
+|]
+
+main :: IO ()
+main = runStdoutLoggingT $ withMySQLPool defaultConnectInfo { connectDatabase = "persistent" } 1 $ liftSqlPersistMPool $ do
+  runMigration migrateAll
+
+  johnId <- insert $ Person "John Doe" $ Just 35
+  delete johnId

--- a/.github/reproductionTemplates/postgresql.hs
+++ b/.github/reproductionTemplates/postgresql.hs
@@ -1,0 +1,35 @@
+#!/usr/bin/env stack
+-- stack --resolver lts-9.21 script
+{-# LANGUAGE EmptyDataDecls             #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE QuasiQuotes                #-}
+{-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE TypeFamilies               #-}
+import Control.Monad.Logger (runStdoutLoggingT)
+import Control.Monad.IO.Class  (liftIO)
+import Database.Persist
+import Database.Persist.Postgresql
+import Database.Persist.TH
+import Control.Monad.Reader
+
+share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistLowerCase|
+Person
+    name String
+    age Int Maybe
+    deriving Show Eq
+BlogPost
+    title String
+    authorId PersonId
+    deriving Show Eq
+|]
+
+main :: IO ()
+main = runStdoutLoggingT $ withPostgresqlPool "dbname=persistent" 1 $ liftSqlPersistMPool $ do
+  runMigration migrateAll
+
+  johnId <- insert $ Person "John Doe" $ Just 35
+  delete johnId

--- a/.github/reproductionTemplates/sqlite.hs
+++ b/.github/reproductionTemplates/sqlite.hs
@@ -1,0 +1,33 @@
+#!/usr/bin/env stack
+-- stack --resolver lts-9.21 script
+{-# LANGUAGE EmptyDataDecls             #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE QuasiQuotes                #-}
+{-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE TypeFamilies               #-}
+import Control.Monad.IO.Class  (liftIO)
+import Database.Persist
+import Database.Persist.Sqlite
+import Database.Persist.TH
+
+share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistLowerCase|
+Person
+    name String
+    age Int Maybe
+    deriving Show Eq
+BlogPost
+    title String
+    authorId PersonId
+    deriving Show Eq
+|]
+
+main :: IO ()
+main = runSqlite ":memory:" $ do
+    runMigration migrateAll
+
+    johnId <- insert $ Person "John Doe" $ Just 35
+    delete johnId

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,106 @@
+# Contributing
+
+Thanks for your interest in contributing to Persistent! This file has some tips for developing Persistent and getting a pull request accepted.
+
+## Development
+
+Persistent is a mega-repo that contains many Haskell packages, each in a different directory. All the subprojects can be developed with Stack, using `stack <command> <subproject>`, e.g.
+
+* `stack build persistent-mysql`
+* `stack haddock persistent`
+* `stack test persistent-test --flag persistent-test:sqlite --exec persistent-test`
+
+If you'd like to test your changes in a full-fledged app, you can use Stack to build against it, e.g.:
+
+```
+packages:
+- '/path/to/this/repo/persistent-postgresql'
+```
+
+Additional information can be found in `development.md`.
+
+## Coding Guidelines
+
+### Safety
+
+Avoid partial functions in pure code. Even if you know the partial function is safe in your instance, partial functions require more reasoning from the programmer and are not resilient to refactoring.
+
+### Style 
+
+Keep coding style consistent with the rest of the file, but don't worry about style too much otherwise. PRs changing code style are viewed skeptically.
+
+### Dependencies
+
+Avoid adding unnecessary dependencies. If a dependency provides only a minor convenience for your implementation, it's probably better to skip it.
+
+If you do add a new dependency, try to support a wide range of versions of it.
+
+### Backwards Compatibility
+
+Backwards incompatible changes are viewed skeptically—best to ask in an issue to see if a particular backwards incompatible change would be approved. If possible keep backwards compatibility by adding new APIs and deprecating old ones.
+
+Keep backwards compatibility with old versions of dependencies when possible.
+
+## PR Guidelines
+
+### PR Scope
+
+As much as possible, keep separate changes in separate PRs.
+
+### Testing
+
+Tests are strongly recommended, but not required.
+
+If you're reporting an issue, contributing a failing test is a great way to kickstart development on it.
+
+The `persistent-test` package is used to test all the backends, and the tests use the C Preprocessor to support this. An easy way to get started on a test is to find a similar one and copy and paste it into your new file.
+
+### Documentation
+
+All public APIs must be documented. Documenting private functions is optional, but may be nice depending on their complexity. Example documentation:
+
+```
+-- | Retrieve a list of a certain 'Entity' from the database
+--
+-- ==== __Examples__
+--
+-- @
+-- selectUsers :: 'MonadIO' m => 'ReaderT' 'SqlBackend' m ['Entity' User]
+-- selectUsers = 'selectList' [UserAge <-. [40, 41]] []
+-- @
+--
+-- @since 1.5.4
+selectList :: (MonadIO m, PersistQueryRead backend, PersistRecordBackend record backend)
+           => [Filter record] -- ^ Options to filter the query result; see "Query filter combinators" in the Database.Persist documetation
+           -> [SelectOpt record] -- ^ Options to limit and sort the returned records.
+           -> ReaderT backend m [Entity record]
+selectList = ...
+```
+
+Examples are recommended, but not required, in documentation. Marking new APIs with `@since <version number>` is required.
+
+### Versioning
+
+Persistent packages roughly follow the Haskell Package Versioning Policy style of A.B.C.[D] (MAJOR.MAJOR.MINOR.[PATCH])
+
+* A - Used for massive changes in the library. (Example: 1.2.3.4 becomes 2.0.0)
+* B - Used for smaller breaking changes, like removing, renaming, or changing behavior of existing public API. (Example: 1.2.3.4 becomes 1.3.0)
+* C - Used for new public APIs (Example: 1.2.3.4 becomes 1.2.4)
+* D - Used for bug fixes (Example: 1.2.3.4 becomes 1.2.3.5).
+	* D is optional in the version number, so 2.0.0 is a valid version.
+
+Documentation changes don't require a new version.
+
+If you feel there is ambiguity to a change (e.g. fixing a bug in a function, when people may be relying on the old broken behavior), you can ask in an issue or pull request.
+
+Unlike in the Package Versioning Policy, deprecations are not counted as MAJOR changes.
+
+In some cases, dropping compatibility with a major version of a dependency (e.g. changing from transformers >= 0.3 to transformers >= 0.4), is considered a breaking change.
+
+### Changelog
+
+After you submit a PR, update the subproject's Changelog.md file with the new version number and a link to your PR. If your PR does not need to bump the version number, include the change in an "Unreleased" section at the top.
+
+### Releases
+
+Releases should be done as soon as possible after a pull request is merged—don't be shy about reminding us to make a release if we forget.


### PR DESCRIPTION
This PR is the Persistent version of https://github.com/yesodweb/yesod/pull/1451

It makes some small changes for Persistent, but is generally pretty similar.

A major change is that I've created templates for the MySQL, Postgres, SQLite and MongoDB backends to help users create small scripts to reproduce issues.

(As a side note, I think that documentation for getting a minimal running setup for each backend is lacking and these scripts should be adapted into such documentation).

The scripts themselves could especially use reviewing since the contributing guidelines have already been merged into yesod and wai.

Closes #746