### PR TITLE
Expose underlying raw SQLite database pointer.

### DIFF
--- a/persistent-sqlite/ChangeLog.md
+++ b/persistent-sqlite/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for persistent-sqlite
 
+## 2.10.2
+
+* Expose the internals of `Connection` in an Internal module, allowing the user
+  to call SQLite functions via the C FFI. [#772](https://github.com/yesodweb/persistent)
+
 ## 2.10.1
 
 * Add support for reading text values with null characters from the database. Fixes [#921](https://github.com/yesodweb/persistent/issues/921)

--- a/persistent-sqlite/ChangeLog.md
+++ b/persistent-sqlite/ChangeLog.md
@@ -2,8 +2,10 @@
 
 ## 2.10.2
 
+* Add a new `RawSqlite` type and `withRawSqliteConnInfo` function that allow
+  access to the underlying Sqlite `Connection` type. [#772](https://github.com/yesodweb/persistent/pull/772)
 * Expose the internals of `Connection` in an Internal module, allowing the user
-  to call SQLite functions via the C FFI. [#772](https://github.com/yesodweb/persistent)
+  to call SQLite functions via the C FFI. [#772](https://github.com/yesodweb/persistent/pull/772)
 
 ## 2.10.1
 

--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -58,7 +58,6 @@ import Lens.Micro.TH (makeLenses)
 import UnliftIO.Resource (ResourceT, runResourceT)
 
 import Database.Persist.Sql
-import Database.Persist.Sql.Types.Internal (mkPersistBackend)
 import qualified Database.Persist.Sql.Util as Util
 import qualified Database.Sqlite as Sqlite
 

--- a/persistent-sqlite/Database/Sqlite.hs
+++ b/persistent-sqlite/Database/Sqlite.hs
@@ -86,22 +86,18 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Unsafe as BSU
 import qualified Data.ByteString.Internal as BSI
 import Data.Fixed (Pico)
-import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Monoid (mappend, mconcat)
 import Data.Text (Text, pack, unpack)
 import Data.Text.Encoding (encodeUtf8, decodeUtf8With)
 import Data.Text.Encoding.Error (lenientDecode)
 import Data.Time (defaultTimeLocale, formatTime, UTCTime)
 import Data.Typeable (Typeable)
+import Database.Sqlite.Internal (Connection(..), Connection'(..), Statement(..))
 import Foreign
 import Foreign.C
 
 import Database.Persist (PersistValue (..), listToJSON, mapToJSON)
-
-
-data Connection = Connection !(IORef Bool) Connection'
-newtype Connection' = Connection' (Ptr ())
-newtype Statement = Statement (Ptr ())
 
 -- | A custom exception type to make it easier to catch exceptions.
 --

--- a/persistent-sqlite/Database/Sqlite/Internal.hs
+++ b/persistent-sqlite/Database/Sqlite/Internal.hs
@@ -1,0 +1,27 @@
+-- | Utterly unsafe internals of the "Database.Sqlite" module. Useful for
+-- people who want access to the SQLite database pointer to manually call
+-- SQLite API functions via the FFI.
+--
+-- Types and functions in this module are *NOT* covered by the PVP and may
+-- change breakingly in any future version of the package.
+module Database.Sqlite.Internal where
+
+import Data.IORef (IORef)
+import Foreign.Ptr (Ptr)
+
+-- | SQLite connection type, consist of an IORef tracking whether the
+-- connection has been closed and the raw SQLite C API pointer, wrapped in a
+-- 'Connection\'' newtype.
+--
+-- @since 2.10.2
+data Connection = Connection !(IORef Bool) Connection'
+
+-- | Newtype wrapping SQLite C API pointer for a database connection.
+--
+-- @since 2.10.2
+newtype Connection' = Connection' (Ptr ())
+
+-- | Newtype wrapping SQLite C API pointer for a prepared statement.
+--
+-- @since 2.10.2
+newtype Statement = Statement (Ptr ())

--- a/persistent-sqlite/persistent-sqlite.cabal
+++ b/persistent-sqlite/persistent-sqlite.cabal
@@ -1,5 +1,5 @@
 name:            persistent-sqlite
-version:         2.10.1
+version:         2.10.2
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/persistent-sqlite/persistent-sqlite.cabal
+++ b/persistent-sqlite/persistent-sqlite.cabal
@@ -53,6 +53,7 @@ library
                    , unliftio-core
                    , unordered-containers
     exposed-modules: Database.Sqlite
+                     Database.Sqlite.Internal
                      Database.Persist.Sqlite
     ghc-options:     -Wall
     default-language: Haskell2010


### PR DESCRIPTION
Allows people to use the FFI to call SQLite's C API functions. Fixes #771.

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->