### PR TITLE
Support new conduit release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ addons:
   apt:
     packages:
     - libgmp-dev
-    - cabal-install-1.24
-    sources:
-    - hvr-ghc
   postgresql: "9.6"
 
 services:
@@ -17,37 +14,28 @@ services:
 
 matrix:
   include:
-  - env: ARGS="--resolver lts-2" BACKEND=none
-  - env: ARGS="--resolver lts-2" BACKEND=sqlite
-  - env: ARGS="--resolver lts-2" BACKEND=mongodb
-  - env: ARGS="--resolver lts-2" BACKEND=postgresql
-  - env: ARGS="--resolver lts-2" BACKEND=mysql
-
   - env: ARGS="--resolver lts-6" BACKEND=none
-  - env: ARGS="--resolver lts-6" BACKEND=sqlite
-  - env: ARGS="--resolver lts-6" BACKEND=mongodb
-  - env: ARGS="--resolver lts-6" BACKEND=postgresql
-  - env: ARGS="--resolver lts-6" BACKEND=mysql
+  - env: ARGS="--resolver lts-7" BACKEND=none
+  - env: ARGS="--resolver lts-9" BACKEND=none
+  - env: ARGS="--resolver lts-10" BACKEND=none
 
-  - env: ARGS="" BACKEND=none
-  - env: ARGS="" BACKEND=sqlite
-  - env: ARGS="" BACKEND=mongodb
-  - env: ARGS="" BACKEND=postgresql
-  - env: ARGS="" BACKEND=mysql
+  - env: ARGS="--resolver lts-9" BACKEND=sqlite
+  - env: ARGS="--resolver lts-9" BACKEND=mongodb
+  - env: ARGS="--resolver lts-9" BACKEND=postgresql
+  - env: ARGS="--resolver lts-9" BACKEND=mysql
+
+  - env: ARGS="--resolver lts-10" BACKEND=sqlite
+  - env: ARGS="--resolver lts-10" BACKEND=mongodb
+  - env: ARGS="--resolver lts-10" BACKEND=postgresql
+  - env: ARGS="--resolver lts-10" BACKEND=mysql
 
 before_install:
 # Download and unpack the stack executable
 - mkdir -p ~/.local/bin
-- export PATH=$HOME/.local/bin:/opt/cabal/1.24/bin:$PATH
+- export PATH=$HOME/.local/bin:$PATH
 - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 
-# *TEMPORARY* A proposed change #717 uses haskell-src-meta, which requires
-# `happy` to build haskell-src-exts.  This fails in lts-2.  Revert to the
-# commented out line if #717 is not merged, or when testing lts-2 is dropped.
-# script: travis/run.sh
-script:
-- if [[ $ARGS =~ lts-2 ]]; then stack $ARGS --install-ghc install happy; fi
-- travis/run.sh
+script: travis/run.sh
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,3 @@ cache:
 #        packages:
 #        - libzookeeper-mt-dev
 #        - zookeeperd
-
-after_failure:
-- cat ~/.cabal/logs/*log
-

--- a/persistent-mongoDB/ChangeLog.md
+++ b/persistent-mongoDB/ChangeLog.md
@@ -1,3 +1,7 @@
+## 2.8.0
+
+* Switch from `MonadBaseControl` to `MonadUnliftIO`
+
 ## 2.6.0
 
 * Fix upsert behavior [#613](https://github.com/yesodweb/persistent/issues/613)

--- a/persistent-mongoDB/persistent-mongoDB.cabal
+++ b/persistent-mongoDB/persistent-mongoDB.cabal
@@ -19,7 +19,7 @@ Flag high_precision_date
    Default: False
 
 library
-    build-depends:   base               >= 4.6 && < 5
+    build-depends:   base               >= 4.8 && < 5
                    , persistent         >= 2.8   && < 3
                    , text               >= 0.8
                    , transformers       >= 0.2.1

--- a/persistent-mongoDB/persistent-mongoDB.cabal
+++ b/persistent-mongoDB/persistent-mongoDB.cabal
@@ -33,12 +33,12 @@ library
                    , cereal             >= 0.3.0.0
                    , path-pieces        >= 0.1
                    , http-api-data      >= 0.2       && < 0.4
-                   , monad-control      >= 0.3
                    , aeson              >= 0.6.2
                    , attoparsec
                    , time
                    , bytestring
                    , resource-pool      < 0.3
+                   , unliftio-core
 
     exposed-modules: Database.Persist.MongoDB
     ghc-options:     -Wall

--- a/persistent-mongoDB/persistent-mongoDB.cabal
+++ b/persistent-mongoDB/persistent-mongoDB.cabal
@@ -1,5 +1,5 @@
 name:            persistent-mongoDB
-version:         2.6.0
+version:         2.8.0
 license:         MIT
 license-file:    LICENSE
 author:          Greg Weber <greg@gregweber.info>
@@ -20,7 +20,7 @@ Flag high_precision_date
 
 library
     build-depends:   base               >= 4.6 && < 5
-                   , persistent         >= 2.5   && < 3
+                   , persistent         >= 2.8   && < 3
                    , text               >= 0.8
                    , transformers       >= 0.2.1
                    , containers         >= 0.2

--- a/persistent-mysql/ChangeLog.md
+++ b/persistent-mysql/ChangeLog.md
@@ -1,4 +1,12 @@
-## 2.6.2.2
+## Unreleased
+
+* Fix duplicate migrations when using `mediumtext`, `longtext`, `mediumblob`, `longblob`, and `double`s using a custom precision. [#754](https://github.com/yesodweb/persistent/pull/754)
+
+-- This can be released as a minor change on the next update. Currently persistent-mysql can't be released because 2.6.2.2 depends on persistent-2.7.2 being released.
+
+## 2.6.2.2 [UNRELEASED ON HACKAGE]
+
+-- This version depends on persistent 2.7.2, which introduced breaking changes and is deprecated on hackage.
 
 * Fix ambiguous type errors introduced by `persistent-2.7.2` [#723](https://github.com/yesodweb/persistent/pull/723)
 

--- a/persistent-mysql/ChangeLog.md
+++ b/persistent-mysql/ChangeLog.md
@@ -1,5 +1,6 @@
-## Unreleased
+## 2.8.0 (Unreleased)
 
+* Switch from `MonadBaseControl` to `MonadUnliftIO`
 * Fix duplicate migrations when using `mediumtext`, `longtext`, `mediumblob`, `longblob`, and `double`s using a custom precision. [#754](https://github.com/yesodweb/persistent/pull/754)
 
 -- This can be released as a minor change on the next update. Currently persistent-mysql can't be released because 2.6.2.2 depends on persistent-2.7.2 being released.

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -39,7 +39,7 @@ import Control.Monad.Logger (MonadLogger, runNoLoggingT)
 import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except (runExceptT)
-import Control.Monad.Trans.Reader (runReaderT, ReaderT, withReaderT)
+import Control.Monad.Trans.Reader (runReaderT, ReaderT)
 import Control.Monad.Trans.Writer (runWriterT)
 import Data.Either (partitionEithers)
 import Data.Monoid ((<>))
@@ -1220,8 +1220,7 @@ insertManyOnDuplicateKeyUpdate
     -> ReaderT backend m ()
 insertManyOnDuplicateKeyUpdate [] _ _ = return ()
 insertManyOnDuplicateKeyUpdate records fieldValues updates =
-    withReaderT projectBackend
-    . uncurry rawExecute
+    uncurry rawExecute
     $ mkBulkInsertQuery records fieldValues updates
 
 -- | This creates the query for 'bulkInsertOnDuplicateKeyUpdate'. If you

--- a/persistent-mysql/persistent-mysql.cabal
+++ b/persistent-mysql/persistent-mysql.cabal
@@ -1,5 +1,5 @@
 name:            persistent-mysql
-version:         2.6.2.1
+version:         2.8.0
 license:         MIT
 license-file:    LICENSE
 author:          Felipe Lessa <felipe.lessa@gmail.com>, Michael Snoyman
@@ -32,7 +32,7 @@ library
                    , mysql-simple          >= 0.4.3    && < 0.5
                    , mysql                 >= 0.1.1.3  && < 0.2
                    , blaze-builder
-                   , persistent            >= 2.6.1    && < 3
+                   , persistent            >= 2.8.0    && < 3
                    , containers            >= 0.2
                    , bytestring            >= 0.9
                    , text                  >= 0.11.0.6

--- a/persistent-mysql/persistent-mysql.cabal
+++ b/persistent-mysql/persistent-mysql.cabal
@@ -27,7 +27,7 @@ description:
 extra-source-files: ChangeLog.md
 
 library
-    build-depends:   base                  >= 4.6        && < 5
+    build-depends:   base                  >= 4.8        && < 5
                    , transformers          >= 0.2.1
                    , mysql-simple          >= 0.4.3    && < 0.5
                    , mysql                 >= 0.1.1.3  && < 0.2

--- a/persistent-mysql/persistent-mysql.cabal
+++ b/persistent-mysql/persistent-mysql.cabal
@@ -36,7 +36,7 @@ library
                    , containers            >= 0.2
                    , bytestring            >= 0.9
                    , text                  >= 0.11.0.6
-                   , monad-control         >= 0.2
+                   , unliftio-core
                    , aeson                 >= 0.6.2
                    , conduit               >= 0.5.3
                    , resourcet             >= 0.4.10

--- a/persistent-mysql/persistent-mysql.cabal
+++ b/persistent-mysql/persistent-mysql.cabal
@@ -38,7 +38,7 @@ library
                    , text                  >= 0.11.0.6
                    , unliftio-core
                    , aeson                 >= 0.6.2
-                   , conduit               >= 0.5.3
+                   , conduit               >= 1.2.8
                    , resourcet             >= 0.4.10
                    , monad-logger
                    , resource-pool

--- a/persistent-postgresql/ChangeLog.md
+++ b/persistent-postgresql/ChangeLog.md
@@ -1,3 +1,7 @@
+## 2.8.0
+
+* Switch from `MonadBaseControl` to `MonadUnliftIO`
+
 ## 2.6.2.1
 
 * Fix bug where, if a custom column width was set, the field would be migrated every time [#742](https://github.com/yesodweb/persistent/pull/742)

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -45,7 +45,6 @@ import Database.PostgreSQL.Simple.Ok (Ok (..))
 
 import qualified Database.PostgreSQL.LibPQ as LibPQ
 
-import Control.Monad.Trans.Resource
 import Control.Exception (throw)
 import Control.Monad.IO.Unlift (MonadIO (..), MonadUnliftIO)
 import Data.Data

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -105,7 +105,7 @@ instance Exception PostgresServerVersionError
 -- finishes using it.  Note that you should not use the given
 -- 'ConnectionPool' outside the action since it may be already
 -- been released.
-withPostgresqlPool :: (MonadBaseControl IO m, MonadLogger m, MonadIO m, IsSqlBackend backend)
+withPostgresqlPool :: (MonadLogger m, MonadUnliftIO m, IsSqlBackend backend)
                    => ConnectionString
                    -- ^ Connection string to the database.
                    -> Int
@@ -121,7 +121,7 @@ withPostgresqlPool ci = withPostgresqlPoolWithVersion getServerVersion ci
 -- the server version (to workaround an Amazon Redshift bug).
 --
 -- @since 2.6.2
-withPostgresqlPoolWithVersion :: (MonadBaseControl IO m, MonadLogger m, MonadIO m, IsSqlBackend backend)
+withPostgresqlPoolWithVersion :: (MonadUnliftIO m, MonadLogger m, IsSqlBackend backend)
                               => (PG.Connection -> IO (Maybe Double)) 
                               -- ^ action to perform to get the server version
                               -> ConnectionString
@@ -139,7 +139,7 @@ withPostgresqlPoolWithVersion getVer ci = withSqlPool $ open' (const $ return ()
 -- responsibility to properly close the connection pool when
 -- unneeded.  Use 'withPostgresqlPool' for an automatic resource
 -- control.
-createPostgresqlPool :: (MonadIO m, MonadBaseControl IO m, MonadLogger m, IsSqlBackend backend)
+createPostgresqlPool :: (MonadUnliftIO m, MonadLogger m, IsSqlBackend backend)
                      => ConnectionString
                      -- ^ Connection string to the database.
                      -> Int
@@ -157,7 +157,7 @@ createPostgresqlPool = createPostgresqlPoolModified (const $ return ())
 --
 -- @since 2.1.3
 createPostgresqlPoolModified
-    :: (MonadIO m, MonadBaseControl IO m, MonadLogger m, IsSqlBackend backend)
+    :: (MonadUnliftIO m, MonadLogger m, IsSqlBackend backend)
     => (PG.Connection -> IO ()) -- ^ action to perform after connection is created
     -> ConnectionString -- ^ Connection string to the database.
     -> Int -- ^ Number of connections to be kept open in the pool.
@@ -170,7 +170,7 @@ createPostgresqlPoolModified = createPostgresqlPoolModifiedWithVersion getServer
 --
 -- @since 2.6.2
 createPostgresqlPoolModifiedWithVersion
-    :: (MonadIO m, MonadBaseControl IO m, MonadLogger m, IsSqlBackend backend)
+    :: (MonadUnliftIO m, MonadLogger m, IsSqlBackend backend)
     => (PG.Connection -> IO (Maybe Double)) -- ^ action to perform to get the server version
     -> (PG.Connection -> IO ()) -- ^ action to perform after connection is created
     -> ConnectionString -- ^ Connection string to the database.
@@ -181,7 +181,7 @@ createPostgresqlPoolModifiedWithVersion getVer modConn ci =
 
 -- | Same as 'withPostgresqlPool', but instead of opening a pool
 -- of connections, only one connection is opened.
-withPostgresqlConn :: (MonadIO m, MonadBaseControl IO m, MonadLogger m, IsSqlBackend backend)
+withPostgresqlConn :: (MonadUnliftIO m, MonadLogger m, IsSqlBackend backend)
                    => ConnectionString -> (backend -> m a) -> m a
 withPostgresqlConn = withPostgresqlConnWithVersion getServerVersion
 
@@ -189,13 +189,13 @@ withPostgresqlConn = withPostgresqlConnWithVersion getServerVersion
 -- the server version (to workaround an Amazon Redshift bug).
 --
 -- @since 2.6.2
-withPostgresqlConnWithVersion :: (MonadIO m, MonadBaseControl IO m, MonadLogger m, IsSqlBackend backend)
+withPostgresqlConnWithVersion :: (MonadUnliftIO m, MonadLogger m, IsSqlBackend backend)
                               => (PG.Connection -> IO (Maybe Double))
-                              -> ConnectionString 
+                              -> ConnectionString
                               -> (backend -> m a)
                               -> m a
 withPostgresqlConnWithVersion getVer = withSqlConn . open' (const $ return ()) getVer
-                              
+
 open'
     :: (IsSqlBackend backend)
     => (PG.Connection -> IO ())

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -47,7 +47,7 @@ import qualified Database.PostgreSQL.LibPQ as LibPQ
 
 import Control.Monad.Trans.Resource
 import Control.Exception (throw)
-import Control.Monad.IO.Class (MonadIO (..))
+import Control.Monad.IO.Unlift (MonadIO (..), MonadUnliftIO)
 import Data.Data
 import Data.Typeable (Typeable)
 import Data.IORef

--- a/persistent-postgresql/persistent-postgresql.cabal
+++ b/persistent-postgresql/persistent-postgresql.cabal
@@ -27,7 +27,7 @@ library
                    , blaze-builder
                    , time                  >= 1.1
                    , aeson                 >= 0.6.2
-                   , conduit               >= 0.5.3
+                   , conduit               >= 1.2.8
                    , resourcet             >= 1.1
                    , monad-logger          >= 0.3.4
                    , resource-pool

--- a/persistent-postgresql/persistent-postgresql.cabal
+++ b/persistent-postgresql/persistent-postgresql.cabal
@@ -23,7 +23,7 @@ library
                    , containers            >= 0.2
                    , bytestring            >= 0.9
                    , text                  >= 0.7
-                   , monad-control         >= 0.2
+                   , unliftio-core
                    , blaze-builder
                    , time                  >= 1.1
                    , aeson                 >= 0.6.2

--- a/persistent-postgresql/persistent-postgresql.cabal
+++ b/persistent-postgresql/persistent-postgresql.cabal
@@ -1,5 +1,5 @@
 name:            persistent-postgresql
-version:         2.6.2.1
+version:         2.8.0
 license:         MIT
 license-file:    LICENSE
 author:          Felipe Lessa, Michael Snoyman <michael@snoyman.com>
@@ -19,7 +19,7 @@ library
                    , transformers          >= 0.2.1
                    , postgresql-simple     >= 0.4.0    && < 0.6
                    , postgresql-libpq      >= 0.6.1    && < 0.10
-                   , persistent            >= 2.6.1    && < 3
+                   , persistent            >= 2.8.0    && < 3
                    , containers            >= 0.2
                    , bytestring            >= 0.9
                    , text                  >= 0.7

--- a/persistent-postgresql/persistent-postgresql.cabal
+++ b/persistent-postgresql/persistent-postgresql.cabal
@@ -15,7 +15,7 @@ bug-reports:     https://github.com/yesodweb/persistent/issues
 extra-source-files: ChangeLog.md
 
 library
-    build-depends:   base                  >= 4.6        && < 5
+    build-depends:   base                  >= 4.8        && < 5
                    , transformers          >= 0.2.1
                    , postgresql-simple     >= 0.4.0    && < 0.6
                    , postgresql-libpq      >= 0.6.1    && < 0.10

--- a/persistent-redis/persistent-redis.cabal
+++ b/persistent-redis/persistent-redis.cabal
@@ -59,7 +59,7 @@ test-suite  basic
                    , text                  >= 1.2.0.0
                    , aeson                 >= 0.8
                    , binary                >= 0.7      && < 0.9
-                   , time                  >= 1.4      && < 1.7
+                   , time                  >= 1.4      && < 1.9
                    , attoparsec            >= 0.12.0.0
                    , template-haskell
                    , monad-control         >= 0.3.2.0  && < 1.2.0.0

--- a/persistent-sqlite/ChangeLog.md
+++ b/persistent-sqlite/ChangeLog.md
@@ -1,3 +1,7 @@
+## 2.8.0
+
+* Switch from `MonadBaseControl` to `MonadUnliftIO`
+
 ## 2.6.4
 
 * Adds a new function `stepConn`, which uses an additional parameter to give more detailed error messages [#750](https://github.com/yesodweb/persistent/pull/750)

--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -42,7 +42,7 @@ import Control.Monad (when)
 import Control.Monad.IO.Unlift (MonadIO (..), MonadUnliftIO, withUnliftIO, unliftIO)
 import Control.Monad.Logger (NoLoggingT, runNoLoggingT, MonadLogger)
 import Control.Monad.Trans.Reader (ReaderT, runReaderT)
-import Control.Monad.Trans.Resource (ResourceT, runResourceT)
+import UnliftIO.Resource (ResourceT, runResourceT)
 import Control.Monad.Trans.Writer (runWriterT)
 import Data.Acquire (Acquire, mkAcquire, with)
 import Data.Aeson

--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -39,10 +39,8 @@ import qualified Database.Sqlite as Sqlite
 import Control.Applicative as A
 import qualified Control.Exception as E
 import Control.Monad (when)
-import Control.Monad.IO.Class (MonadIO (..))
+import Control.Monad.IO.Unlift (MonadIO (..), MonadUnliftIO, withUnliftIO, unliftIO)
 import Control.Monad.Logger (NoLoggingT, runNoLoggingT, MonadLogger)
-import Control.Monad.Trans.Control (control)
-import Control.Monad.Trans.Control (MonadBaseControl)
 import Control.Monad.Trans.Reader (ReaderT, runReaderT)
 import Control.Monad.Trans.Resource (ResourceT, runResourceT)
 import Control.Monad.Trans.Writer (runWriterT)
@@ -67,7 +65,7 @@ import Lens.Micro.TH (makeLenses)
 -- Note that this should not be used with the @:memory:@ connection string, as
 -- the pool will regularly remove connections, destroying your database.
 -- Instead, use 'withSqliteConn'.
-createSqlitePool :: (MonadIO m, MonadLogger m, MonadBaseControl IO m, IsSqlBackend backend)
+createSqlitePool :: (MonadLogger m, MonadUnliftIO m, IsSqlBackend backend)
                  => Text -> Int -> m (Pool backend)
 createSqlitePool = createSqlitePoolFromInfo . conStringToInfo
 
@@ -78,14 +76,14 @@ createSqlitePool = createSqlitePoolFromInfo . conStringToInfo
 -- Instead, use 'withSqliteConn'.
 --
 -- @since 2.6.2
-createSqlitePoolFromInfo :: (MonadIO m, MonadLogger m, MonadBaseControl IO m, IsSqlBackend backend)
+createSqlitePoolFromInfo :: (MonadLogger m, MonadUnliftIO m, IsSqlBackend backend)
                          => SqliteConnectionInfo -> Int -> m (Pool backend)
 createSqlitePoolFromInfo connInfo = createSqlPool $ open' connInfo
 
 -- | Run the given action with a connection pool.
 --
 -- Like 'createSqlitePool', this should not be used with @:memory:@.
-withSqlitePool :: (MonadBaseControl IO m, MonadIO m, MonadLogger m, IsSqlBackend backend)
+withSqlitePool :: (MonadUnliftIO m, MonadLogger m, IsSqlBackend backend)
                => Text
                -> Int -- ^ number of connections to open
                -> (Pool backend -> m a) -> m a
@@ -96,18 +94,18 @@ withSqlitePool connInfo = withSqlPool . open' $ conStringToInfo connInfo
 -- Like 'createSqlitePool', this should not be used with @:memory:@.
 --
 -- @since 2.6.2
-withSqlitePoolInfo :: (MonadBaseControl IO m, MonadIO m, MonadLogger m, IsSqlBackend backend)
+withSqlitePoolInfo :: (MonadUnliftIO m, MonadLogger m, IsSqlBackend backend)
                => SqliteConnectionInfo
                -> Int -- ^ number of connections to open
                -> (Pool backend -> m a) -> m a
 withSqlitePoolInfo connInfo = withSqlPool $ open' connInfo
 
-withSqliteConn :: (MonadBaseControl IO m, MonadIO m, MonadLogger m, IsSqlBackend backend)
+withSqliteConn :: (MonadUnliftIO m, MonadLogger m, IsSqlBackend backend)
                => Text -> (backend -> m a) -> m a
 withSqliteConn = withSqliteConnInfo . conStringToInfo
 
 -- | @since 2.6.2
-withSqliteConnInfo :: (MonadBaseControl IO m, MonadIO m, MonadLogger m, IsSqlBackend backend)
+withSqliteConnInfo :: (MonadUnliftIO m, MonadLogger m, IsSqlBackend backend)
                    => SqliteConnectionInfo -> (backend -> m a) -> m a
 withSqliteConnInfo = withSqlConn . open'
 
@@ -179,7 +177,7 @@ wrapConnectionInfo connInfo conn logFunc = do
 -- that all log messages are discarded.
 --
 -- @since 1.1.4
-runSqlite :: (MonadBaseControl IO m, MonadIO m, IsSqlBackend backend)
+runSqlite :: (MonadUnliftIO m, IsSqlBackend backend)
           => Text -- ^ connection string
           -> ReaderT backend (NoLoggingT (ResourceT m)) a -- ^ database action
           -> m a
@@ -193,7 +191,7 @@ runSqlite connstr = runResourceT
 -- that all log messages are discarded.
 --
 -- @since 2.6.2
-runSqliteInfo :: (MonadBaseControl IO m, MonadIO m, IsSqlBackend backend)
+runSqliteInfo :: (MonadUnliftIO m, IsSqlBackend backend)
               => SqliteConnectionInfo
               -> ReaderT backend (NoLoggingT (ResourceT m)) a -- ^ database action
               -> m a
@@ -515,13 +513,13 @@ instance PersistConfig SqliteConf where
     runPool _ = runSqlPool
     loadConfig = parseJSON
 
-finally :: MonadBaseControl IO m
+finally :: MonadUnliftIO m
         => m a -- ^ computation to run first
         -> m b -- ^ computation to run afterward (even if an exception was raised)
         -> m a
-finally a sequel = control $ \runInIO ->
-                     E.finally (runInIO a)
-                               (runInIO sequel)
+finally a sequel = withUnliftIO $ \u ->
+                     E.finally (unliftIO u a)
+                               (unliftIO u sequel)
 {-# INLINABLE finally #-}
 -- | Creates a SqliteConnectionInfo from a connection string, with the
 -- default settings.

--- a/persistent-sqlite/persistent-sqlite.cabal
+++ b/persistent-sqlite/persistent-sqlite.cabal
@@ -33,7 +33,7 @@ library
                    , containers              >= 0.2
                    , text                    >= 0.7
                    , aeson                   >= 0.6.2
-                   , conduit                 >= 0.5.3
+                   , conduit                 >= 1.2.8
                    , monad-logger            >= 0.2.4
                    , microlens-th            >= 0.4.1.1
                    , resourcet               >= 1.1

--- a/persistent-sqlite/persistent-sqlite.cabal
+++ b/persistent-sqlite/persistent-sqlite.cabal
@@ -25,7 +25,7 @@ flag build-sanity-exe
   default: False
 
 library
-    build-depends:   base                    >= 4.6         && < 5
+    build-depends:   base                    >= 4.8         && < 5
                    , bytestring              >= 0.9.1
                    , transformers            >= 0.2.1
                    , persistent              >= 2.8.0       && < 3

--- a/persistent-sqlite/persistent-sqlite.cabal
+++ b/persistent-sqlite/persistent-sqlite.cabal
@@ -29,7 +29,7 @@ library
                    , bytestring              >= 0.9.1
                    , transformers            >= 0.2.1
                    , persistent              >= 2.6.1       && < 3
-                   , monad-control           >= 0.2
+                   , unliftio-core
                    , containers              >= 0.2
                    , text                    >= 0.7
                    , aeson                   >= 0.6.2

--- a/persistent-sqlite/persistent-sqlite.cabal
+++ b/persistent-sqlite/persistent-sqlite.cabal
@@ -1,5 +1,5 @@
 name:            persistent-sqlite
-version:         2.6.4
+version:         2.8.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -28,7 +28,7 @@ library
     build-depends:   base                    >= 4.6         && < 5
                    , bytestring              >= 0.9.1
                    , transformers            >= 0.2.1
-                   , persistent              >= 2.6.1       && < 3
+                   , persistent              >= 2.8.0       && < 3
                    , unliftio-core
                    , containers              >= 0.2
                    , text                    >= 0.7

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -101,7 +101,8 @@ library
                    , http-api-data            >= 0.2
                    , text                     >= 0.8
                    , transformers             >= 0.2.1
-                   , monad-control            >= 0.3
+                   , unliftio-core
+                   , unliftio
                    , containers               >= 0.2
                    , bytestring               >= 0.9
                    , base64-bytestring

--- a/persistent-test/src/CompositeTest.hs
+++ b/persistent-test/src/CompositeTest.hs
@@ -19,8 +19,6 @@
 module CompositeTest where
 
 import Test.Hspec.Expectations ()
-import qualified Control.Monad.Trans.Control
-import qualified Control.Exception as E
 import Init
 
 #ifndef WITH_NOSQL
@@ -311,11 +309,3 @@ matchParentK = (\(a:b:c:[]) -> (,,) <$> fromPersistValue a <*> fromPersistValue 
 matchCitizenAddressK :: Key CitizenAddress -> Either Text (Int64, Int64)
 matchCitizenAddressK = (\(a:b:[]) -> (,) <$> fromPersistValue a <*> fromPersistValue b)
                      . keyToValues
-
-catch' :: (Control.Monad.Trans.Control.MonadBaseControl IO m, E.Exception e)
-       => m a       -- ^ The computation to run
-       -> (e -> m a) -- ^ Handler to invoke if an exception is raised
-       -> m a
-catch' a handler = Control.Monad.Trans.Control.control $ \runInIO ->
-                    E.catch (runInIO a)
-                            (\e -> runInIO $ handler e)

--- a/persistent-test/src/Init.hs
+++ b/persistent-test/src/Init.hs
@@ -110,7 +110,7 @@ import System.IO.Unsafe (unsafePerformIO)
 #endif
 
 import Control.Monad (unless, (>=>))
-import Control.Monad.Trans.Control (MonadBaseControl)
+import Control.Monad.IO.Unlift (MonadUnliftIO)
 
 -- Data types
 import Data.Int (Int32, Int64)
@@ -191,7 +191,7 @@ dbName = "persistent"
 type BackendMonad = Context
 
 #ifdef WITH_MONGODB
-runConn :: (MonadIO m, MonadBaseControl IO m) => Action m backend -> m ()
+runConn :: MonadUnliftIO m => Action m backend -> m ()
 runConn f = do
   conf <- liftIO $ applyDockerEnv $ defaultMongoConf dbName -- { mgRsPrimary = Just "replicaset" }
   void $ withMongoPool conf $ runMongoDBPool MongoDB.master f
@@ -201,7 +201,7 @@ setupMongo = void $ MongoDB.dropDatabase dbName
 #endif
 
 #ifdef WITH_ZOOKEEPER
-runConn :: (MonadIO m, MonadBaseControl IO m) => Action m backend -> m ()
+runConn :: MonadUnliftIO m => Action m backend -> m ()
 runConn f = do
   let conf = defaultZookeeperConf {zCoord = "localhost:2181/" ++ T.unpack dbName}
   void $ withZookeeperPool conf $ runZookeeperPool f
@@ -234,7 +234,7 @@ sqlite_database_file = error "Sqlite tests disabled"
 sqlite_database :: ()
 sqlite_database = error "Sqlite tests disabled"
 #  endif
-runConn :: (MonadIO m, MonadBaseControl IO m) => SqlPersistT (LoggingT m) t -> m ()
+runConn :: MonadUnliftIO m => SqlPersistT (LoggingT m) t -> m ()
 runConn f = do
   travis <- liftIO isTravis
   let debugPrint = not travis && _debugOn

--- a/persistent-test/src/PersistentTest.hs
+++ b/persistent-test/src/PersistentTest.hs
@@ -21,6 +21,7 @@ import Test.HUnit hiding (Test)
 import Control.Monad.Trans.Resource (runResourceT)
 import Test.Hspec.Expectations ()
 import Test.Hspec.QuickCheck(prop)
+import UnliftIO (MonadUnliftIO, catch)
 
 import Database.Persist
 
@@ -44,9 +45,6 @@ import Database.Persist.MySQL()
 #  endif
 
 #endif
-
-import qualified Control.Monad.Trans.Control
-import Control.Exception.Lifted (catch)
 
 import Control.Monad.IO.Class
 
@@ -186,7 +184,7 @@ db :: Action IO () -> Assertion
 db = db' cleanDB
 #endif
 
-catchPersistException :: Control.Monad.Trans.Control.MonadBaseControl IO m => m a -> b -> m b
+catchPersistException :: MonadUnliftIO m => m a -> b -> m b
 catchPersistException action errValue = do
     Left res <-
       (Right `fmap` action) `catch`
@@ -1188,14 +1186,6 @@ caseCommitRollback = db $ do
     transactionUndo
     c4 <- count filt
     c4 @== 4
-
-catch' :: (Control.Monad.Trans.Control.MonadBaseControl IO m, E.Exception e)
-       => m a       -- ^ The computation to run
-       -> (e -> m a) -- ^ Handler to invoke if an exception is raised
-       -> m a
-catch' a handler = Control.Monad.Trans.Control.control $ \runInIO ->
-                    E.catch (runInIO a)
-                            (\e -> runInIO $ handler e)
 
 #endif
 

--- a/persistent-test/src/PersistentTest.hs
+++ b/persistent-test/src/PersistentTest.hs
@@ -35,7 +35,6 @@ import Database.Persist.MongoDB (toInsertDoc, docToEntityThrow, collectionName, 
 
 import Database.Persist.TH (mkDeleteCascade, mkSave)
 import qualified Data.Text as T
-import qualified Control.Exception as E
 
 #  ifdef WITH_POSTGRESQL
 import Data.List (sort)

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,4 +1,8 @@
-## 2.7.3 
+## 2.8.0
+
+* Switch from `MonadBaseControl` to `MonadUnliftIO`
+
+## 2.7.3
 
 * Reverts [#723](https://github.com/yesodweb/persistent/pull/723), which generalized functions using the `BackendCompatible` class. These changes were an accidental breaking change.
 * Recommend the `PersistDbSpecific` docs if someone gets an error about converting from `PersistDbSpecific`

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,6 +1,7 @@
 ## 2.8.0
 
 * Switch from `MonadBaseControl` to `MonadUnliftIO`
+* Reapplies [#723](https://github.com/yesodweb/persistent/pull/723), which was reverted in version 2.7.3.
 
 ## 2.7.3
 

--- a/persistent/Database/Persist/Class/DeleteCascade.hs
+++ b/persistent/Database/Persist/Class/DeleteCascade.hs
@@ -9,7 +9,7 @@ import Database.Persist.Class.PersistStore
 import Database.Persist.Class.PersistQuery
 import Database.Persist.Class.PersistEntity
 
-import qualified Data.Conduit as C
+import Data.Conduit
 import qualified Data.Conduit.List as CL
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Reader (ReaderT, ask, runReaderT)
@@ -31,4 +31,4 @@ deleteCascadeWhere :: (MonadIO m, DeleteCascade record backend, PersistQueryWrit
 deleteCascadeWhere filts = do
     srcRes <- selectKeysRes filts []
     conn <- ask
-    liftIO $ with srcRes (C.$$ CL.mapM_ (flip runReaderT conn . deleteCascade))
+    liftIO $ with srcRes (\src -> runConduit $ src .| CL.mapM_ (flip runReaderT conn . deleteCascade))

--- a/persistent/Database/Persist/Class/PersistConfig.hs
+++ b/persistent/Database/Persist/Class/PersistConfig.hs
@@ -7,8 +7,7 @@ module Database.Persist.Class.PersistConfig
 
 import Data.Aeson (Value (Object))
 import Data.Aeson.Types (Parser)
-import Control.Monad.IO.Class (MonadIO)
-import Control.Monad.Trans.Control (MonadBaseControl)
+import Control.Monad.IO.Unlift (MonadUnliftIO)
 import Control.Applicative as A ((<$>))
 import qualified Data.HashMap.Strict as HashMap
 
@@ -31,7 +30,7 @@ class PersistConfig c where
     createPoolConfig :: c -> IO (PersistConfigPool c)
 
     -- | Run a database action by taking a connection from the pool.
-    runPool :: (MonadBaseControl IO m, MonadIO m)
+    runPool :: MonadUnliftIO m
             => c
             -> PersistConfigBackend c m a
             -> PersistConfigPool c

--- a/persistent/Database/Persist/Class/PersistEntity.hs
+++ b/persistent/Database/Persist/Class/PersistEntity.hs
@@ -175,15 +175,13 @@ data Filter record = forall typ. PersistField typ => Filter
 data Entity record =
     Entity { entityKey :: Key record
            , entityVal :: record }
+    deriving Typeable
 
-deriving instance (PersistEntity record, Generic (Key record), Generic record) => Generic (Entity record)
-deriving instance (PersistEntity record, Eq (Key record), Eq record) => Eq (Entity record)
-deriving instance (PersistEntity record, Ord (Key record), Ord record) => Ord (Entity record)
-deriving instance (PersistEntity record, Show (Key record), Show record) => Show (Entity record)
-deriving instance (PersistEntity record, Read (Key record), Read record) => Read (Entity record)
-#if MIN_VERSION_base(4,7,0)
-deriving instance Typeable Entity
-#endif
+deriving instance (Generic (Key record), Generic record) => Generic (Entity record)
+deriving instance (Eq (Key record), Eq record) => Eq (Entity record)
+deriving instance (Ord (Key record), Ord record) => Ord (Entity record)
+deriving instance (Show (Key record), Show record) => Show (Entity record)
+deriving instance (Read (Key record), Read record) => Read (Entity record)
 
 -- | Get list of values corresponding to given entity.
 entityValues :: PersistEntity record => Entity record -> [PersistValue]

--- a/persistent/Database/Persist/Class/PersistStore.hs
+++ b/persistent/Database/Persist/Class/PersistStore.hs
@@ -23,7 +23,7 @@ module Database.Persist.Class.PersistStore
 
 import qualified Data.Text as T
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import Control.Exception.Lifted (throwIO)
+import Control.Exception (throwIO)
 import Control.Monad.Trans.Reader (ReaderT)
 import Control.Monad.Reader (MonadReader (ask), runReaderT)
 import Database.Persist.Class.PersistEntity

--- a/persistent/Database/Persist/Sql/Migration.hs
+++ b/persistent/Database/Persist/Sql/Migration.hs
@@ -25,6 +25,7 @@ import System.IO.Silently (hSilence)
 import Database.Persist.Sql.Types
 import Database.Persist.Sql.Raw
 import Database.Persist.Types
+import Database.Persist.Sql.Orphan.PersistStore()
 
 allSql :: CautiousMigration -> [Sql]
 allSql = map snd

--- a/persistent/Database/Persist/Sql/Migration.hs
+++ b/persistent/Database/Persist/Sql/Migration.hs
@@ -13,9 +13,8 @@ module Database.Persist.Sql.Migration
   ) where
 
 
-import Control.Monad.Trans.Control (MonadBaseControl)
 import Control.Monad.Trans.Class (MonadTrans (..))
-import Control.Monad.IO.Class
+import Control.Monad.IO.Unlift
 import Control.Monad.Trans.Writer
 import Control.Monad.Trans.Reader (ReaderT (..), ask)
 import Control.Monad (liftM, unless)
@@ -23,7 +22,6 @@ import Data.Text (Text, unpack, snoc, isPrefixOf, pack)
 import qualified Data.Text.IO
 import System.IO
 import System.IO.Silently (hSilence)
-import Control.Monad.Trans.Control (liftBaseOp_)
 import Database.Persist.Sql.Types
 import Database.Persist.Sql.Raw
 import Database.Persist.Types
@@ -79,10 +77,11 @@ runMigration m = runMigration' m False >> return ()
 
 -- | Same as 'runMigration', but returns a list of the SQL commands executed
 -- instead of printing them to stderr.
-runMigrationSilent :: (MonadBaseControl IO m, MonadIO m)
+runMigrationSilent :: (MonadUnliftIO m, MonadIO m)
                    => Migration
                    -> ReaderT SqlBackend m [Text]
-runMigrationSilent m = liftBaseOp_ (hSilence [stderr]) $ runMigration' m True
+runMigrationSilent m = withRunInIO $ \run ->
+  hSilence [stderr] $ run $ runMigration' m True
 
 -- | Run the given migration against the database. If the migration fails
 -- to parse, or there are any unsafe migrations, then this will error at

--- a/persistent/Database/Persist/Sql/Orphan/PersistQuery.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistQuery.hs
@@ -57,7 +57,7 @@ instance PersistQueryRead SqlBackend where
     selectSourceRes filts opts = do
         conn <- ask
         srcRes <- rawQueryRes (sql conn) (getFiltsValues conn filts)
-        return $ fmap ($= CL.mapM parse) srcRes
+        return $ fmap (.| CL.mapM parse) srcRes
       where
         (limit, offset, orders) = limitOffsetOrder opts
 
@@ -85,7 +85,7 @@ instance PersistQueryRead SqlBackend where
     selectKeysRes filts opts = do
         conn <- ask
         srcRes <- rawQueryRes (sql conn) (getFiltsValues conn filts)
-        return $ fmap ($= CL.mapM parse) srcRes
+        return $ fmap (.| CL.mapM parse) srcRes
       where
         t = entityDef $ dummyFromFilts filts
         cols conn = T.intercalate "," $ dbIdColumns conn t

--- a/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
@@ -23,7 +23,7 @@ import Database.Persist
 import Database.Persist.Sql.Types
 import Database.Persist.Sql.Raw
 import Database.Persist.Sql.Util (dbIdColumns, keyAndEntityColumnNames)
-import qualified Data.Conduit as C
+import Data.Conduit
 import qualified Data.Conduit.List as CL
 import qualified Data.Text as T
 import Data.Text (Text, unpack)
@@ -45,11 +45,11 @@ import Database.Persist.Class ()
 withRawQuery :: MonadIO m
              => Text
              -> [PersistValue]
-             -> C.Sink [PersistValue] IO a
+             -> ConduitT [PersistValue] Void IO a
              -> ReaderT SqlBackend m a
 withRawQuery sql vals sink = do
     srcRes <- rawQueryRes sql vals
-    liftIO $ with srcRes (C.$$ sink)
+    liftIO $ with srcRes (\src -> runConduit $ src .| sink)
 
 toSqlKey :: ToBackendKey SqlBackend record => Int64 -> Key record
 toSqlKey = fromBackendKey . SqlBackendKey

--- a/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
@@ -32,6 +32,7 @@ import Control.Monad.IO.Class
 import Data.ByteString.Char8 (readInteger)
 import Data.Maybe (isJust)
 import Data.List (find)
+import Data.Void (Void)
 import Control.Monad.Trans.Reader (ReaderT, ask, withReaderT)
 import Data.Acquire (with)
 import Data.Int (Int64)
@@ -45,7 +46,7 @@ import Database.Persist.Class ()
 withRawQuery :: MonadIO m
              => Text
              -> [PersistValue]
-             -> ConduitT [PersistValue] Void IO a
+             -> ConduitM [PersistValue] Void IO a
              -> ReaderT SqlBackend m a
 withRawQuery sql vals sink = do
     srcRes <- rawQueryRes sql vals

--- a/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
@@ -39,7 +39,7 @@ import Web.PathPieces (PathPiece)
 import Web.HttpApiData (ToHttpApiData, FromHttpApiData)
 import Database.Persist.Sql.Class (PersistFieldSql)
 import qualified Data.Aeson as A
-import Control.Exception.Lifted (throwIO)
+import Control.Exception (throwIO)
 import Database.Persist.Class ()
 
 withRawQuery :: MonadIO m

--- a/persistent/Database/Persist/Sql/Raw.hs
+++ b/persistent/Database/Persist/Sql/Raw.hs
@@ -47,20 +47,20 @@ rawQueryRes sql vals = do
         stmtQuery stmt vals
 
 -- | Execute a raw SQL statement
-rawExecute :: MonadIO m
+rawExecute :: (MonadIO m, BackendCompatible SqlBackend backend)
            => Text            -- ^ SQL statement, possibly with placeholders.
            -> [PersistValue]  -- ^ Values to fill the placeholders.
-           -> ReaderT SqlBackend m ()
+           -> ReaderT backend m ()
 rawExecute x y = liftM (const ()) $ rawExecuteCount x y
 
 -- | Execute a raw SQL statement and return the number of
 -- rows it has modified.
-rawExecuteCount :: (MonadIO m, IsSqlBackend backend)
+rawExecuteCount :: (MonadIO m, BackendCompatible SqlBackend backend)
                 => Text            -- ^ SQL statement, possibly with placeholders.
                 -> [PersistValue]  -- ^ Values to fill the placeholders.
                 -> ReaderT backend m Int64
 rawExecuteCount sql vals = do
-    conn <- persistBackend `liftM` ask
+    conn <- projectBackend `liftM` ask
     runLoggingT (logDebugNS (pack "SQL") $ T.append sql $ pack $ "; " ++ show vals)
         (connLogFunc conn)
     stmt <- getStmt sql
@@ -69,10 +69,10 @@ rawExecuteCount sql vals = do
     return res
 
 getStmt
-  :: (MonadIO m, IsSqlBackend backend)
+  :: (MonadIO m, BackendCompatible SqlBackend backend)
   => Text -> ReaderT backend m Statement
 getStmt sql = do
-    conn <- persistBackend `liftM` ask
+    conn <- projectBackend `liftM` ask
     liftIO $ getStmtConn conn sql
 
 getStmtConn :: SqlBackend -> Text -> IO Statement

--- a/persistent/Database/Persist/Sql/Run.hs
+++ b/persistent/Database/Persist/Sql/Run.hs
@@ -15,7 +15,7 @@ import Control.Exception (onException, bracket)
 import Control.Monad.IO.Unlift
 import Control.Exception (mask)
 import System.Timeout (timeout)
-import Data.IORef (readIORef, writeIORef, newIORef)
+import Data.IORef (readIORef)
 import qualified Data.Map as Map
 import Control.Monad (liftM)
 

--- a/persistent/Database/Persist/Sql/Types/Internal.hs
+++ b/persistent/Database/Persist/Sql/Types/Internal.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -39,6 +40,7 @@ import Database.Persist.Class
   , PersistQueryRead, PersistQueryWrite
   , PersistStoreRead, PersistStoreWrite
   , PersistUniqueRead, PersistUniqueWrite
+  , BackendCompatible(..)
   )
 import Database.Persist.Class.PersistStore (IsPersistBackend (..))
 import Database.Persist.Types
@@ -130,7 +132,7 @@ readToUnknown ma = do
 
 -- | A constraint synonym which witnesses that a backend is SQL and can run read queries.
 type SqlBackendCanRead backend =
-  ( IsSqlBackend backend
+  ( BackendCompatible SqlBackend backend
   , PersistQueryRead backend, PersistStoreRead backend, PersistUniqueRead backend
   )
 -- | A constraint synonym which witnesses that a backend is SQL and can run read and write queries.

--- a/persistent/Database/Persist/Sql/Types/Internal.hs
+++ b/persistent/Database/Persist/Sql/Types/Internal.hs
@@ -28,7 +28,7 @@ import Control.Monad.Logger (LogSource, LogLevel)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Reader (ReaderT, runReaderT, ask)
 import Data.Acquire (Acquire)
-import Data.Conduit (Source)
+import Data.Conduit (ConduitM)
 import Data.Int (Int64)
 import Data.IORef (IORef)
 import Data.Map (Map)
@@ -57,7 +57,7 @@ data Statement = Statement
     , stmtExecute :: [PersistValue] -> IO Int64
     , stmtQuery :: forall m. MonadIO m
                 => [PersistValue]
-                -> Acquire (Source m [PersistValue])
+                -> Acquire (ConduitM () [PersistValue] m ())
     }
 
 data SqlBackend = SqlBackend

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -31,15 +31,11 @@ library
                    , containers               >= 0.2
                    , conduit                  >= 1.0
                    , resourcet                >= 1.1
-                   , exceptions               >= 0.6
-                   , monad-control            >= 0.3
-                   , lifted-base              >= 0.1
                    , resource-pool            >= 0.2.2.0
                    , path-pieces              >= 0.1
                    , http-api-data            >= 0.2       && < 0.4
                    , aeson                    >= 0.5
                    , monad-logger             >= 0.3
-                   , transformers-base
                    , base64-bytestring
                    , unordered-containers
                    , vector
@@ -53,6 +49,7 @@ library
                    , fast-logger              >= 2.1
                    , scientific
                    , tagged
+                   , unliftio-core
 
     exposed-modules: Database.Persist
                      Database.Persist.Quasi
@@ -112,7 +109,6 @@ test-suite test
                    , scientific
                    , tagged
                    , fast-logger              >= 2.1
-                   , lifted-base              >= 0.1
                    , mtl
                    , template-haskell
                    , resource-pool

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -30,7 +30,7 @@ library
                    , text                     >= 0.8
                    , containers               >= 0.2
                    , conduit                  >= 1.2.8
-                   , resourcet                >= 1.1
+                   , resourcet                >= 1.1.10
                    , resource-pool            >= 0.2.2.0
                    , path-pieces              >= 0.1
                    , http-api-data            >= 0.2       && < 0.4

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:            persistent
-version:         2.7.3
+version:         2.8.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -50,6 +50,7 @@ library
                    , scientific
                    , tagged
                    , unliftio-core
+                   , void
 
     exposed-modules: Database.Persist
                      Database.Persist.Quasi
@@ -86,7 +87,7 @@ test-suite test
     type:          exitcode-stdio-1.0
     main-is:       test/main.hs
 
-    build-depends:   base >= 4.6 && < 5
+    build-depends:   base >= 4.8 && < 5
                    , hspec >= 1.3
                    , containers
                    , text

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -29,7 +29,7 @@ library
                    , old-locale
                    , text                     >= 0.8
                    , containers               >= 0.2
-                   , conduit                  >= 1.0
+                   , conduit                  >= 1.2.8
                    , resourcet                >= 1.1
                    , resource-pool            >= 0.2.2.0
                    , path-pieces              >= 0.1

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -35,7 +35,7 @@ library
                    , path-pieces              >= 0.1
                    , http-api-data            >= 0.2       && < 0.4
                    , aeson                    >= 0.5
-                   , monad-logger             >= 0.3
+                   , monad-logger             >= 0.3.28
                    , base64-bytestring
                    , unordered-containers
                    , vector

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,3 +11,15 @@ packages:
 extra-deps:
 - monad-logger-0.3.28
 - mysql-simple-0.4.4
+
+- mono-traversable-1.0.8.1
+- unliftio-0.2.4.0
+- unliftio-core-0.1.1.0
+- async-2.1.1.1
+- typed-process-0.2.1.0
+- git: https://github.com/snoyberg/conduit
+  commit: 7f75bfca8d479e1737861a75437a288af662a3cf
+  subdirs:
+  - conduit
+  - conduit-extra
+  - resourcet

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,3 +17,4 @@ extra-deps:
 - unliftio-core-0.1.1.0
 - async-2.1.1.1
 - typed-process-0.2.1.0
+- resourcet-1.1.11

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,9 +17,3 @@ extra-deps:
 - unliftio-core-0.1.1.0
 - async-2.1.1.1
 - typed-process-0.2.1.0
-- git: https://github.com/snoyberg/conduit
-  commit: 7f75bfca8d479e1737861a75437a288af662a3cf
-  subdirs:
-  - conduit
-  - conduit-extra
-  - resourcet

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,3 +8,5 @@ packages:
   - ./persistent-mysql
   - ./persistent-postgresql
   - ./persistent-redis
+extra-deps:
+- monad-logger-0.3.28

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-8.2
+resolver: lts-10.4
 packages:
   - ./persistent
   - ./persistent-template
@@ -9,7 +9,7 @@ packages:
   - ./persistent-postgresql
   - ./persistent-redis
 extra-deps:
-- monad-logger-0.3.28
+- monad-logger-0.3.28.1
 - mysql-simple-0.4.4
 
 - mono-traversable-1.0.8.1

--- a/travis/run.sh
+++ b/travis/run.sh
@@ -5,7 +5,16 @@ set -euxo pipefail
 if [ "$BACKEND" = "none" ]
 then
     PACKAGES=$(stack --install-ghc query locals | grep '^ *path' | sed 's@^ *path:@@' | grep -v 'persistent-test' )
-    exec stack $ARGS --no-terminal test --pedantic $PACKAGES
+
+    PEDANTIC="--pedantic"
+    # Turn off pedantic for lts-7, due to the sometimes invalid
+    # redundant constraint warnings.
+    if [ "$ARGS" = "--resolver lts-7" ]
+    then
+        PEDANTIC=""
+    fi
+
+    exec stack $ARGS --no-terminal test $PEDANTIC $PACKAGES
 else
     if [ "$BACKEND" = "postgresql" ]
     then

--- a/travis/run.sh
+++ b/travis/run.sh
@@ -2,13 +2,10 @@
 
 set -euxo pipefail
 
-ARGS="$ARGS --no-terminal --install-ghc"
-stack $ARGS solver --update-config
-
 if [ "$BACKEND" = "none" ]
 then
     PACKAGES=$(stack --install-ghc query locals | grep '^ *path' | sed 's@^ *path:@@' | grep -v 'persistent-test' )
-    exec stack $ARGS test --pedantic $PACKAGES
+    exec stack $ARGS --no-terminal test --pedantic $PACKAGES
 else
     if [ "$BACKEND" = "postgresql" ]
     then
@@ -19,5 +16,5 @@ else
     fi
 
     cd persistent-test
-    exec stack $ARGS test --pedantic --fast persistent-test --flag persistent-test:$BACKEND --exec persistent-test
+    exec stack $ARGS --no-terminal test --pedantic --fast persistent-test --flag persistent-test:$BACKEND --exec persistent-test
 fi


### PR DESCRIPTION
The new version of conduit (1.3) is going to be released soon, and will be switching from `monad-control` over to `unliftio-core`. This PR moves the persistent API over as well for compatibility, while still keeping compatibility with the older version (though Travis may discover a few things I still need to tweak to make this work). It also drops usage of deprecated operators and type synonyms in conduit 1.3, and cleans up a few other warnings.

Is there any objection to me merging this and making a new major release of persistent, persistent-sqlite, persistent-postgresql, persistent-mysql, and persistent-mongoDB when I'm releasing the new version of conduit?