### PR TITLE
Use native PostgreSQL arrays when serializing lists

### DIFF
--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -422,7 +422,7 @@ instance PGTF.ToField P where
     toField (P (PersistTimeOfDay t))   = PGTF.toField t
     toField (P (PersistUTCTime t))     = PGTF.toField t
     toField (P PersistNull)            = PGTF.toField PG.Null
-    toField (P (PersistList l))        = PGTF.toField $ listToJSON l
+    toField (P (PersistList l))        = PGTF.toField $ PG.PGArray (map P l)
     toField (P (PersistMap m))         = PGTF.toField $ mapToJSON m
     toField (P (PersistDbSpecific s))  = PGTF.toField (Unknown s)
     toField (P (PersistObjectId _))    =


### PR DESCRIPTION
There are a number of issues requesting native PostgreSQL arrays (#609, #571, and a few older ones), instead of the current roundtrip through JSON. I looked at the code and it seems the only change needed to support this is the one-line change in this PR. I tested this locally and the list serialization to PGArray works as intended and tests (run as `stack test` in the root directory) all pass.

If this is accepted, it would be great to backport to the 2.6.* version which is the latest available on stackage as well.