### PR TITLE
Add sql= to unique constraints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ persistent-test/db/
 
 # macOS
 .DS_Store
+
+# hspec nonsense
+.hspec-failures

--- a/docs/Persistent-entity-syntax.md
+++ b/docs/Persistent-entity-syntax.md
@@ -119,8 +119,18 @@ For MongoDB currently one always needs to create the key on the application side
     Id String sqltype=varchar(3) sql=code
 ```
 
-Composite key (using multiple columns) can also be defined using `Primary` (see [Primary and Foreign Keys](#primary-and-foreign-keys)). 
-    
+Composite key (using multiple columns) can also be defined using `Primary` (see [Primary and Foreign Keys](#primary-and-foreign-keys)).
+
+`sql=` also works for setting the names of unique indexes.
+
+```
+Person
+  name Text
+  phone Text
+  UniquePersonPhone phone sql=UniqPerPhone
+```
+
+This makes a unique index requiring `phone` to be unique across `Person` rows. Ordinarily Persistent will generate a snake-case index name from the capitalized name provided such that `UniquePersonPhone` becomes `unique_person_phone`. However, we provided a `sql=` so the index name in the database will instead be `UniqPerPhone`. Keep in mind `sql=` and `!` attrs must come after the list of fields in front of the index name in the quasi-quoter.
 
 ## Primary and Foreign keys
 

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -1,5 +1,5 @@
 name:            persistent-test
-version:         2.0.1.0
+version:         2.0.2.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/persistent-test/src/UniqueTest.hs
+++ b/persistent-test/src/UniqueTest.hs
@@ -20,12 +20,12 @@ share [mkPersist sqlSettings,  mkMigrate "uniqueMigrate"] [persistLowerCase|
 #endif
   TestNonNull
     fieldA Int
-    UniqueTestNonNull fieldA
+    UniqueTestNonNull fieldA sql=UniqueTestNonNull !force
     deriving Eq Show
   TestNull
     fieldA Int
     fieldB Int Maybe
-    UniqueTestNull fieldA fieldB !force
+    UniqueTestNull fieldA fieldB sql=UniqueTestNonNullSqlName !force
     deriving Eq Show
 #ifndef WITH_NOSQL
   TestCheckmark

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,3 +1,7 @@
+## 2.8.2
+
+* Added support for `sql=` to the unique constraints quasi-quoter so that users can specify the database names of the constraints.
+
 ## 2.8.1
 
 * DRY-ed up and exposed several util functions in `Database.Persist.Sql.Util`.

--- a/persistent/Database/Persist/Quasi.hs
+++ b/persistent/Database/Persist/Quasi.hs
@@ -462,7 +462,10 @@ takeComposite fields pkcols
                 else d
         | otherwise = getDef ds t
 
--- Unique UppercaseConstraintName list of lowercasefields
+-- Unique UppercaseConstraintName list of lowercasefields terminated
+-- by ! or sql= such that a unique constraint can look like:
+-- `UniqueTestNull fieldA fieldB sql=ConstraintNameInDatabase !force`
+-- Here using sql= sets the name of the constraint.
 takeUniq :: PersistSettings
          -> Text
          -> [FieldDef]

--- a/persistent/Database/Persist/Quasi.hs
+++ b/persistent/Database/Persist/Quasi.hs
@@ -23,7 +23,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import Control.Arrow ((&&&))
 import qualified Data.Map as M
-import Data.List (foldl')
+import Data.List (find, foldl')
 import Data.Monoid (mappend)
 import Control.Monad (msum, mplus)
 
@@ -464,24 +464,51 @@ takeComposite fields pkcols
 
 -- Unique UppercaseConstraintName list of lowercasefields
 takeUniq :: PersistSettings
-          -> Text
-          -> [FieldDef]
-          -> [Text]
-          -> UniqueDef
+         -> Text
+         -> [FieldDef]
+         -> [Text]
+         -> UniqueDef
 takeUniq ps tableName defs (n:rest)
     | not (T.null n) && isUpper (T.head n)
         = UniqueDef
             (HaskellName n)
-            (DBName $ psToDBName ps (tableName `T.append` n))
+            dbName
             (map (HaskellName &&& getDBName defs) fields)
             attrs
   where
-    (fields,attrs) = break ("!" `T.isPrefixOf`) rest
-    getDBName [] t = error $ "Unknown column in unique constraint: " ++ show t
+    isAttr a =
+      "!" `T.isPrefixOf` a
+    isSqlName a =
+      "sql=" `T.isPrefixOf` a
+    isNonField a =
+       isAttr a
+      || isSqlName a
+    (fields, nonFields) =
+      break isNonField rest
+    attrs = filter isAttr nonFields
+    usualDbName =
+      DBName $ psToDBName ps (tableName `T.append` n)
+    sqlName :: Maybe DBName
+    sqlName =
+      case find isSqlName nonFields of
+        Nothing ->
+          Nothing
+        (Just t) ->
+          case drop 1 $ T.splitOn "=" t of
+            (x : _) -> Just (DBName x)
+            _ -> Nothing
+    dbName = fromMaybe usualDbName sqlName
+    getDBName [] t =
+      error $ "Unknown column in unique constraint: " ++ show t
+              ++ " " ++ show defs ++ show n ++ " " ++ show attrs
     getDBName (d:ds) t
         | fieldHaskell d == HaskellName t = fieldDB d
         | otherwise = getDBName ds t
-takeUniq _ tableName _ xs = error $ "invalid unique constraint on table[" ++ show tableName ++ "] expecting an uppercase constraint name xs=" ++ show xs
+takeUniq _ tableName _ xs =
+  error $ "invalid unique constraint on table["
+          ++ show tableName
+          ++ "] expecting an uppercase constraint name xs="
+          ++ show xs
 
 data UnboundForeignDef = UnboundForeignDef
                          { _unboundFields :: [Text] -- ^ fields in other entity

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:            persistent
-version:         2.8.1
+version:         2.8.2
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html) (kind of, not sure if any haddocks specify the QQ)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock (not relevant, didn't add anything new?)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts) --- I am waiting for this one.

I needed to be able to specify the database name of a unique constraint. This was triggered by the porting of a client's Groundhog schema to Persistent. I didn't want to drop and then create the constraint with `snake_case` syntax and I imagine this has come up at some point for someone else so I'm adding it.

Please let me know if I missed anything.