### PR TITLE
Document building a subset of targets.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ packages:
 - '/path/to/this/repo/persistent-postgresql'
 ```
 
-Additional information can be found in `development.md`.
+Additional information can be found in [development.md](development.md).
 
 ## Coding Guidelines
 

--- a/README.md
+++ b/README.md
@@ -32,10 +32,7 @@ One can always fall back to using the raw database driver or other lower-level o
 
 ## Install from source
 
-Clone the repo and run
-
-    stack build
-
-# Developing persistent
-
-See [development.md](https://github.com/yesodweb/persistent/blob/master/development.md).
+Clone the repo and run `stack build` to build all targets. Persistent
+supports many backends. If you have only some of these installed the
+[development](development.md) docs show how to build against a subset of
+targets.

--- a/README.md
+++ b/README.md
@@ -34,5 +34,5 @@ One can always fall back to using the raw database driver or other lower-level o
 
 Clone the repo and run `stack build` to build all targets. Persistent
 supports many backends. If you have only some of these installed the
-[development](development.md) docs show how to build against a subset of
+[development doc](development.md) shows how to build against a subset of
 targets.

--- a/development.md
+++ b/development.md
@@ -8,7 +8,7 @@ listed in `stack.yaml` and is equivalent to;
 persistent-mongoDB persistent-mysql persistent-postgresql persistent-redis
 ```
 
-I can build a subset of targets excluding those with backends not installed:
+To build a subset of targets excluding those with backends not installed:
 
 ```
 > stack build persistent-mysql

--- a/development.md
+++ b/development.md
@@ -1,12 +1,43 @@
+# Building with Backends
+
+With all required backends installed, `stack build` can build all packages
+listed in `stack.yaml` and is equivalent to;
+
+```
+> stack build persistent persistent-template persistent-sqlite persistent-test
+persistent-mongoDB persistent-mysql persistent-postgresql persistent-redis
+```
+
+I can build a subset of targets excluding those with backends not installed:
+
+```
+> stack build persistent-mysql
+...
+    Process exited with code: ExitFailure 1
+    Configuring mysql-0.1.4...
+    setup: The program 'mysql_config' is required but it could not be found
+    
+> stack build persistent-postgresql
+...
+    Process exited with code: ExitFailure 1
+    Configuring postgresql-libpq-0.9.4.0...
+    setup: The program 'pg_config' is required but it could not be found.
+    
+> stack build persistent persistent-template persistent-sqlite persistent-test
+persistent-mongoDB persistent-redis
+...
+Completed 6 action(s).
+```
+
 # Running persistent tests using Stack
 
 For testing specific package:
 
-    stack test persistent-sqlite
+    > stack test persistent-sqlite
 
 For appropriate backend specific testing using the package `persistent-test`:
 
-    stack test persistent-test --flag persistent-test:<backend> --exec persistent-test
+    > stack test persistent-test --flag persistent-test:<backend> --exec persistent-test
 
 where <backend> is one listed in the cabal file
 
@@ -14,39 +45,37 @@ where <backend> is one listed in the cabal file
 
 All tests are ran from the persistent-test directory
 
-    cd persistent-test
+    > cd persistent-test
 
 Use cabal
 
-    cabal configure --enable-tests
+    > cabal configure --enable-tests
 
 If you would like to configure tests with a specific backend that can be enabled
 using
 
-    cabal configure -f<backend> --enable-tests
+    > cabal configure -f<backend> --enable-tests
 
 where <backend> is one of mongodb/postgresql/mysql/couchdb.
 
 Now run with
 
-    cabal build && dist/build/test/test
+    > cabal build && dist/build/test/test
 
-
-# Backends
+# Testing Backends
 
 By default the sqlite backend is tested.
 To test other backends, you can give a flag described in persisten-test.
 
-    cabal configure -fmongodb --enable-tests
-
+    > cabal configure -fmongodb --enable-tests
 
 ## Installing backends
 
 For an easy install we recommend running a database from a docker container.
 Lets develop easy entry points for testing a database using a command runner.
 
-    just --list
-    just test-mongo
+    > just --list
+    > just test-mongo
 
 [Installing just is easy](https://github.com/casey/just/releases).
 Or you can look in `./bin/` for the commands it will call and run them directly

--- a/development.md
+++ b/development.md
@@ -8,7 +8,8 @@ listed in `stack.yaml` and is equivalent to;
 persistent-mongoDB persistent-mysql persistent-postgresql persistent-redis
 ```
 
-To build a subset of targets excluding those with backends not installed:
+To build when missing backends, such as mysql and postgres shown here, drop the
+targets not installed:
 
 ```
 > stack build persistent-mysql

--- a/development.md
+++ b/development.md
@@ -1,15 +1,15 @@
 # Building with Backends
 
 With all required backends installed, `stack build` can build all packages
-listed in `stack.yaml` and is equivalent to;
+listed in `stack.yaml` and is equivalent to:
 
 ```
 > stack build persistent persistent-template persistent-sqlite persistent-test
 persistent-mongoDB persistent-mysql persistent-postgresql persistent-redis
 ```
 
-To build when missing backends, such as mysql and postgres shown here, drop the
-targets not installed:
+If backends such as mysql and postgres are not installed then the default build
+will fail as will builds for packages for those backends alone:
 
 ```
 > stack build persistent-mysql
@@ -23,7 +23,11 @@ targets not installed:
     Process exited with code: ExitFailure 1
     Configuring postgresql-libpq-0.9.4.0...
     setup: The program 'pg_config' is required but it could not be found.
-    
+```
+
+To build all other packages, drop the failing package names as targets:
+
+```
 > stack build persistent persistent-template persistent-sqlite persistent-test
 persistent-mongoDB persistent-redis
 ...


### PR DESCRIPTION
Documentation changes explaining how to build against a subset of targets if only some of the required backends are installed, fixes #808.