### PR TITLE
added: PersistentTest: upsert fail, it expected equivalent repsert

### DIFF
--- a/persistent-test/src/PersistentTest.hs
+++ b/persistent-test/src/PersistentTest.hs
@@ -573,6 +573,15 @@ specs = describe "persistent" $ do
         upsertAge (entityVal update') @== 5
         upsertExtra (entityVal update') @== "extra"
 #endif
+    it "leaving this empty is the equivalent of performing a repsert on a unique key" $ db $ do
+        Entity key _ <- insertEntity (Upsert "foo" "initial" "" 2)
+        repsert' <- do
+          repsert key (Upsert "foo" "update" "" 3)
+          getJustEntity key
+        deleteWhere ([] :: [Filter Upsert])
+        _ <- insertEntity (Upsert "foo" "initial" "" 2)
+        upsert' <- upsert (Upsert "foo" "update" "" 3) []
+        upsert' @== repsert'
 
   describe "upsertBy" $ do
     let uniqueEmail = UniqueUpsertBy "a"


### PR DESCRIPTION
I see
[haskell - Persistent `upsert` isn't working -
Stack Overflow](https://stackoverflow.com/questions/50050431/persistent-upsert-isnt-working)

The question is that if the second update argument of upsert is empty, the data will not be updated.

Certainly it is written in the document comment as follows.

> leaving this empty is the equivalent of performing a repsert on a unique key
>
> [Database.Persist.Class](https://www.stackage.org/haddock/lts-11.15/persistent-2.8.2/Database-Persist-Class.html#v:upsert)

According to the document, upsert needs to behave like repsert if the second argument is empty.

However, looking at the source code, it seems that such behavior is not supposed to be.

So I wrote a test that failed.

To send test results, this bug report uses pull request instead of issue.

I do not know which is better for me, whether to modify the document or modify the implementation.

It is fail test, I do not check version number and CI.

Before submitting your PR, check that you've:

- [ ] Bumped the version number
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->