### PR TITLE
Improve error message when marshalling fails

### DIFF
--- a/persistent-template/ChangeLog.md
+++ b/persistent-template/ChangeLog.md
@@ -1,4 +1,5 @@
 ## 2.6.0
+* [persistent#846](https://github.com/yesodweb/persistent/pull/846): Improve error message when marshalling fails
 * [persistent#826](https://github.com/yesodweb/persistent/pull/826): Change `Unique` derive `Show`
 
 ## 2.5.4

--- a/persistent-template/Database/Persist/TH.hs
+++ b/persistent-template/Database/Persist/TH.hs
@@ -1007,18 +1007,23 @@ fromValues t funName conE fields = do
       UInfixE exp applyE (fpv `AppE` VarE name)
 
     mkPersistValue field =
-      [|mapLeft (fieldError field) . fromPersistValue|]
+      [|mapLeft (fieldError t field) . fromPersistValue|]
 
-fieldError :: FieldDef -> Text -> Text
-fieldError field err = mconcat
+fieldError :: EntityDef -> FieldDef -> Text -> Text
+fieldError entity field err = mconcat
   [ "Couldn't parse field `"
   , fieldName
-  , "` from database results: "
+  , "` from table `"
+  , tableName
+  , "`. "
   , err
   ]
   where
     fieldName =
       unHaskellName (fieldHaskell field)
+
+    tableName =
+      unDBName (entityDB entity)
 
 mkEntity :: EntityMap -> MkPersistSettings -> EntityDef -> Q [Dec]
 mkEntity entMap mps t = do

--- a/persistent-template/Database/Persist/TH.hs
+++ b/persistent-template/Database/Persist/TH.hs
@@ -674,9 +674,6 @@ mapLeft :: (a -> c) -> Either a b -> Either c b
 mapLeft _ (Right r) = Right r
 mapLeft f (Left l)  = Left (f l)
 
-fieldError :: Text -> Text -> Text
-fieldError fieldName err = "Couldn't parse field `" `mappend` fieldName `mappend` "` from database results: " `mappend` err
-
 mkFromPersistValues :: MkPersistSettings -> EntityDef -> Q [Clause]
 mkFromPersistValues _ t@(EntityDef { entitySum = False }) =
     fromValues t "fromPersistValues" entE $ entityFields t
@@ -980,37 +977,43 @@ headNote (x:[]) = x
 headNote xs = error $ "mkKeyFromValues: expected a list of one element, got: "
   `mappend` show xs
 
-
 fromValues :: EntityDef -> Text -> Exp -> [FieldDef] -> Q [Clause]
 fromValues t funName conE fields = do
-    x <- newName "x"
-    let funMsg = entityText t `mappend` ": " `mappend` funName `mappend` " failed on: "
-    patternMatchFailure <-
-      [|Left $ mappend funMsg (pack $ show $(return $ VarE x))|]
-    suc <- patternSuccess fields
-    return [ suc, normalClause [VarP x] patternMatchFailure ]
+  x <- newName "x"
+  let funMsg = entityText t `mappend` ": " `mappend` funName `mappend` " failed on: "
+  patternMatchFailure <- [|Left $ mappend funMsg (pack $ show $(return $ VarE x))|]
+  suc <- patternSuccess
+  return [ suc, normalClause [VarP x] patternMatchFailure ]
   where
-    patternSuccess [] = do
-      rightE <- [|Right|]
-      return $ normalClause [ListP []] (rightE `AppE` conE)
-    patternSuccess fieldsNE = do
-        x1 <- newName "x1"
-        restNames <- mapM (\i -> newName $ "x" `mappend` show i) [2..length fieldsNE]
-        (fpv1:mkPersistValues) <- mapM mkPvFromFd fieldsNE
-        app1E <- [|(<$>)|]
-        let conApp = infixFromPersistValue app1E fpv1 conE x1
-        applyE <- [|(A.<*>)|]
-        let applyFromPersistValue = infixFromPersistValue applyE
+    patternSuccess =
+      case fields of
+        [] -> do
+          rightE <- [|Right|]
+          return $ normalClause [ListP []] (rightE `AppE` conE)
+        _ -> do
+          x1 <- newName "x1"
+          restNames <- mapM (\i -> newName $ "x" `mappend` show i) [2..length fields]
+          (fpv1:mkPersistValues) <- mapM mkPvFromFd fields
+          app1E <- [|(<$>)|]
+          let conApp = infixFromPersistValue app1E fpv1 conE x1
+          applyE <- [|(A.<*>)|]
+          let applyFromPersistValue = infixFromPersistValue applyE
 
-        return $ normalClause
-            [ListP $ map VarP (x1:restNames)]
-            (foldl' (\exp (name, fpv) -> applyFromPersistValue fpv exp name) conApp (zip restNames mkPersistValues))
-        where
-          infixFromPersistValue applyE fpv exp name =
-              UInfixE exp applyE (fpv `AppE` VarE name)
-          mkPvFromFd = mkPersistValue . unHaskellName . fieldHaskell
-          mkPersistValue fieldName = [|mapLeft (fieldError fieldName) . fromPersistValue|]
+          return $ normalClause
+              [ListP $ map VarP (x1:restNames)]
+              (foldl' (\exp (name, fpv) -> applyFromPersistValue fpv exp name) conApp (zip restNames mkPersistValues))
 
+    infixFromPersistValue applyE fpv exp name =
+      UInfixE exp applyE (fpv `AppE` VarE name)
+
+    mkPvFromFd =
+      mkPersistValue . unHaskellName . fieldHaskell
+
+    mkPersistValue fieldName =
+      [|mapLeft (fieldError fieldName) . fromPersistValue|]
+
+fieldError :: Text -> Text -> Text
+fieldError fieldName err = "Couldn't parse field `" `mappend` fieldName `mappend` "` from database results: " `mappend` err
 
 mkEntity :: EntityMap -> MkPersistSettings -> EntityDef -> Q [Dec]
 mkEntity entMap mps t = do


### PR DESCRIPTION
Alters the error message that appears when marshalling DB values to include the name of the table. I have found it useful to know the table when this error rears its head with generic field names (`lastAccessed` for example), allowing me to go straight to the offending table.

---

I'm not sure which of these I need to complete for this change (bumping version number seems drastic, and I've not changed any public facing API):

Before submitting your PR, check that you've:

- [ ] Bumped the version number
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)