### PR TITLE
Add benchmark for persistent-template

### DIFF
--- a/persistent-template/bench/Main.hs
+++ b/persistent-template/bench/Main.hs
@@ -1,0 +1,30 @@
+module Main (main) where
+
+import Criterion.Main
+import qualified Data.Text as Text
+import Language.Haskell.TH
+
+import Database.Persist.Quasi
+import Database.Persist.TH
+import Models
+
+parseReferences' :: String -> IO Exp
+parseReferences' = runQ . parseReferences upperCaseSettings . Text.pack
+
+main :: IO ()
+main = defaultMain
+    [ bgroup "Parsing"
+        [ bgroup "Increasing model count"
+            [ bench "1x10" $ whnfIO $ parseReferences' (mkModels 10 10)
+            , bench "10x10" $ whnfIO $ parseReferences' (mkModels 10 10)
+            , bench "100x10" $ whnfIO $ parseReferences' (mkModels 100 10)
+            , bench "1000x10" $ whnfIO $ parseReferences' (mkModels 1000 10)
+            ]
+        , bgroup "Increasing field count"
+            [ bench "100x1" $ whnfIO $ parseReferences' (mkModels 100 1)
+            , bench "100x10" $ whnfIO $ parseReferences' (mkModels 100 10)
+            , bench "100x100" $ whnfIO $ parseReferences' (mkModels 100 100)
+            , bench "100x1000" $ whnfIO $ parseReferences' (mkModels 100 1000)
+            ]
+        ]
+    ]

--- a/persistent-template/bench/Models.hs
+++ b/persistent-template/bench/Models.hs
@@ -1,0 +1,36 @@
+module Models where
+
+import Data.Monoid
+import Data.List
+import Data.FileEmbed
+
+-- | # of models, # of fields
+mkModels :: Int -> Int -> String
+mkModels i f = unlines . fmap unlines . take i . map mkModel . zip [0..] . cycle $
+    [ "Model"
+    , "Foobar"
+    , "User"
+    , "King"
+    , "Queen"
+    , "Dog"
+    , "Cat"
+    ]
+  where
+    mkModel (i, m) =
+        (m <> show i) : indent 4 (mkFields f)
+
+
+indent :: Int -> [String] -> [String]
+indent i = map (replicate i ' ' ++)
+
+mkFields :: Int -> [String]
+mkFields i = take i $ map mkField $ zip [0..] $ cycle
+    [ "Bool"
+    , "Int"
+    , "String"
+    , "Char"
+    , "Double"
+    ]
+  where
+    mkField (i, typ) = "field" <> show i <> "\t\t" <> typ
+

--- a/persistent-template/persistent-template.cabal
+++ b/persistent-template/persistent-template.cabal
@@ -54,3 +54,17 @@ test-suite test
 source-repository head
   type:     git
   location: git://github.com/yesodweb/persistent.git
+
+benchmark persistent-th-bench
+    ghc-options:      -O2 -threaded 
+    type:             exitcode-stdio-1.0
+    main-is:          Main.hs
+    hs-source-dirs:   bench
+    build-depends:    base
+                    , criterion
+                    , file-embed
+                    , persistent-template
+                    , persistent
+                    , text
+                    , template-haskell
+    other-modules:    Models


### PR DESCRIPTION
I was going to see if optimizing the parser would net meaningful compilation gains, but it doesn't appear to be that slow.

Here's the output from a run on my laptop:

```
benchmarking Parsing/Increasing model count/1x10
time                 902.7 μs   (895.7 μs .. 911.2 μs)
                     0.999 R²   (0.999 R² .. 1.000 R²)
mean                 906.8 μs   (901.8 μs .. 916.8 μs)
std dev              22.43 μs   (11.78 μs .. 36.48 μs)
variance introduced by outliers: 14% (moderately inflated)

benchmarking Parsing/Increasing model count/10x10
time                 915.1 μs   (910.9 μs .. 919.7 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 917.2 μs   (913.1 μs .. 925.6 μs)
std dev              19.59 μs   (11.16 μs .. 36.22 μs)
variance introduced by outliers: 11% (moderately inflated)

benchmarking Parsing/Increasing model count/100x10
time                 17.41 ms   (17.03 ms .. 17.77 ms)
                     0.997 R²   (0.995 R² .. 0.999 R²)
mean                 16.88 ms   (16.31 ms .. 17.24 ms)
std dev              1.020 ms   (545.2 μs .. 1.822 ms)
variance introduced by outliers: 26% (moderately inflated)

benchmarking Parsing/Increasing model count/1000x10
time                 216.9 ms   (158.4 ms .. 274.7 ms)
                     0.975 R²   (0.904 R² .. 1.000 R²)
mean                 196.1 ms   (168.2 ms .. 213.3 ms)
std dev              28.39 ms   (12.92 ms .. 39.74 ms)
variance introduced by outliers: 38% (moderately inflated)

benchmarking Parsing/Increasing field count/100x1
time                 192.6 μs   (185.1 μs .. 198.5 μs)
                     0.994 R²   (0.992 R² .. 0.998 R²)
mean                 184.7 μs   (182.8 μs .. 188.3 μs)
std dev              8.209 μs   (5.398 μs .. 11.79 μs)
variance introduced by outliers: 44% (moderately inflated)

benchmarking Parsing/Increasing field count/100x10
time                 909.3 μs   (900.3 μs .. 920.6 μs)
                     0.999 R²   (0.998 R² .. 1.000 R²)
mean                 911.4 μs   (905.5 μs .. 921.0 μs)
std dev              24.25 μs   (15.47 μs .. 40.37 μs)
variance introduced by outliers: 16% (moderately inflated)

benchmarking Parsing/Increasing field count/100x100
time                 15.41 ms   (15.13 ms .. 15.65 ms)
                     0.998 R²   (0.996 R² .. 0.999 R²)
mean                 14.94 ms   (14.44 ms .. 15.22 ms)
std dev              852.0 μs   (466.3 μs .. 1.469 ms)
variance introduced by outliers: 25% (moderately inflated)

benchmarking Parsing/Increasing field count/100x1000
time                 165.8 ms   (123.8 ms .. 212.3 ms)
                     0.972 R²   (0.928 R² .. 1.000 R²)
mean                 160.5 ms   (139.2 ms .. 174.5 ms)
std dev              22.04 ms   (11.11 ms .. 32.61 ms)
variance introduced by outliers: 32% (moderately inflated)
```

Parsing appears to take `O(n+m)` where `n` is the number of models and `m` is the number of fields. 100x10 seems fairly representative of most databases, and it takes under a millisecond.