### PR TITLE
Add openSimpleConnWithVersion function to persistent-postgresql

### DIFF
--- a/persistent-postgresql/ChangeLog.md
+++ b/persistent-postgresql/ChangeLog.md
@@ -1,5 +1,8 @@
 # Changelog for persistent-postgresql
 
+## 2.9.1
+* Add `openSimpleConnWithVersion` function. [#881](https://github.com/yesodweb/persistent/pull/881)
+
 ## 2.9.0
 
 * Added support for SQL isolation levels to via SqlBackend. [#812]

--- a/persistent-postgresql/ChangeLog.md
+++ b/persistent-postgresql/ChangeLog.md
@@ -1,7 +1,7 @@
 # Changelog for persistent-postgresql
 
 ## 2.9.1
-* Add `openSimpleConnWithVersion` function. [#881](https://github.com/yesodweb/persistent/pull/881)
+* Add `openSimpleConnWithVersion` function. [#883](https://github.com/yesodweb/persistent/pull/883)
 
 ## 2.9.0
 

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -240,6 +240,8 @@ openSimpleConn = openSimpleConnWithVersion getServerVersion
 
 -- | Generate a 'SqlBackend' from a 'PG.Connection', but takes a callback for
 -- obtaining the server version.
+--
+-- @since 2.9.1
 openSimpleConnWithVersion :: (IsSqlBackend backend) => (PG.Connection -> IO (Maybe Double)) -> LogFunc -> PG.Connection -> IO backend
 openSimpleConnWithVersion getVer logFunc conn = do
     smap <- newIORef $ Map.empty

--- a/persistent-postgresql/persistent-postgresql.cabal
+++ b/persistent-postgresql/persistent-postgresql.cabal
@@ -1,5 +1,5 @@
 name:            persistent-postgresql
-version:         2.9.0
+version:         2.9.1
 license:         MIT
 license-file:    LICENSE
 author:          Felipe Lessa, Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

This adds a version of `openSimpleConnWithVersion`. Since I never use old versions of PostgreSQL that lack upsert support, I want to be able to avoid doing round trip checks of the version each time I create a connection via `openSimpleConn`.