### PR TITLE
Type error on upsert.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ services:
 
 matrix:
   include:
-  - env: ARGS="--resolver lts-6  --stack-yaml stack_lts-10.yaml"
   - env: ARGS="--resolver lts-9  --stack-yaml stack_lts-10.yaml"
   - env: ARGS="--resolver lts-11"
   - env: ARGS="--resolver lts-12"

--- a/persistent-mongoDB/test/EmbedTestMongo.hs
+++ b/persistent-mongoDB/test/EmbedTestMongo.hs
@@ -1,5 +1,6 @@
 {-# OPTIONS_GHC -fno-warn-unused-binds -fno-warn-orphans -O0 #-}
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}

--- a/persistent-mongoDB/test/EntityEmbedTestMongo.hs
+++ b/persistent-mongoDB/test/EntityEmbedTestMongo.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-unused-binds #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE EmptyDataDecls #-}

--- a/persistent-mongoDB/test/MongoInit.hs
+++ b/persistent-mongoDB/test/MongoInit.hs
@@ -14,8 +14,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module MongoInit (
-  isTravis
-  , BackendMonad
+  BackendMonad
   , runConn
   , MonadIO
   , persistSettings
@@ -71,7 +70,6 @@ import qualified Data.ByteString as BS
 import Data.Text (Text)
 import Database.Persist
 import Database.Persist.TH ()
-import System.Environment (getEnvironment)
 
 import Database.Persist.Sql (PersistFieldSql(..))
 import Database.Persist.TH (mkPersistSettings)

--- a/persistent-mongoDB/test/main.hs
+++ b/persistent-mongoDB/test/main.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# language RankNTypes #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}

--- a/persistent-mysql/test/InsertDuplicateUpdate.hs
+++ b/persistent-mysql/test/InsertDuplicateUpdate.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-unused-binds -fno-warn-orphans -O0 #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE CPP                        #-}
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE EmptyDataDecls             #-}

--- a/persistent-mysql/test/main.hs
+++ b/persistent-mysql/test/main.hs
@@ -1,6 +1,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# OPTIONS_GHC -fno-warn-unused-binds #-}
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE CPP #-}

--- a/persistent-postgresql/test/ArrayAggTest.hs
+++ b/persistent-postgresql/test/ArrayAggTest.hs
@@ -18,19 +18,15 @@
 
 module ArrayAggTest where
 
+import PgInit
+
 import qualified Data.Text as T
 import Data.List (sort)
 import Control.Monad.IO.Class (MonadIO)
 import Data.Aeson
-import qualified Data.Vector as V (fromList)
 import Test.Hspec.Expectations ()
 
 import PersistentTestModels
-
-import Database.Persist
-import Database.Persist.Postgresql.JSON
-
-import PgInit
 
 share [mkPersist persistSettings,  mkMigrate "jsonTestMigrate"] [persistLowerCase|
   TestValue

--- a/persistent-postgresql/test/EquivalentTypeTestPostgres.hs
+++ b/persistent-postgresql/test/EquivalentTypeTestPostgres.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-unused-binds #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}

--- a/persistent-postgresql/test/main.hs
+++ b/persistent-postgresql/test/main.hs
@@ -1,6 +1,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# OPTIONS_GHC -fno-warn-unused-binds #-}
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE CPP #-}

--- a/persistent-redis/tests/basic-test.hs
+++ b/persistent-redis/tests/basic-test.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE TemplateHaskell, QuasiQuotes #-}
 {-# LANGUAGE TypeFamilies, EmptyDataDecls, GADTs #-}
 {-# LANGUAGE TypeSynonymInstances, MultiParamTypeClasses, GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
 module Main where
 
 import qualified Database.Redis as R
@@ -12,7 +13,7 @@ import Control.Monad.IO.Class (liftIO)
 import Data.Text (Text, pack, unpack)
 
 let redisSettings = mkPersistSettings (ConT ''RedisBackend)
- in share [mkPersist redisSettings] [persistLowerCase| 
+ in share [mkPersist redisSettings] [persistLowerCase|
 Person
     name String
     age Int
@@ -34,7 +35,7 @@ mkKey s = case keyFromValues [PersistText s] of
     Left  a -> fail (unpack a)
 
 main :: IO ()
-main = 
+main =
     withRedisConn redisConf $ runRedisPool $ do
         _ <- liftIO $ print "Inserting..."
         s <- insert $ Person "Test" 12

--- a/persistent-sqlite/test/SqliteInit.hs
+++ b/persistent-sqlite/test/SqliteInit.hs
@@ -46,6 +46,7 @@ module SqliteInit (
   , truncateUTCTime
   , arbText
   , liftA2
+  , MonadFail
   ) where
 
 import Init
@@ -57,12 +58,9 @@ import Init
     )
 
 -- re-exports
-import Control.Applicative (liftA2)
 import Test.QuickCheck.Instances ()
-import Data.Char (generalCategory, GeneralCategory(..))
-import qualified Data.Text as T
-import Data.Fixed (Pico,Micro)
-import Data.Time
+-- import Data.Fixed (Pico,Micro)
+-- import Data.Time
 import Control.Applicative as A ((<$>), (<*>))
 import Control.Exception (SomeException)
 import Control.Monad (void, replicateM, liftM, when, forM_)
@@ -72,13 +70,11 @@ import Test.Hspec
 
 -- testing
 import Test.HUnit ((@?=),(@=?), Assertion, assertFailure, assertBool)
-import Test.QuickCheck
 
 import qualified Data.ByteString as BS
-import Data.Text (Text, unpack)
+import Data.Text (Text)
 import Database.Persist
 import Database.Persist.TH ()
-import System.Environment (getEnvironment)
 
 import Control.Monad.Logger
 import Control.Monad.Trans.Resource (ResourceT, runResourceT)
@@ -86,8 +82,6 @@ import Database.Persist.Sql
 import System.Log.FastLogger (fromLogStr)
 
 import Database.Persist.Sqlite
-import Data.IORef (newIORef, IORef, writeIORef, readIORef)
-import System.IO.Unsafe (unsafePerformIO)
 
 import Control.Monad (unless, (>=>))
 import Control.Monad.IO.Unlift (MonadUnliftIO)

--- a/persistent-sqlite/test/SqliteInit.hs
+++ b/persistent-sqlite/test/SqliteInit.hs
@@ -59,8 +59,6 @@ import Init
 
 -- re-exports
 import Test.QuickCheck.Instances ()
--- import Data.Fixed (Pico,Micro)
--- import Data.Time
 import Control.Applicative as A ((<$>), (<*>))
 import Control.Exception (SomeException)
 import Control.Monad (void, replicateM, liftM, when, forM_)

--- a/persistent-sqlite/test/main.hs
+++ b/persistent-sqlite/test/main.hs
@@ -1,6 +1,7 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# OPTIONS_GHC -fno-warn-unused-binds #-}
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE CPP #-}

--- a/persistent-template/ChangeLog.md
+++ b/persistent-template/ChangeLog.md
@@ -1,3 +1,7 @@
+## 2.7.0
+
+* Depends on `persistent-2.10.0` which provides the `OnlyOneUniqueKey` and `AtLeastOneUniqueKey` classes. Automatically generates instances for these classes based on how many unique keys the entity definition gets. This changes requires `UndecidableInstances` to be enabled on each module that generates entity definitions. [TODO: add issue number]()
+
 ## 2.6.0
 * [persistent#846](https://github.com/yesodweb/persistent/pull/846): Improve error message when marshalling fails
 * [persistent#826](https://github.com/yesodweb/persistent/pull/826): Change `Unique` derive `Show`

--- a/persistent-template/ChangeLog.md
+++ b/persistent-template/ChangeLog.md
@@ -1,6 +1,6 @@
 ## 2.7.0
 
-* Depends on `persistent-2.10.0` which provides the `OnlyOneUniqueKey` and `AtLeastOneUniqueKey` classes. Automatically generates instances for these classes based on how many unique keys the entity definition gets. This changes requires `UndecidableInstances` to be enabled on each module that generates entity definitions. [TODO: add issue number]()
+* Depends on `persistent-2.10.0` which provides the `OnlyOneUniqueKey` and `AtLeastOneUniqueKey` classes. Automatically generates instances for these classes based on how many unique keys the entity definition gets. This changes requires `UndecidableInstances` to be enabled on each module that generates entity definitions. [#885](https://github.com/yesodweb/persistent/pull/885)
 
 ## 2.6.0
 * [persistent#846](https://github.com/yesodweb/persistent/pull/846): Improve error message when marshalling fails

--- a/persistent-template/Database/Persist/TH.hs
+++ b/persistent-template/Database/Persist/TH.hs
@@ -1119,9 +1119,9 @@ mkUniqueKeyInstances mps t = do
     undecidableInstancesEnabled <- isExtEnabled UndecidableInstances
     unless undecidableInstancesEnabled . fail
         $ "Generating Persistent entities now requires the 'UndecidableInstances' "
-        <> "language extension. Please enable it in your file by copy/pasting "
-        <> "this line into the top of your file: \n\n"
-        <> "{-# LANGUAGE UndecidableInstances #-}"
+        `mappend` "language extension. Please enable it in your file by copy/pasting "
+        `mappend` "this line into the top of your file: \n\n"
+        `mappend` "{-# LANGUAGE UndecidableInstances #-}"
     case entityUniques t of
         [] -> mappend <$> typeErrorSingle <*> typeErrorAtLeastOne
         [_] -> mappend <$> singleUniqueKey <*> atLeastOneKey

--- a/persistent-template/Database/Persist/TH.hs
+++ b/persistent-template/Database/Persist/TH.hs
@@ -1173,7 +1173,7 @@ mkUniqueKeyInstances mps t = do
 
     singleUniqueKey :: Q [Dec]
     singleUniqueKey = do
-        expr <- [e|\p -> head (persistUniqueKeysP p)|]
+        expr <- [e|\p -> head (persistUniqueKeys p)|]
         let impl = [FunD onlyUniquePName [Clause [] (NormalB expr) []]]
         cxt <- withPersistStoreWriteCxt
         pure [instanceD cxt onlyOneUniqueKeyClass impl]
@@ -1183,7 +1183,7 @@ mkUniqueKeyInstances mps t = do
 
     atLeastOneKey :: Q [Dec]
     atLeastOneKey = do
-        expr <- [e|\p -> NEL.fromList (persistUniqueKeysP p)|]
+        expr <- [e|\p -> NEL.fromList (persistUniqueKeys p)|]
         let impl = [FunD requireUniquesPName [Clause [] (NormalB expr) []]]
         cxt <- withPersistStoreWriteCxt
         pure [instanceD cxt atLeastOneUniqueKeyClass impl]

--- a/persistent-template/Database/Persist/TH.hs
+++ b/persistent-template/Database/Persist/TH.hs
@@ -47,11 +47,16 @@ module Database.Persist.TH
     , packPTH
     , lensPTH
     , parseReferences
+    , AtLeastOneUniqueKey(..)
+    , OnlyOneUniqueKey(..)
     ) where
 
 import Prelude hiding ((++), take, concat, splitAt, exp)
+
+import qualified Data.List.NonEmpty as NEL
 import Database.Persist
 import Database.Persist.Sql (Migration, migrate, SqlBackend, PersistFieldSql)
+-- import Database.Persist.Class
 import Database.Persist.Quasi
 import Language.Haskell.TH.Lib (
 #if MIN_VERSION_template_haskell(2,11,0)
@@ -61,7 +66,7 @@ import Language.Haskell.TH.Lib (
 import Language.Haskell.TH.Quote
 import Language.Haskell.TH.Syntax
 import Data.Char (toLower, toUpper)
-import Control.Monad (forM, (<=<), mzero)
+import Control.Monad (forM, unless, (<=<), mzero)
 import qualified System.IO as SIO
 import Data.Text (pack, Text, append, unpack, concat, uncons, cons, stripPrefix, stripSuffix)
 import qualified Data.Text as T
@@ -86,6 +91,8 @@ import Web.PathPieces (PathPiece(..))
 import Web.HttpApiData (ToHttpApiData(..), FromHttpApiData(..))
 import GHC.Generics (Generic)
 import qualified Data.Text.Encoding as TE
+
+import GHC.TypeLits
 
 -- | This special-cases "type_" and strips out its underscore. When
 -- used for JSON serialization and deserialization, it works around
@@ -116,14 +123,14 @@ persistFileWith :: PersistSettings -> FilePath -> Q Exp
 persistFileWith ps fp = persistManyFileWith ps [fp]
 
 -- | Same as 'persistFileWith', but uses several external files instead of
--- one. Splitting your Persistent definitions into multiple modules can 
+-- one. Splitting your Persistent definitions into multiple modules can
 -- potentially dramatically speed up compile times.
 --
 -- The recommended file extension is @.persistentmodels@.
 --
 -- ==== __Examples__
 --
--- Split your Persistent definitions into multiple files (@models1@, @models2@), 
+-- Split your Persistent definitions into multiple files (@models1@, @models2@),
 -- then create a new module for each new file and run 'mkPersist' there:
 --
 -- @
@@ -145,13 +152,13 @@ persistFileWith ps fp = persistManyFileWith ps [fp]
 -- -- Migrate.hs
 -- 'share'
 --     ['mkMigrate' "migrateAll"]
---     $('persistManyFileWith' 'lowerCaseSettings' ["models1.persistentmodels","models2.persistentmodels"]) 
+--     $('persistManyFileWith' 'lowerCaseSettings' ["models1.persistentmodels","models2.persistentmodels"])
 -- @
 --
 -- Tip: To get the same import behavior as if you were declaring all your models in
 -- one file, import your new files @as Name@ into another file, then export @module Name@.
 --
--- This approach may be used in the future to reduce memory usage during compilation, 
+-- This approach may be used in the future to reduce memory usage during compilation,
 -- but so far we've only seen mild reductions.
 --
 -- See <https://github.com/yesodweb/persistent/issues/778 persistent#778> and
@@ -367,7 +374,8 @@ mkPersist mps ents' = do
     x <- fmap Data.Monoid.mconcat $ mapM (persistFieldFromEntity mps) ents
     y <- fmap mconcat $ mapM (mkEntity entMap mps) ents
     z <- fmap mconcat $ mapM (mkJSON mps) ents
-    return $ mconcat [x, y, z]
+    uniqueKeyInstances <- fmap mconcat $ mapM (mkUniqueKeyInstances mps) ents
+    return $ mconcat [x, y, z, uniqueKeyInstances]
   where
     ents = map fixEntityDef ents'
     entMap = M.fromList $ map (\ent -> (entityHaskell ent, ent)) ents
@@ -1105,6 +1113,83 @@ mkEntity entMap mps t = do
   where
     genDataType = genericDataType mps entName backendT
     entName = entityHaskell t
+
+mkUniqueKeyInstances :: MkPersistSettings -> EntityDef -> Q [Dec]
+mkUniqueKeyInstances mps t = do
+    undecidableInstancesEnabled <- isExtEnabled UndecidableInstances
+    unless undecidableInstancesEnabled . fail
+        $ "Generating Persistent entities now requires the 'UndecidableInstances' "
+        <> "language extension. Please enable it in your file by copy/pasting "
+        <> "this line into the top of your file: \n\n"
+        <> "{-# LANGUAGE UndecidableInstances #-}"
+    case entityUniques t of
+        [] -> mappend <$> typeErrorSingle <*> typeErrorAtLeastOne
+        [_] -> mappend <$> singleUniqueKey <*> atLeastOneKey
+        (_:_) -> mappend <$> typeErrorMultiple <*> atLeastOneKey
+  where
+    requireUniquesPName = mkName "requireUniquesP"
+    onlyUniquePName = mkName "onlyUniqueP"
+    typeErrorSingle = mkOnlyUniqueError typeErrorNoneCtx
+    typeErrorMultiple = mkOnlyUniqueError typeErrorMultipleCtx
+
+    withPersistStoreWriteCxt =
+        if mpsGeneric mps
+            then do
+                write <- [t|PersistStoreWrite $(pure (VarT $ mkName "backend")) |]
+                pure [write]
+            else do
+                pure []
+
+    typeErrorNoneCtx = do
+        tyErr <- [t|TypeError (NoUniqueKeysError $(pure genDataType))|]
+        (tyErr :) <$> withPersistStoreWriteCxt
+
+    typeErrorMultipleCtx = do
+        tyErr <- [t|TypeError (MultipleUniqueKeysError $(pure genDataType))|]
+        (tyErr :) <$> withPersistStoreWriteCxt
+
+    mkOnlyUniqueError :: Q Cxt -> Q [Dec]
+    mkOnlyUniqueError mkCtx = do
+        ctx <- mkCtx
+        let impl = mkImpossible onlyUniquePName
+        pure [instanceD ctx onlyOneUniqueKeyClass impl]
+
+    mkImpossible name =
+        [ FunD name
+            [ Clause
+                [ WildP ]
+                (NormalB
+                    (VarE (mkName "error") `AppE` LitE (StringL "impossible"))
+                )
+                []
+            ]
+        ]
+
+    typeErrorAtLeastOne :: Q [Dec]
+    typeErrorAtLeastOne = do
+        let impl = mkImpossible requireUniquesPName
+        cxt <- typeErrorMultipleCtx
+        pure [instanceD cxt atLeastOneUniqueKeyClass impl]
+
+    singleUniqueKey :: Q [Dec]
+    singleUniqueKey = do
+        expr <- [e|\p -> head (persistUniqueKeysP p)|]
+        let impl = [FunD onlyUniquePName [Clause [] (NormalB expr) []]]
+        cxt <- withPersistStoreWriteCxt
+        pure [instanceD cxt onlyOneUniqueKeyClass impl]
+
+    atLeastOneUniqueKeyClass = ConT ''AtLeastOneUniqueKey `AppT` genDataType
+    onlyOneUniqueKeyClass =  ConT ''OnlyOneUniqueKey `AppT` genDataType
+
+    atLeastOneKey :: Q [Dec]
+    atLeastOneKey = do
+        expr <- [e|\p -> NEL.fromList (persistUniqueKeysP p)|]
+        let impl = [FunD requireUniquesPName [Clause [] (NormalB expr) []]]
+        cxt <- withPersistStoreWriteCxt
+        pure [instanceD cxt atLeastOneUniqueKeyClass impl]
+
+    genDataType = genericDataType mps (entityHaskell t) backendT
+
 
 entityText :: EntityDef -> Text
 entityText = unHaskellName . entityHaskell

--- a/persistent-template/persistent-template.cabal
+++ b/persistent-template/persistent-template.cabal
@@ -1,5 +1,5 @@
 name:            persistent-template
-version:         2.6.0
+version:         2.7.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -15,9 +15,9 @@ bug-reports:     https://github.com/yesodweb/persistent/issues
 extra-source-files: test/main.hs ChangeLog.md README.md
 
 library
-    build-depends:   base                     >= 4.6         && < 5
+    build-depends:   base                     >= 4.6       && < 5
                    , template-haskell
-                   , persistent               >= 2.5       && < 3
+                   , persistent               >= 2.10      && < 3
                    , monad-control            >= 0.2       && < 1.1
                    , bytestring               >= 0.9
                    , text                     >= 0.5

--- a/persistent-template/test/main.hs
+++ b/persistent-template/test/main.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings, QuasiQuotes, TemplateHaskell, TypeFamilies, GADTs #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}

--- a/persistent-test/src/CustomPersistFieldTest.hs
+++ b/persistent-test/src/CustomPersistFieldTest.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-unused-binds #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# language RankNTypes #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -15,7 +16,6 @@ module CustomPersistFieldTest (specsWith, customFieldMigrate) where
 
 import Init
 import CustomPersistField
-import Control.Monad.Fail
 
 share [mkPersist sqlSettings { mpsGeneric = True },  mkMigrate "customFieldMigrate"] [persistLowerCase|
   BlogPost

--- a/persistent-test/src/CustomPrimaryKeyReferenceTest.hs
+++ b/persistent-test/src/CustomPrimaryKeyReferenceTest.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}

--- a/persistent-test/src/DataTypeTest.hs
+++ b/persistent-test/src/DataTypeTest.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fno-warn-unused-binds #-}
 {-# OPTIONS_GHC -fno-warn-unused-imports #-}
 {-# LANGUAGE RankNTypes #-}

--- a/persistent-test/src/EmbedOrderTest.hs
+++ b/persistent-test/src/EmbedOrderTest.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-unused-binds #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ScopedTypeVariables, FlexibleInstances #-}
 {-# LANGUAGE QuasiQuotes, TypeFamilies, GeneralizedNewtypeDeriving, TemplateHaskell,
              OverloadedStrings, GADTs, FlexibleContexts, EmptyDataDecls, MultiParamTypeClasses #-}

--- a/persistent-test/src/EmbedTest.hs
+++ b/persistent-test/src/EmbedTest.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-unused-binds -fno-warn-orphans -O0 #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}

--- a/persistent-test/src/EmptyEntityTest.hs
+++ b/persistent-test/src/EmptyEntityTest.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-unused-binds #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}

--- a/persistent-test/src/EntityEmbedTest.hs
+++ b/persistent-test/src/EntityEmbedTest.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-unused-binds #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE EmptyDataDecls #-}

--- a/persistent-test/src/EquivalentTypeTest.hs
+++ b/persistent-test/src/EquivalentTypeTest.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-unused-binds #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}

--- a/persistent-test/src/HtmlTest.hs
+++ b/persistent-test/src/HtmlTest.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-unused-binds #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE QuasiQuotes, TemplateHaskell, GADTs, TypeFamilies, OverloadedStrings, FlexibleContexts, EmptyDataDecls, FlexibleInstances, GeneralizedNewtypeDeriving, MultiParamTypeClasses #-}
 module HtmlTest (specsWith, cleanDB, htmlMigrate) where
 

--- a/persistent-test/src/LargeNumberTest.hs
+++ b/persistent-test/src/LargeNumberTest.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}

--- a/persistent-test/src/MaxLenTest.hs
+++ b/persistent-test/src/MaxLenTest.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-unused-binds #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving, QuasiQuotes, TemplateHaskell, GADTs, TypeFamilies, OverloadedStrings, FlexibleContexts, FlexibleInstances, EmptyDataDecls, MultiParamTypeClasses #-}
 
 module MaxLenTest (specsWith, maxlenMigrate) where

--- a/persistent-test/src/MigrationColumnLengthTest.hs
+++ b/persistent-test/src/MigrationColumnLengthTest.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE QuasiQuotes, TemplateHaskell, GADTs, TypeFamilies, OverloadedStrings, FlexibleContexts, EmptyDataDecls  #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}

--- a/persistent-test/src/MigrationIdempotencyTest.hs
+++ b/persistent-test/src/MigrationIdempotencyTest.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}

--- a/persistent-test/src/MigrationOnlyTest.hs
+++ b/persistent-test/src/MigrationOnlyTest.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-unused-binds #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}

--- a/persistent-test/src/MigrationTest.hs
+++ b/persistent-test/src/MigrationTest.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}

--- a/persistent-test/src/PersistUniqueTest.hs
+++ b/persistent-test/src/PersistUniqueTest.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}

--- a/persistent-test/src/PersistentTest.hs
+++ b/persistent-test/src/PersistentTest.hs
@@ -386,50 +386,6 @@ specsWith runDb = describe "persistent" $ do
       pBlue30 <- updateGet key25 [PersonAge +=. 2]
       pBlue30 @== Person "Updated" 30 Nothing
 
-  describe "putMany" $ do
-    it "adds new rows when entity has no unique constraints" $ runDb $ do
-        let mkPerson name = Person1 name 25
-        let names = ["putMany bob", "putMany bob", "putMany smith"]
-        let records = map mkPerson names
-        _ <- putMany records
-        entitiesDb <- selectList [Person1Name <-. names] []
-        let recordsDb = fmap entityVal entitiesDb
-        recordsDb @== records
-        deleteWhere [Person1Name <-. names]
-    it "adds new rows when no conflicts" $ runDb $ do
-        let mkUpsert e = Upsert e "new" "" 1
-        let keys = ["putMany1","putMany2","putMany3"]
-        let vals = map mkUpsert keys
-        _ <- putMany vals
-        Just (Entity _ v1) <- getBy $ UniqueUpsert "putMany1"
-        Just (Entity _ v2) <- getBy $ UniqueUpsert "putMany2"
-        Just (Entity _ v3) <- getBy $ UniqueUpsert "putMany3"
-        [v1,v2,v3] @== vals
-        deleteBy $ UniqueUpsert "putMany1"
-        deleteBy $ UniqueUpsert "putMany2"
-        deleteBy $ UniqueUpsert "putMany3"
-    it "handles conflicts by replacing old keys with new records" $ runDb $ do
-        let mkUpsert1 e = Upsert e "new" "" 1
-        let mkUpsert2 e = Upsert e "new" "" 2
-        let vals = map mkUpsert2 ["putMany4", "putMany5", "putMany6", "putMany7"]
-        Entity k1 _ <- insertEntity $ mkUpsert1 "putMany4"
-        Entity k2 _ <- insertEntity $ mkUpsert1 "putMany5"
-        _ <- putMany $ mkUpsert1 "putMany4" : vals
-        Just e1 <- getBy $ UniqueUpsert "putMany4"
-        Just e2 <- getBy $ UniqueUpsert "putMany5"
-        Just e3@(Entity k3 _) <- getBy $ UniqueUpsert "putMany6"
-        Just e4@(Entity k4 _) <- getBy $ UniqueUpsert "putMany7"
-
-        [e1,e2,e3,e4] @== [ Entity k1 (mkUpsert2 "putMany4")
-                          , Entity k2 (mkUpsert2 "putMany5")
-                          , Entity k3 (mkUpsert2 "putMany6")
-                          , Entity k4 (mkUpsert2 "putMany7")
-                          ]
-        deleteBy $ UniqueUpsert "putMany4"
-        deleteBy $ UniqueUpsert "putMany5"
-        deleteBy $ UniqueUpsert "putMany6"
-        deleteBy $ UniqueUpsert "putMany7"
-
   describe "repsertMany" $ do
     it "adds new rows when no conflicts" $ runDb $ do
         ids@[johnId, janeId, aliceId, eveId] <- replicateM 4 $ liftIO (Person1Key `fmap` generateKey)

--- a/persistent-test/src/PrimaryTest.hs
+++ b/persistent-test/src/PrimaryTest.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
@@ -8,6 +9,7 @@
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
+
 module PrimaryTest where
 
 import Init

--- a/persistent-test/src/Recursive.hs
+++ b/persistent-test/src/Recursive.hs
@@ -1,4 +1,5 @@
 {-# OPTIONS_GHC -fno-warn-unused-binds #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}

--- a/persistent-test/src/RenameTest.hs
+++ b/persistent-test/src/RenameTest.hs
@@ -1,5 +1,6 @@
 {-# OPTIONS_GHC -fno-warn-unused-binds -fno-warn-orphans #-}
 {-# LANGUAGE RankNTypes, ScopedTypeVariables #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -12,10 +13,11 @@
 {-# LANGUAGE TypeFamilies #-}
 module RenameTest where
 
+import Init
+
 import Data.Time (getCurrentTime, Day, UTCTime(..))
 import qualified Data.Map as Map
 import qualified Data.Text as T
-import Init
 
 -- persistent used to not allow types with an "Id" suffix
 -- this verifies that the issue is fixed

--- a/persistent-test/src/TransactionLevelTest.hs
+++ b/persistent-test/src/TransactionLevelTest.hs
@@ -1,5 +1,4 @@
-{-# OPTIONS_GHC -fno-warn-unused-binds -fno-warn-orphans -O0 #-}
-{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE EmptyDataDecls             #-}
 {-# LANGUAGE FlexibleContexts           #-}

--- a/persistent-test/src/UniqueTest.hs
+++ b/persistent-test/src/UniqueTest.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE EmptyDataDecls #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 2.10.0
 
-* Added two type classes `OnlyOneUniqueKey` and `AtLeastOneUniqueKey`. These classes are used as constraints on functions that expect a certain amount of unique keys. They are defined automatically as part of the `persistent-template`'s generation. [TODO: add issue number]()
+* Added two type classes `OnlyOneUniqueKey` and `AtLeastOneUniqueKey`. These classes are used as constraints on functions that expect a certain amount of unique keys. They are defined automatically as part of the `persistent-template`'s generation. [#885](https://github.com/yesodweb/persistent/pull/885)
 
 ## 2.9.2
 

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for persistent
 
+## 2.10.0
+
+* Added two type classes `OnlyOneUniqueKey` and `AtLeastOneUniqueKey`. These classes are used as constraints on functions that expect a certain amount of unique keys. They are defined automatically as part of the `persistent-template`'s generation. [TODO: add issue number]()
+
 ## 2.9.2
 
 * Add documentation for the `Migration` type and some helpers. [#860](https://github.com/yesodweb/persistent/pull/860)

--- a/persistent/Database/Persist/Class.hs
+++ b/persistent/Database/Persist/Class.hs
@@ -91,6 +91,10 @@ module Database.Persist.Class
     , PersistUnique
     , PersistUniqueRead (..)
     , PersistUniqueWrite (..)
+    , OnlyOneUniqueKey (..)
+    , AtLeastOneUniqueKey (..)
+    , NoUniqueKeysError
+    , MultipleUniqueKeysError
     , getByValue
     , insertBy
     , insertUniqueEntity

--- a/persistent/Database/Persist/Class/PersistEntity.hs
+++ b/persistent/Database/Persist/Class/PersistEntity.hs
@@ -21,7 +21,6 @@ module Database.Persist.Class.PersistEntity
       -- * PersistField based on other typeclasses
     , toPersistValueJSON, fromPersistValueJSON
     , toPersistValueEnum, fromPersistValueEnum
-    , persistUniqueKeysP
     ) where
 
 import Database.Persist.Types.Base
@@ -102,9 +101,6 @@ class ( PersistField (Key record), ToJSON (Key record), FromJSON (Key record)
     -- | Use a 'PersistField' as a lens.
     fieldLens :: EntityField record field
               -> (forall f. Functor f => (field -> f field) -> Entity record -> f (Entity record))
-
-    persistUniqueKeysP :: proxy record -> [Unique record]
-    persistUniqueKeysP _ = persistUniqueKeys (undefined :: record)
 
 type family BackendSpecificUpdate backend record
 

--- a/persistent/Database/Persist/Class/PersistEntity.hs
+++ b/persistent/Database/Persist/Class/PersistEntity.hs
@@ -21,6 +21,7 @@ module Database.Persist.Class.PersistEntity
       -- * PersistField based on other typeclasses
     , toPersistValueJSON, fromPersistValueJSON
     , toPersistValueEnum, fromPersistValueEnum
+    , persistUniqueKeysP
     ) where
 
 import Database.Persist.Types.Base
@@ -101,6 +102,9 @@ class ( PersistField (Key record), ToJSON (Key record), FromJSON (Key record)
     -- | Use a 'PersistField' as a lens.
     fieldLens :: EntityField record field
               -> (forall f. Functor f => (field -> f field) -> Entity record -> f (Entity record))
+
+    persistUniqueKeysP :: proxy record -> [Unique record]
+    persistUniqueKeysP _ = persistUniqueKeys (undefined :: record)
 
 type family BackendSpecificUpdate backend record
 

--- a/persistent/Database/Persist/Class/PersistUnique.hs
+++ b/persistent/Database/Persist/Class/PersistUnique.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables, TypeFamilies, FlexibleContexts, ConstraintKinds #-}
 {-# LANGUAGE TypeOperators, DataKinds #-}
 

--- a/persistent/Database/Persist/Class/PersistUnique.hs
+++ b/persistent/Database/Persist/Class/PersistUnique.hs
@@ -10,6 +10,7 @@ module Database.Persist.Class.PersistUnique
   , NoUniqueKeysError
   , MultipleUniqueKeysError
   , getByValue
+  , getByValueUniques
   , insertBy
   , insertUniqueEntity
   , replaceUnique
@@ -22,6 +23,7 @@ module Database.Persist.Class.PersistUnique
 
 import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NEL
+import qualified Data.Map as Map
 import Database.Persist.Types
 import Control.Exception (throwIO)
 import Control.Monad (liftM)
@@ -135,12 +137,11 @@ class (PersistUniqueRead backend, PersistStoreWrite backend) =>
         case conflict of
             Nothing -> Just `liftM` insert datum
             Just _ -> return Nothing
+
     -- | Update based on a uniqueness constraint or insert:
     --
     -- * insert the new record if it does not exist;
     -- * If the record exists (matched via it's uniqueness constraint), then update the existing record with the parameters which is passed on as list to the function.
-    --
-    -- Throws an exception if there is more than 1 uniqueness constraint.
     --
     -- === __Example usage__
     --
@@ -162,7 +163,7 @@ class (PersistUniqueRead backend, PersistStoreWrite backend) =>
     -- > +-----+-----+--------+
     --
     -- > upsertX :: MonadIO m => [Update User] -> ReaderT SqlBackend m (Maybe (Entity User))
-    -- > upsertX updates = upsert (User "X" 999) upadtes
+    -- > upsertX updates = upsert (User "X" 999) updates
     --
     -- > mXEnt <- upsertX [UserAge +=. 15]
     --
@@ -183,15 +184,21 @@ class (PersistUniqueRead backend, PersistStoreWrite backend) =>
     --
     -- > mSpjEnt <- upsertSpj [UserAge +=. 15]
     --
-    -- Then, it throws an error message something like "Expected only one unique key, got"
+    -- This fails with a compile-time type error alerting us to the fact
+    -- that this record has multiple unique keys, and suggests that we look or
+    -- 'upsertBy' to select the unique key we want.
     upsert
         :: (MonadIO m, PersistRecordBackend record backend, OnlyOneUniqueKey record)
-        => record          -- ^ new record to insert
-        -> [Update record]  -- ^ updates to perform if the record already exists
-        -> ReaderT backend m (Entity record) -- ^ the record in the database after the operation
+        => record
+        -- ^ new record to insert
+        -> [Update record]
+        -- ^ updates to perform if the record already exists
+        -> ReaderT backend m (Entity record)
+        -- ^ the record in the database after the operation
     upsert record updates = do
         uniqueKey <- onlyUnique record
         upsertBy uniqueKey record updates
+
     -- | Update based on a given uniqueness constraint or insert:
     --
     -- * insert the new record if it does not exist;
@@ -249,10 +256,14 @@ class (PersistUniqueRead backend, PersistStoreWrite backend) =>
     -- > +-----+-----+-----+
     upsertBy
         :: (MonadIO m, PersistRecordBackend record backend)
-        => Unique record   -- ^ uniqueness constraint to find by
-        -> record          -- ^ new record to insert
-        -> [Update record] -- ^ updates to perform if the record already exists
-        -> ReaderT backend m (Entity record) -- ^ the record in the database after the operation
+        => Unique record
+        -- ^ uniqueness constraint to find by
+        -> record
+        -- ^ new record to insert
+        -> [Update record]
+        -- ^ updates to perform if the record already exists
+        -> ReaderT backend m (Entity record)
+        -- ^ the record in the database after the operation
     upsertBy uniqueKey record updates = do
         mrecord <- getBy uniqueKey
         maybe (insertEntity record) (`updateGetEntity` updates) mrecord
@@ -264,6 +275,7 @@ class (PersistUniqueRead backend, PersistStoreWrite backend) =>
     --
     -- * insert new records that do not exist (or violate any unique constraints)
     -- * replace existing records (matching any unique constraint)
+    --
     -- @since 2.8.1
     putMany
         ::
@@ -284,6 +296,10 @@ class (PersistUniqueRead backend, PersistStoreWrite backend) =>
 class PersistEntity record => OnlyOneUniqueKey record where
     onlyUniqueP :: record -> Unique record
 
+-- | This is an error message. It is used when writing instances of
+-- 'OnlyOneUniqueKey' for an entity that has no unique keys.
+--
+-- @since 2.10.0
 type NoUniqueKeysError ty =
     'Text "The entity "
         ':<>: 'ShowType ty
@@ -291,6 +307,10 @@ type NoUniqueKeysError ty =
     ':$$: 'Text "The function you are trying to call requires a unique key "
         ':<>: 'Text "to be defined on the entity."
 
+-- | This is an error message. It is used when an entity has multiple
+-- unique keys, and the function expects a single unique key.
+--
+-- @since 2.10.0
 type MultipleUniqueKeysError ty =
     'Text "The entity "
         ':<>: 'ShowType ty
@@ -338,23 +358,6 @@ insertBy val = do
     case res of
         Nothing -> Right `liftM` insert val
         Just z -> return $ Left z
-
--- | Insert a value, checking for conflicts with any unique constraints. If a
--- duplicate exists in the database, it is left untouched. The key of the
--- existing or new entry is returned
-_insertOrGet
-    ::
-    ( MonadIO m
-    , PersistUniqueWrite backend
-    , PersistRecordBackend record backend
-    , AtLeastOneUniqueKey record
-    )
-    => record -> ReaderT backend m (Key record)
-_insertOrGet val = do
-    res <- getByValue val
-    case res of
-        Nothing -> insert val
-        Just (Entity key _) -> return key
 
 -- | Like 'insertEntity', but returns 'Nothing' when the record
 -- couldn't be inserted because of a uniqueness constraint.
@@ -408,18 +411,18 @@ insertUniqueEntity datum =
 --
 -- > mSimonConst <- onlySimonConst
 --
--- @mSimonConst@ would be Simon's uniqueness constraint. Note that @onlyUnique@ doesn't work if there're more than two constraints.
+-- @mSimonConst@ would be Simon's uniqueness constraint. Note that
+-- @onlyUnique@ doesn't work if there're more than two constraints. It will
+-- fail with a type error instead.
 onlyUnique
-    :: (MonadIO m
-       ,PersistUniqueWrite backend
-       ,PersistRecordBackend record backend)
+    ::
+    ( MonadIO m
+    , PersistUniqueWrite backend
+    , PersistRecordBackend record backend
+    , OnlyOneUniqueKey record
+    )
     => record -> ReaderT backend m (Unique record)
-onlyUnique record =
-    case onlyUniqueEither record of
-        Right u -> return u
-        Left us ->
-            requireUniques record us >>=
-            liftIO . throwIO . OnlyUniqueException . show . length
+onlyUnique = pure . onlyUniqueP
 
 onlyUniqueEither
     :: (PersistEntity record)
@@ -459,10 +462,15 @@ getByValue
     )
     => record -> ReaderT backend m (Maybe (Entity record))
 getByValue record = do
-    uniqs <- requireUniques record (persistUniqueKeys record)
-    getByValueUniques uniqs record
+    let uniqs = requireUniquesP record
+    getByValueUniques (NEL.toList uniqs)
 
--- | Retrieve a record from the database using the given unique keys.
+-- | Retrieve a record from the database using the given unique keys. It
+-- will attempt to find a matching record for each 'Unique' in the list,
+-- and returns the first one that has a match.
+--
+-- Returns 'Nothing' if you provide an empty list ('[]') or if no value
+-- matches in the database.
 --
 -- @since 2.10.0
 getByValueUniques
@@ -472,9 +480,8 @@ getByValueUniques
     , PersistRecordBackend record backend
     )
     => [Unique record]
-    -> record
     -> ReaderT backend m (Maybe (Entity record))
-getByValueUniques uniqs _ =
+getByValueUniques uniqs =
     checkUniques uniqs
   where
     checkUniques [] = return Nothing
@@ -483,15 +490,6 @@ getByValueUniques uniqs _ =
         case y of
             Nothing -> checkUniques xs
             Just z -> return $ Just z
-
-requireUniques
-    :: (MonadIO m, PersistEntity record)
-    => record -> [Unique record] -> m [Unique record]
-requireUniques record [] = liftIO $ throwIO $ userError errorMsg
-  where
-    errorMsg = "getByValue: " `Data.Monoid.mappend` unpack (recordName record) `mappend` " does not have any Unique"
-
-requireUniques _ xs = return xs
 
 -- TODO: expose this to users
 recordName
@@ -577,17 +575,24 @@ defaultPutMany
     => [record]
     -> ReaderT backend m ()
 defaultPutMany []   = return ()
-defaultPutMany rsD  = do
+defaultPutMany rsD@(e:es)  = do
     let uKeys = persistUniqueKeys . head $ rsD
     case uKeys of
         [] -> insertMany_ rsD
         uniqs -> go uniqs
   where
     go uniqs = do
-        let rs = nubBy ((==) `on` persistUniqueKeyValues) (reverse rsD)
+        -- deduplicate the list of records in Haskell by unique key. The
+        -- previous implementation used Data.List.nubBy which is O(n^2)
+        -- complexity.
+        let rs = map snd
+                . Map.toList
+                . Map.fromList
+                . map (\r -> (persistUniqueKeyValues r, r))
+                $ rsD
 
         -- lookup record(s) by their unique key
-        mEsOld <- mapM (getByValueUniques uniqs) rs
+        mEsOld <- mapM (getByValueUniques . persistUniqueKeys) rs
 
         -- find pre-existing entities and corresponding (incoming) records
         let merge (Just x) y = Just (x, y)
@@ -610,7 +615,8 @@ defaultPutMany rsD  = do
         -- replace existing records
         mapM_ (uncurry replace) krs
 
--- | The _essence_ of a unique record.
--- useful for comaparing records in haskell land for uniqueness equality.
+-- | This function returns a list of 'PersistValue' that correspond to the
+-- 'Unique' keys on that record. This is useful for comparing two @record@s
+-- for equality only on the basis of their 'Unique' keys.
 persistUniqueKeyValues :: PersistEntity record => record -> [PersistValue]
-persistUniqueKeyValues r = concat $ map persistUniqueToValues $ persistUniqueKeys r
+persistUniqueKeyValues = concatMap persistUniqueToValues . persistUniqueKeys

--- a/persistent/Database/Persist/Class/PersistUnique.hs
+++ b/persistent/Database/Persist/Class/PersistUnique.hs
@@ -21,6 +21,7 @@ module Database.Persist.Class.PersistUnique
   where
 
 import Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NEL
 import Database.Persist.Types
 import Control.Exception (throwIO)
 import Control.Monad (liftM)
@@ -33,7 +34,7 @@ import Database.Persist.Class.PersistEntity
 import Data.Monoid (mappend)
 import Data.Text (unpack, Text)
 import Data.Maybe (catMaybes)
-import GHC.TypeLits
+import GHC.TypeLits (TypeError(..), ErrorMessage(..))
 
 -- | Queries against 'Unique' keys (other than the id 'Key').
 --
@@ -71,10 +72,7 @@ class (PersistCore backend, PersistStoreRead backend) =>
     -- > |  1 | SPJ  |  40 |
     -- > +----+------+-----+
     getBy
-        ::
-        ( MonadIO m
-        , PersistRecordBackend record backend
-        )
+        :: (MonadIO m, PersistRecordBackend record backend)
         => Unique record -> ReaderT backend m (Maybe (Entity record))
 
 -- | Some functions in this module ('insertUnique', 'insertBy', and
@@ -283,8 +281,8 @@ class (PersistUniqueRead backend, PersistStoreWrite backend) =>
 -- instances for records that have 0 or multiple unique keys.
 --
 -- @since 2.10.0
-class OnlyOneUniqueKey record where
-    onlyUniqueP :: proxy record -> Unique record
+class PersistEntity record => OnlyOneUniqueKey record where
+    onlyUniqueP :: record -> Unique record
 
 type NoUniqueKeysError ty =
     'Text "The entity "
@@ -310,8 +308,8 @@ type MultipleUniqueKeysError ty =
 -- 0 unique keys.
 --
 -- @since 2.10.0
-class AtLeastOneUniqueKey record where
-    requireUniquesP :: proxy record -> NonEmpty (Unique record)
+class PersistEntity record => AtLeastOneUniqueKey record where
+    requireUniquesP :: record -> NonEmpty (Unique record)
 
 -- | Insert a value, checking for conflicts with any unique constraints.  If a
 -- duplicate exists in the database, it is returned as 'Left'. Otherwise, the

--- a/persistent/Database/Persist/Sql/Orphan/PersistUnique.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistUnique.hs
@@ -24,10 +24,13 @@ import Data.List (nubBy)
 import Data.Function (on)
 
 defaultUpsert
-    :: (MonadIO m
-       ,PersistEntity record
-       ,PersistUniqueWrite backend
-       ,PersistEntityBackend record ~ BaseBackend backend)
+    ::
+    ( MonadIO m
+    , PersistEntity record
+    , PersistUniqueWrite backend
+    , PersistEntityBackend record ~ BaseBackend backend
+    , OnlyOneUniqueKey record
+    )
     => record -> [Update record] -> ReaderT backend m (Entity record)
 defaultUpsert record updates = do
     uniqueKey <- onlyUnique record

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:            persistent
-version:         2.9.2
+version:         2.10.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -22,7 +22,7 @@ library
     if flag(nooverlap)
         cpp-options: -DNO_OVERLAP
 
-    build-depends:   base                     >= 4.7       && < 5
+    build-depends:   base                     >= 4.9       && < 5
                    , bytestring               >= 0.9
                    , transformers             >= 0.2.1
                    , time                     >= 1.1.4


### PR DESCRIPTION
This PR introduces a few type classes that are required on `upsert` and related functions that have expectations on how many unique keys a record has.

Instances for these classes are generated automatically, and "failing" instances get informative "TypeError"s when you misuse them.

Fixes #868 
Fixes #796 

---

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->