### PR TITLE
Recommend `rawExecute` when return value is not expected.

### DIFF
--- a/persistent/Database/Persist/Sql/Raw.hs
+++ b/persistent/Database/Persist/Sql/Raw.hs
@@ -103,7 +103,8 @@ getStmtConn conn sql = do
             return stmt
 
 -- | Execute a raw SQL statement and return its results as a
--- list.
+-- list. If you do not expect a return value, use of
+-- `rawExecute` is recommended.
 --
 -- If you're using 'Entity'@s@ (which is quite likely), then you
 -- /must/ use entity selection placeholders (double question


### PR DESCRIPTION
Easy way to avoid most of the problems associated with #896.
