### PR TITLE
Fix qmarks

### DIFF
--- a/persistent-test/src/PersistentTest.hs
+++ b/persistent-test/src/PersistentTest.hs
@@ -84,6 +84,10 @@ specsWith runDb = describe "persistent" $ do
       ps <- selectList [FilterAnd []] [Desc PersonAge]
       assertNotEmpty ps
 
+  it "Filter In" $ runDb $ do
+    _ <- selectList [Filter PersonName (FilterValue "Kostas") In] []
+    return ()
+
   it "order of opts is irrelevant" $ runDb $ do
       let eq (a, b, _) (c, d) = (a, b) @== (c, d)
           limitOffsetOrder' :: [SelectOpt Person] -> (Int, Int, [SelectOpt Person])

--- a/persistent/Database/Persist/Sql/Orphan/PersistQuery.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistQuery.hs
@@ -343,8 +343,8 @@ filterClauseHelper includeTable includeWhere conn orNull filters =
                 else id)
             $ connEscapeName conn $ fieldName field
         qmarks = case value of
-                    FilterValue{} -> "?"
-                    UnsafeValue{} -> "?"
+                    FilterValue{} -> "(?)"
+                    UnsafeValue{} -> "(?)"
                     FilterValues xs ->
                         let parens a = "(" <> a <> ")"
                             commas = T.intercalate ","


### PR DESCRIPTION
This pr fixes a small bug, which appears when using the `Filter` data type. The test added fails with
```
  src/PersistentTest.hs:87:3: 
  1) persistent Filter In
       uncaught exception: SqliteException
       SQLite3 returned ErrorError while attempting to perform prepare "SELECT \"id\", \"name\", \"age\", \"color\" FROM \"Person\" WHERE (\"name\" IN ?)": near "?": syntax error
```
The issue is that `?` should be wrapped in `( )` or sqlite can't parse it.

There seems to be more issues related to the `Filter` data type. For example someone could write `Filter PersonName (FilterValues ["a", "b"]) Eq` which will also fail. An additional fix could be:
- Hide Filter from users so that it is a Opaque type. Users will have to use the combinators from `Database.Persist`
- make constuctors safer, so that ie `Eq` can only be combined with `FilterValue` and not `FilterValues`.

Before submitting your PR, check that you've:

- [ ] Bumped the version number
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->