### PR TITLE
Fix Unique Constraints in SQlite

### DIFF
--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -522,6 +522,7 @@ mkCreateTable isTemp entity (cols, uniqs) =
         , "("
         , T.intercalate "," $ map (escape . fieldDB) $ compositeFields pdef
         , ")"
+        , T.concat $ map sqlUnique uniqs
         , ")"
         ]
     Nothing -> T.concat


### PR DESCRIPTION

SQlite seems to ignore Unique Keys when there is a Primary Key.

This 
```
share [mkPersist sqlSettings, mkSave "entityDefs"] [persistLowerCase|
Person
    name String
    creditcard Int
    Primary name
    UniqueA creditcard
|]
``` 
translates into 
` CREATE TABLE "person"("name" VARCHAR NOT NULL,"creditcard" INTEGER NOT NULL, PRIMARY KEY ("name"))`

while after the fix
` CREATE TABLE "person"("name" VARCHAR NOT NULL,"creditcard" INTEGER NOT NULL, PRIMARY KEY ("name"),CONSTRAINT "unique_a" UNIQUE ("creditcard"))`


Before submitting your PR, check that you've:

- [ ] Bumped the version number
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
