### PR TITLE
Enable the SQLITE_ENABLE_STAT4 flag by default.

### DIFF
--- a/persistent-sqlite/ChangeLog.md
+++ b/persistent-sqlite/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for persistent-sqlite
 
+## 2.10.2
+
+* Add a flag for SQLITE_STAT4 and enable it by default, allowing for better query optimisation when using ANALYZE. This breaks the query planner stability guarantee, but the required flag for that isn't enabled or exposed by persistent. Only affects the vendored SQLite library, has no effect when using system SQLite.
+
 ## 2.10.1
 
 * Add support for reading text values with null characters from the database. Fixes [#921](https://github.com/yesodweb/persistent/issues/921)

--- a/persistent-sqlite/persistent-sqlite.cabal
+++ b/persistent-sqlite/persistent-sqlite.cabal
@@ -36,10 +36,10 @@ flag json1
   description: Enable json1 in the vendored SQLite library; has no effect if a system SQLite library is used.
   default: True
 flag use-stat3
-  description: Enable STAT3 in the vendored SQLite library; has no effect if a syste
+  description: Enable STAT3 in the vendored SQLite library; has no effect if a system SQLite library is used.
   default: False
 flag use-stat4
-  description: Enable STAT4 in the vendored SQLite library (supercedes stat3); has n
+  description: Enable STAT4 in the vendored SQLite library (supercedes stat3); has no effect if a system SQLite library is used.
   default: True
 
 library

--- a/persistent-sqlite/persistent-sqlite.cabal
+++ b/persistent-sqlite/persistent-sqlite.cabal
@@ -35,6 +35,12 @@ flag have-usleep
 flag json1
   description: Enable json1 in the vendored SQLite library; has no effect if a system SQLite library is used.
   default: True
+flag use-stat3
+  description: Enable STAT3 in the vendored SQLite library; has no effect if a syste
+  default: False
+flag use-stat4
+  description: Enable STAT4 in the vendored SQLite library (supercedes stat3); has n
+  default: True
 
 library
     build-depends:   base                    >= 4.9         && < 5
@@ -76,6 +82,10 @@ library
        cc-options: -DHAVE_USLEEP
     if flag(json1)
       cc-options: -DSQLITE_ENABLE_JSON1
+    if flag(use-stat3)
+      cc-options: -DSQLITE_ENABLE_STAT3
+    if flag(use-stat4)
+      cc-options: -DSQLITE_ENABLE_STAT4
 
     c-sources: cbits/config.c
 


### PR DESCRIPTION
STAT4 expands the ANALYZE command's logic, logging more data when using ANALYZE allowing for better query plan optimisation. This PR enables this code by default and adds flags to toggle which profiling/analysis code to build.