### PR TITLE
[persistent-template] Expose the knot tying logic of `parseReferences` directly

### DIFF
--- a/persistent-template/ChangeLog.md
+++ b/persistent-template/ChangeLog.md
@@ -1,3 +1,8 @@
+## 2.7.2
+
+* Expose the knot tying logic of `parseReferences` so that users can build
+  migrations from independently define entities at runtime [#932](https://github.com/yesodweb/persistent/pull/932)
+
 ## 2.7.1
 
 * Add the `mkEntityDefList` function to work around [#902](https://github.com/yesodweb/persistent/issues/902). [#904](https://github.com/yesodweb/persistent/pull/904)

--- a/persistent-template/persistent-template.cabal
+++ b/persistent-template/persistent-template.cabal
@@ -1,5 +1,5 @@
 name:            persistent-template
-version:         2.7.1
+version:         2.7.2
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
TH code generation makes up a significant amount of compile time (see also
#924) and forcing all entities that reference each other to be in a single TH
block means that ALL the code generation has to be redone and recompiled
whenever a single entity changes.

The reason that persistent requires all entities to be in the same TH block is
to properly setup the cross-references from foreign keys when generating a
Migration.

All the logic to build a Migration from a list of `EntityDef`s is already
exposed in persistent/persistent-template, so it's perfectly possible to
generate the `Migration` at runtime from independent entity definitions. The
only thing stopping users from doing this is that the logic to setup the
cross-references for foreign keys is...complicated.

`parseReferences` currently fixes these cross-references for entities in a
single block AND generates the resulting TH. This commit simply moves the logic
for fixing the cross-references into a separate, exported function and has
`parseReferences` call that function.

The result is that users can now define entities independently (even in
separate modules), use this new function to fix up the cross-references, and
then generate the resulting `Migration` at runtime.

I've been using this for a while now, defining each entity (and associated
code) in its own module, with no problems and it has substantially reduced the
(re)compile times after schema changes.

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->