### PR TITLE
Add support for constraint= attribute to override foreign reference constraint names

### DIFF
--- a/docs/Persistent-entity-syntax.md
+++ b/docs/Persistent-entity-syntax.md
@@ -136,6 +136,18 @@ This makes a unique index requiring `phone` to be unique across `Person` rows. O
 
 The [tests for this feature](https://github.com/yesodweb/persistent/blob/master/persistent-test/src/CompositeTest.hs#L53) demonstrates their usage
 
+### constraint=
+
+You can use the `constraint=` attribute to override the constraint name used in migrations. This is useful particularly when the automatically generated constraint names exceed database limits (e.g. MySQL does not allow constraint names longer than 64 characters).
+
+```
+VeryLongTableName
+  name Text
+
+AnotherVeryLongTableName
+  veryLongTableNameId VeryLongTableNameId constraint=short_foreign_key
+```
+
 ## Laziness
 
 By default the records created by persistent have strict fields. You can prefix a field name with `~` to make it lazy (or `!` to make it strict).

--- a/persistent-mysql/ChangeLog.md
+++ b/persistent-mysql/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for persistent-mysql
 
+## 2.10.1
+
+* Added `constraint=` attribute to allow users to specify foreign reference constraint names.
+
 ## 2.10.0
 
 * Remove deprecated `SomeField` type and pattern synonym. Use `HandleUpdateCollision` type instead and the `copyField` function instead of `SomeField` constructor/pattern. [#894](https://github.com/yesodweb/persistent/pull/894)

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -341,8 +341,8 @@ migrate' connectInfo allDefs getter val = do
                         AddUniqueConstraint uname $
                         map (findTypeAndMaxLen name) ucols ]
         let foreigns = do
-              Column { cName=cname, cReference=Just (refTblName, _a) } <- newcols
-              return $ AlterColumn name (refTblName, addReference allDefs (refName name cname) refTblName cname)
+              Column { cName=cname, cReference=Just (refTblName, refConstraintName) } <- newcols
+              return $ AlterColumn name (refTblName, addReference allDefs refConstraintName refTblName cname)
 
         let foreignsAlt = map (\fdef -> let (childfields, parentfields) = unzip (map (\((_,b),(_,d)) -> (b,d)) (foreignFields fdef))
                                         in AlterColumn name (foreignRefTableDBName fdef, AddReference (foreignRefTableDBName fdef) (foreignConstraintNameDBName fdef) childfields parentfields)) fdefs
@@ -704,7 +704,7 @@ findAlters tblName allDefs col@(Column name isNull type_ def _defConstraintName 
     -- new fkey that didnt exist before
         [] -> case ref of
                Nothing -> ([(name, Add' col)],[])
-               Just (tname, _b) -> let cnstr = [addReference allDefs (refName tblName name) tname name]
+               Just (tname, cname) -> let cnstr = [addReference allDefs cname tname name]
                                   in (map ((,) tname) (Add' col : cnstr), cols)
         Column _ isNull' type_' def' _defConstraintName' maxLen' ref':_ ->
             let -- Foreign key
@@ -712,7 +712,7 @@ findAlters tblName allDefs col@(Column name isNull type_ def _defConstraintName 
                             (False, Just (_, cname)) -> [(name, DropReference cname)]
                             _ -> []
                 refAdd  = case (ref == ref', ref) of
-                            (False, Just (tname, _cname)) -> [(tname, addReference allDefs (refName tblName name) tname name)]
+                            (False, Just (tname, cname)) -> [(tname, addReference allDefs cname tname name)]
                             _ -> []
                 -- Type and nullability
                 modType | showSqlType type_ maxLen False `ciEquals` showSqlType type_' maxLen' False && isNull == isNull' = []
@@ -883,10 +883,6 @@ showAlter table (_, DropReference cname) = concat
     , escapeDBName cname
     ]
 
-refName :: DBName -> DBName -> DBName
-refName (DBName table) (DBName column) =
-    DBName $ T.concat [table, "_", column, "_fkey"]
-
 ----------------------------------------------------------------------
 
 escape :: DBName -> Text
@@ -983,8 +979,8 @@ mockMigrate _connectInfo allDefs _getter val = do
                         AddUniqueConstraint uname $
                         map (findTypeAndMaxLen name) ucols ]
         let foreigns = do
-              Column { cName=cname, cReference=Just (refTblName, _a) } <- newcols
-              return $ AlterColumn name (refTblName, addReference allDefs (refName name cname) refTblName cname)
+              Column { cName=cname, cReference=Just (refTblName, refConstraintName) } <- newcols
+              return $ AlterColumn name (refTblName, addReference allDefs refConstraintName refTblName cname)
 
         let foreignsAlt = map (\fdef -> let (childfields, parentfields) = unzip (map (\((_,b),(_,d)) -> (b,d)) (foreignFields fdef))
                                         in AlterColumn name (foreignRefTableDBName fdef, AddReference (foreignRefTableDBName fdef) (foreignConstraintNameDBName fdef) childfields parentfields)) fdefs

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for persistent
 
+## 2.10.1
+
+* Added `constraint=` attribute to allow users to specify foreign reference constraint names.
+
 ## 2.10.0
 
 * Added two type classes `OnlyOneUniqueKey` and `AtLeastOneUniqueKey`. These classes are used as constraints on functions that expect a certain amount of unique keys. They are defined automatically as part of the `persistent-template`'s generation. [#885](https://github.com/yesodweb/persistent/pull/885)

--- a/persistent/Database/Persist/Sql/Internal.hs
+++ b/persistent/Database/Persist/Sql/Internal.hs
@@ -61,9 +61,13 @@ mkColumns allDefs t =
             Just (resolveTableName allDefs f, refName tn c)
         | otherwise = Nothing
     ref _ _ ("noreference":_) = Nothing
-    ref c _ (a:_)
-        | Just x <- T.stripPrefix "reference=" a =
-            Just (DBName x, refName tn c)
+    ref c fe (a:as)
+        | Just x <- T.stripPrefix "reference=" a = do
+            constraintName <- snd <$> (ref c fe as)
+            pure (DBName x, constraintName)
+        | Just x <- T.stripPrefix "constraint=" a = do
+            tableName <- fst <$> (ref c fe as)
+            pure (tableName, DBName x)
     ref c x (_:as) = ref c x as
 
 refName :: DBName -> DBName -> DBName


### PR DESCRIPTION
This change adds support for a `constraint=` attribute that allows users to override the automatically generated foreign reference constraint names with their own. The motivation for this change is that we had two instances of very long table/column names that led to automatically generated constraint names exceeding 64 characters, which [is not allowed in MySQL](https://dev.mysql.com/doc/refman/5.7/en/identifiers.html). Without a change like this we could not use the `printMigrations` output.

Please let myself (@charukiewicz) or @belevy know if you have suggestions for a better solution or alternative approach.

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)