### PR TITLE
Tidying up code in Persist/TH.hs

### DIFF
--- a/persistent-template/Database/Persist/TH.hs
+++ b/persistent-template/Database/Persist/TH.hs
@@ -54,6 +54,7 @@ import Data.Aeson
     , Value (Object), (.:), (.:?)
     , eitherDecodeStrict'
     )
+import qualified Data.ByteString as BS
 import Data.Char (toLower, toUpper)
 import qualified Data.HashMap.Strict as HM
 import Data.Int (Int64)
@@ -163,10 +164,7 @@ persistManyFileWith ps fps = do
     parseReferences ps s
 
 getFileContents :: FilePath -> IO Text
-getFileContents fp = do
-    h <- SIO.openFile fp SIO.ReadMode
-    SIO.hSetEncoding h SIO.utf8_bom
-    TIO.hGetContents h
+getFileContents = fmap decodeUtf8 . BS.readFile
 
 -- | Takes a list of (potentially) independently defined entities and properly
 -- links all foreign keys to reference the right 'EntityDef', tying the knot

--- a/persistent-template/Database/Persist/TH.hs
+++ b/persistent-template/Database/Persist/TH.hs
@@ -68,13 +68,11 @@ import Data.Text (pack, Text, append, unpack, concat, uncons, cons, stripPrefix,
 import qualified Data.Text as T
 import Data.Text.Encoding (decodeUtf8)
 import qualified Data.Text.Encoding as TE
-import qualified Data.Text.IO as TIO
 import GHC.Generics (Generic)
 import GHC.TypeLits
 import Language.Haskell.TH.Lib (conT, varE)
 import Language.Haskell.TH.Quote
 import Language.Haskell.TH.Syntax
-import qualified System.IO as SIO
 import Text.Read (readPrec, lexP, step, prec, parens, Lexeme(Ident))
 import Web.PathPieces (PathPiece(..))
 import Web.HttpApiData (ToHttpApiData(..), FromHttpApiData(..))


### PR DESCRIPTION
Another refactor/tidy up of the `TH.hs` file, makes the formatting/indentation consistent across all the functions, extracts/renames a function used to read a file from the filesystem, and makes some code fixes suggested by `hlint`.