### PR TITLE
Add Quiet variants of runMigration, functioning as workaround for the broken runMigrationSilent

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for persistent
 
+## 2.10.2
+
+* Added `runMigrationQuiet` and `runMigrationUnsafeQuiet` to `Database.Persist.Sql.Migration` as safer alternatives to `runMigrationSilent`. This functions as workaround/fix for: [#966](https://github.com/yesodweb/persistent/issues/966), [#948](https://github.com/yesodweb/persistent/issues/948), [#640](https://github.com/yesodweb/persistent/issues/640), and [#474](https://github.com/yesodweb/persistent/issues/474)
+
 ## 2.10.1
 
 * Added `constraint=` attribute to allow users to specify foreign reference constraint names.

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -2,7 +2,9 @@
 
 ## 2.10.2
 
-* Added `runMigrationQuiet` and `runMigrationUnsafeQuiet` to `Database.Persist.Sql.Migration` as safer alternatives to `runMigrationSilent`. This functions as workaround/fix for: [#966](https://github.com/yesodweb/persistent/issues/966), [#948](https://github.com/yesodweb/persistent/issues/948), [#640](https://github.com/yesodweb/persistent/issues/640), and [#474](https://github.com/yesodweb/persistent/issues/474)
+* Added `runMigrationQuiet` and `runMigrationUnsafeQuiet` to `Database.Persist.Sql.Migration` as safer alternatives to `runMigrationSilent`. [#971](https://github.com/yesodweb/persistent/pull/971)
+
+  This functions as workaround/fix for: [#966](https://github.com/yesodweb/persistent/issues/966), [#948](https://github.com/yesodweb/persistent/issues/948), [#640](https://github.com/yesodweb/persistent/issues/640), and [#474](https://github.com/yesodweb/persistent/issues/474)
 
 ## 2.10.1
 

--- a/persistent/Database/Persist/Sql/Migration.hs
+++ b/persistent/Database/Persist/Sql/Migration.hs
@@ -93,7 +93,7 @@ runMigration m = runMigration' m False >> return ()
 runMigrationQuiet :: MonadIO m
                   => Migration
                   -> ReaderT SqlBackend m [Text]
-runMigrationQuiet m = runMigration' m True >> return ()
+runMigrationQuiet m = runMigration' m True
 
 -- | Same as 'runMigration', but returns a list of the SQL commands executed
 -- instead of printing them to stderr.
@@ -135,7 +135,7 @@ runMigration' m silent = do
 runMigrationUnsafe :: MonadIO m
                    => Migration
                    -> ReaderT SqlBackend m ()
-runMigrationUnsafe m = runMigrationUnsafe' False >> return ()
+runMigrationUnsafe m = runMigrationUnsafe' False m >> return ()
 
 -- | Same as 'runMigrationUnsafe', but returns a list of the SQL commands
 -- executed instead of printing them to stderr.
@@ -144,12 +144,12 @@ runMigrationUnsafe m = runMigrationUnsafe' False >> return ()
 runMigrationUnsafeQuiet :: MonadIO m
                         => Migration
                         -> ReaderT SqlBackend m [Text]
-runMigrationUnsafeQuiet m = runMigrationUnsafe' True
+runMigrationUnsafeQuiet = runMigrationUnsafe' True
 
 runMigrationUnsafe' :: MonadIO m
                     => Bool
                     -> Migration
-                    -> ReaderT SqlBackend m ()
+                    -> ReaderT SqlBackend m [Text]
 runMigrationUnsafe' silent m = do
     mig <- parseMigration' m
     mapM (executeMigrate silent) $ sortMigrations $ allSql mig

--- a/persistent/Database/Persist/Sql/Migration.hs
+++ b/persistent/Database/Persist/Sql/Migration.hs
@@ -5,8 +5,10 @@ module Database.Persist.Sql.Migration
   , showMigration
   , getMigration
   , runMigration
+  , runMigrationQuiet
   , runMigrationSilent
   , runMigrationUnsafe
+  , runMigrationUnsafeQuiet
   , migrate
   -- * Utilities for constructing migrations
   , reportErrors
@@ -80,8 +82,26 @@ runMigration :: MonadIO m
              -> ReaderT SqlBackend m ()
 runMigration m = runMigration' m False >> return ()
 
+-- | Same as 'runMigration', but does not report the individual migrations on
+-- stderr. Instead it returns a list of the executed SQL commands.
+--
+-- This is a safer/more robust alternative to 'runMigrationSilent', but may be
+-- less silent for some persistent implementations, most notably
+-- persistent-postgresql
+--
+-- @since 2.10.2
+runMigrationQuiet :: MonadIO m
+                  => Migration
+                  -> ReaderT SqlBackend m [Text]
+runMigrationQuiet m = runMigration' m True >> return ()
+
 -- | Same as 'runMigration', but returns a list of the SQL commands executed
 -- instead of printing them to stderr.
+--
+-- This function silences the migration by remapping 'stderr'. As a result, it
+-- is not thread-safe and can clobber output from other parts of the program.
+-- This implementation method was chosen to also silence postgresql migration
+-- output on stderr, but is not recommended!
 runMigrationSilent :: MonadUnliftIO m
                    => Migration
                    -> ReaderT SqlBackend m [Text]
@@ -115,9 +135,24 @@ runMigration' m silent = do
 runMigrationUnsafe :: MonadIO m
                    => Migration
                    -> ReaderT SqlBackend m ()
-runMigrationUnsafe m = do
+runMigrationUnsafe m = runMigrationUnsafe' False >> return ()
+
+-- | Same as 'runMigrationUnsafe', but returns a list of the SQL commands
+-- executed instead of printing them to stderr.
+--
+-- @since 2.10.2
+runMigrationUnsafeQuiet :: MonadIO m
+                        => Migration
+                        -> ReaderT SqlBackend m [Text]
+runMigrationUnsafeQuiet m = runMigrationUnsafe' True
+
+runMigrationUnsafe' :: MonadIO m
+                    => Bool
+                    -> Migration
+                    -> ReaderT SqlBackend m ()
+runMigrationUnsafe' silent m = do
     mig <- parseMigration' m
-    mapM_ (executeMigrate False) $ sortMigrations $ allSql mig
+    mapM (executeMigrate silent) $ sortMigrations $ allSql mig
 
 executeMigrate :: MonadIO m => Bool -> Text -> ReaderT SqlBackend m Text
 executeMigrate silent s = do

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:            persistent
-version:         2.10.1
+version:         2.10.2
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
This PR addresses: #474, #640, #948, and #966.

This would obsolete PR: #965

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)