### PR TITLE
MySQL `constraint=` attribute test

### DIFF
--- a/persistent-mysql/persistent-mysql.cabal
+++ b/persistent-mysql/persistent-mysql.cabal
@@ -56,6 +56,7 @@ test-suite test
     hs-source-dirs:  test
     other-modules:   MyInit
                      InsertDuplicateUpdate
+                     CustomConstraintTest
     ghc-options:     -Wall
 
     build-depends:   base             >= 4.9 && < 5

--- a/persistent-mysql/test/CustomConstraintTest.hs
+++ b/persistent-mysql/test/CustomConstraintTest.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE EmptyDataDecls             #-}
+{-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE QuasiQuotes                #-}
+{-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE UndecidableInstances       #-}
+module CustomConstraintTest where
+
+import MyInit
+import qualified Data.Text as T
+
+share [mkPersist sqlSettings, mkMigrate "customConstraintMigrate"] [persistLowerCase|
+CustomConstraint1
+    some_field Text
+    deriving Show
+
+CustomConstraint2
+    cc_id CustomConstraint1Id constraint=custom_constraint
+    deriving Show
+|]
+
+specs :: (MonadIO m, MonadFail m) => RunDb SqlBackend m -> Spec
+specs runDb = do
+  describe "custom constraint used in migration" $ do
+    it "custom constraint is actually created" $ runDb $ do
+      runMigration customConstraintMigrate
+      runMigration customConstraintMigrate -- run a second time to ensure the constraint isn't dropped
+      let query = T.concat ["SELECT COUNT(*) "
+                           ,"FROM information_schema.key_column_usage "
+                           ,"WHERE ordinal_position=1 "
+                           ,"AND referenced_table_name=? "
+                           ,"AND referenced_column_name=? "
+                           ,"AND table_name=? "
+                           ,"AND column_name=? "
+                           ,"AND constraint_name=?"]
+      [Single exists] <- rawSql query [PersistText "custom_constraint1"
+                                      ,PersistText "id"
+                                      ,PersistText "custom_constraint2"
+                                      ,PersistText "cc_id"
+                                      ,PersistText "custom_constraint"]
+      liftIO $ 1 @?= (exists :: Int)

--- a/persistent-mysql/test/main.hs
+++ b/persistent-mysql/test/main.hs
@@ -45,6 +45,7 @@ import qualified SumTypeTest
 import qualified TransactionLevelTest
 import qualified UniqueTest
 import qualified UpsertTest
+import qualified CustomConstraintTest
 
 type Tuple a b = (a, b)
 
@@ -179,6 +180,7 @@ main = do
     TransactionLevelTest.specsWith db
 
     MigrationIdempotencyTest.specsWith db
+    CustomConstraintTest.specs db
 
 roundFn :: RealFrac a => a -> Integer
 roundFn = round


### PR DESCRIPTION
This PR ports the Postgresql `CustomConstraintTest` from #979 to the MySQL backend. 

Before submitting your PR, check that you've:

- [ ] Bumped the version number

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->