### PR TITLE
persistent-sqlite: a fix for template-haskell 2.16, GHC 8.10 alpha

### DIFF
--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -704,7 +704,6 @@ data SqliteConnectionInfo = SqliteConnectionInfo
     , _fkEnabled :: Bool -- ^ if foreign-key constraints are enabled.
     , _extraPragmas :: [Text] -- ^ additional pragmas to be set on initialization
     } deriving Show
-makeLenses ''SqliteConnectionInfo
 
 instance FromJSON SqliteConnectionInfo where
     parseJSON v = modifyFailure ("Persistent: error loading SqliteConnectionInfo: " ++) $
@@ -714,6 +713,7 @@ instance FromJSON SqliteConnectionInfo where
         <*> o .: "fkEnabled"
         <*> o .:? "extraPragmas" .!= []
 
+makeLenses ''SqliteConnectionInfo
 
 -- | Like `withSqliteConnInfo`, but exposes the internal `Sqlite.Connection`.
 -- For power users who want to manually interact with SQLite's C API via


### PR DESCRIPTION
In GHC 8.10 (alpha2, at least), a TH splice (eg makeLenses) between
usage and definition of an instance (eg FromJSON) makes the instance
invisible at the usage site, causing an error. Cf
https://gitlab.haskell.org/ghc/ghc/merge_requests/1817#note_242542

This change lets persistent-sqlite build with GHC 8.10-alpha2.
I'm not sure about the other packages (didn't have the right deps
to build mysql).