### PR TITLE
Remove overlapping Lift instance

### DIFF
--- a/persistent-template/ChangeLog.md
+++ b/persistent-template/ChangeLog.md
@@ -1,5 +1,9 @@
 ## Unreleased changes
 
+## 2.7.4
+
+* Remove an overlapping instance for `Lift a`. [#998](https://github.com/yesodweb/persistent/pull/998)
+
 ## 2.7.3
 
 * Update module documentation for `Database.Persist.TH` to better describe the purpose of the module [#968](https://github.com/yesodweb/persistent/pull/968)

--- a/persistent-template/persistent-template.cabal
+++ b/persistent-template/persistent-template.cabal
@@ -1,5 +1,5 @@
 name:            persistent-template
-version:         2.7.3
+version:         2.7.4
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -26,6 +26,7 @@ library
                    , path-pieces
                    , template-haskell         >= 2.11
                    , text                     >= 1.2
+                   , th-lift-instances        >= 0.1.14    && < 0.2
                    , transformers             >= 0.5       && < 0.6
                    , unordered-containers
     exposed-modules: Database.Persist.TH

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -14,4 +14,4 @@ extra-deps:
   - bson-0.3.2.8
   - hedis-0.12.8
   - HTTP-4000.3.14
-  
+  - th-lift-instances-0.1.14

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,3 +9,6 @@ packages:
   - ./persistent-postgresql
   - ./persistent-redis
   - ./persistent-qq
+
+extra-deps:
+  - th-lift-instances-0.1.14

--- a/stack_lts-10.yaml
+++ b/stack_lts-10.yaml
@@ -20,4 +20,6 @@ extra-deps:
 - resourcet-1.1.11
 - scientific-0.3.6.2
 - text-1.2.3.0
+- th-lift-0.8.0.1
+- th-lift-instances-0.1.14
 - unliftio-0.2.0.0

--- a/stack_lts-12.yaml
+++ b/stack_lts-12.yaml
@@ -13,3 +13,5 @@ extra-deps:
 - aeson-1.4.1.0
 - postgresql-libpq-0.9.4.2
 - postgresql-simple-0.6.1
+- th-lift-0.8.0.1
+- th-lift-instances-0.1.14


### PR DESCRIPTION
This patch removes the overlapping `instance Lift' a => Lift a` by replacing the three `Lift'` instances with `Lift` instances:

* There has been an `instance Lift a => Lift [a]` in `template-haskell` for a while now, so that one is already covered.
* The `instance (Lift k, Lift v) => Lift (Map k v)` is now obtained from the `th-lift-instances` library, which is the canonical home for that particular instance.
* The `text` library defines an `instance Lift Text` since version 1.2.4.0. On earlier versions of `text`, an equivalent instance is obtained from the `th-lift-instances` library, which backports it.

Before submitting your PR, check that you've:

- [X] Bumped the version number

After submitting your PR:

- [X] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->