### PR TITLE
Use StandaloneDeriving and DerivingStrategies in persistent-template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ matrix:
     compiler: ": #GHC HEAD"
     addons: {apt: {packages: [cabal-install-head,ghc-head,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
 
-  - env: BUILD=stack ARGS="--resolver lts-9  --stack-yaml stack_lts-10.yaml"
   - env: BUILD=stack ARGS="--resolver lts-11 --stack-yaml stack_lts-12.yaml"
   - env: BUILD=stack ARGS="--resolver lts-12 --stack-yaml stack_lts-12.yaml"
   - env: BUILD=stack ARGS="--resolver lts-14"

--- a/persistent-mongoDB/test/EmbedTestMongo.hs
+++ b/persistent-mongoDB/test/EmbedTestMongo.hs
@@ -7,6 +7,9 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# OPTIONS_GHC -Wno-unused-top-binds -Wno-orphans -O0 #-}
 module EmbedTestMongo (specs) where
 

--- a/persistent-mongoDB/test/EntityEmbedTestMongo.hs
+++ b/persistent-mongoDB/test/EntityEmbedTestMongo.hs
@@ -6,6 +6,9 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
 module EntityEmbedTestMongo where
 
 -- because we are using a type alias we need to declare in a separate module

--- a/persistent-mongoDB/test/main.hs
+++ b/persistent-mongoDB/test/main.hs
@@ -6,6 +6,9 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# OPTIONS_GHC -Wno-unused-top-binds #-}
 
 import qualified Data.ByteString as BS

--- a/persistent-mysql/test/CustomConstraintTest.hs
+++ b/persistent-mysql/test/CustomConstraintTest.hs
@@ -8,6 +8,8 @@
 {-# LANGUAGE TemplateHaskell            #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE UndecidableInstances       #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE StandaloneDeriving         #-}
 module CustomConstraintTest where
 
 import MyInit

--- a/persistent-mysql/test/InsertDuplicateUpdate.hs
+++ b/persistent-mysql/test/InsertDuplicateUpdate.hs
@@ -5,6 +5,8 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 module InsertDuplicateUpdate where
 

--- a/persistent-mysql/test/main.hs
+++ b/persistent-mysql/test/main.hs
@@ -6,6 +6,8 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# OPTIONS_GHC -Wno-unused-top-binds #-}
 
 import MyInit

--- a/persistent-mysql/test/main.hs
+++ b/persistent-mysql/test/main.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# OPTIONS_GHC -Wno-unused-top-binds #-}
 
 import MyInit

--- a/persistent-postgresql/test/ArrayAggTest.hs
+++ b/persistent-postgresql/test/ArrayAggTest.hs
@@ -7,6 +7,9 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-} -- FIXME
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module ArrayAggTest where
 

--- a/persistent-postgresql/test/CustomConstraintTest.hs
+++ b/persistent-postgresql/test/CustomConstraintTest.hs
@@ -8,6 +8,8 @@
 {-# LANGUAGE TemplateHaskell            #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE UndecidableInstances       #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE StandaloneDeriving         #-}
 module CustomConstraintTest where
 
 import PgInit

--- a/persistent-postgresql/test/EquivalentTypeTestPostgres.hs
+++ b/persistent-postgresql/test/EquivalentTypeTestPostgres.hs
@@ -6,6 +6,8 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# OPTIONS_GHC -Wno-unused-top-binds #-}
 
 module EquivalentTypeTestPostgres (specs) where

--- a/persistent-postgresql/test/JSONTest.hs
+++ b/persistent-postgresql/test/JSONTest.hs
@@ -7,6 +7,9 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-} -- FIXME
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module JSONTest where
 

--- a/persistent-postgresql/test/main.hs
+++ b/persistent-postgresql/test/main.hs
@@ -5,6 +5,9 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# OPTIONS_GHC -Wno-unused-top-binds #-}
 
 import PgInit

--- a/persistent-qq/test/PersistentTestModels.hs
+++ b/persistent-qq/test/PersistentTestModels.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-} -- FIXME
+{-# LANGUAGE DerivingStrategies #-}
 module PersistentTestModels where
 
 import Control.Monad.Reader

--- a/persistent-redis/tests/basic-test.hs
+++ b/persistent-redis/tests/basic-test.hs
@@ -6,6 +6,8 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE StandaloneDeriving #-}
 module Main where
 
 import Control.Monad.IO.Class (MonadIO, liftIO)

--- a/persistent-sqlite/test/main.hs
+++ b/persistent-sqlite/test/main.hs
@@ -9,6 +9,8 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE DerivingStrategies #-}
 
 import SqliteInit
 

--- a/persistent-template/ChangeLog.md
+++ b/persistent-template/ChangeLog.md
@@ -5,7 +5,7 @@
 * Drops support for GHC 8.0, so that `DerivingStrategies` can be used by `persistent-template`
 * `persistent-template` now requires `DerivingStrategies`, `GeneralizedNewtypeDeriving`, and `StandaloneDeriving` to be enabled in the file where Persistent entities are created
 * Fixes a long-standing issue where persistent-template would fail when `DeriveAnyClass` was enabled (See #578)
-* [#]()
+* [#1002](https://github.com/yesodweb/persistent/pull/1002)
 
 ## 2.7.4
 

--- a/persistent-template/ChangeLog.md
+++ b/persistent-template/ChangeLog.md
@@ -1,5 +1,12 @@
 ## Unreleased changes
 
+## 2.7.5
+
+* Drops support for GHC 8.0, so that `DerivingStrategies` can be used by `persistent-template`
+* `persistent-template` now requires `DerivingStrategies`, `GeneralizedNewtypeDeriving`, and `StandaloneDeriving` to be enabled in the file where Persistent entities are created
+* Fixes a long-standing issue where persistent-template would fail when `DeriveAnyClass` was enabled (See #578)
+* [#]()
+
 ## 2.7.4
 
 * Remove an overlapping instance for `Lift a`. [#998](https://github.com/yesodweb/persistent/pull/998)

--- a/persistent-template/ChangeLog.md
+++ b/persistent-template/ChangeLog.md
@@ -1,6 +1,6 @@
 ## Unreleased changes
 
-## 2.7.5
+## 2.8.0
 
 * Drops support for GHC 8.0, so that `DerivingStrategies` can be used by `persistent-template`
 * `persistent-template` now requires `DerivingStrategies`, `GeneralizedNewtypeDeriving`, and `StandaloneDeriving` to be enabled in the file where Persistent entities are created

--- a/persistent-template/Database/Persist/TH.hs
+++ b/persistent-template/Database/Persist/TH.hs
@@ -1110,13 +1110,7 @@ mkEntity entityMap mps t = do
 
 mkUniqueKeyInstances :: MkPersistSettings -> EntityDef -> Q [Dec]
 mkUniqueKeyInstances mps t = do
-    -- FIXME: isExtEnabled breaks the benchmark
-    undecidableInstancesEnabled <- isExtEnabled UndecidableInstances
-    unless undecidableInstancesEnabled . fail
-        $ "Generating Persistent entities now requires the 'UndecidableInstances' "
-        `mappend` "language extension. Please enable it in your file by copy/pasting "
-        `mappend` "this line into the top of your file: \n\n"
-        `mappend` "{-# LANGUAGE UndecidableInstances #-}"
+    requirePersistentExtensions
     case entityUniques t of
         [] -> mappend <$> typeErrorSingle <*> typeErrorAtLeastOne
         [_] -> mappend <$> singleUniqueKey <*> atLeastOneKey
@@ -1838,6 +1832,7 @@ instanceD = InstanceD Nothing
 -- This function should be called before any code that depends on one of the required extensions being enabled.
 requirePersistentExtensions :: Q ()
 requirePersistentExtensions = do
+-- FIXME: isExtEnabled breaks the benchmark
   unenabledExtensions <- filterM (fmap not . isExtEnabled) requiredExtensions
 
   case unenabledExtensions of
@@ -1856,5 +1851,5 @@ requirePersistentExtensions = do
                     ]
         
   where
-    requiredExtensions = [DerivingStrategies, GeneralizedNewtypeDeriving, StandaloneDeriving]
+    requiredExtensions = [DerivingStrategies, GeneralizedNewtypeDeriving, StandaloneDeriving, UndecidableInstances]
     extensionToPragma ext = "{-# LANGUAGE " <> show ext <> " #-}"

--- a/persistent-template/Database/Persist/TH.hs
+++ b/persistent-template/Database/Persist/TH.hs
@@ -7,6 +7,9 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# OPTIONS_GHC -fno-warn-orphans -fno-warn-missing-fields #-}
 
 -- | This module provides the tools for defining your database schema and using
@@ -48,7 +51,7 @@ module Database.Persist.TH
 
 import Prelude hiding ((++), take, concat, splitAt, exp)
 
-import Control.Monad (forM, unless, (<=<), mzero)
+import Control.Monad (forM, unless, (<=<), mzero, filterM)
 import Data.Aeson
     ( ToJSON (toJSON), FromJSON (parseJSON), (.=), object
     , Value (Object), (.:), (.:?)
@@ -59,6 +62,7 @@ import Data.Char (toLower, toUpper)
 import qualified Data.HashMap.Strict as HM
 import Data.Int (Int64)
 import Data.List (foldl')
+import qualified Data.List as List
 import qualified Data.List.NonEmpty as NEL
 import qualified Data.Map as M
 import Data.Maybe (isJust, listToMaybe, mapMaybe, fromMaybe)
@@ -496,17 +500,10 @@ upperFirst t =
 dataTypeDec :: MkPersistSettings -> EntityDef -> Q Dec
 dataTypeDec mps t = do
     let names = map (mkName . unpack) $ entityDerives t
-#if MIN_VERSION_template_haskell(2,12,0)
     DataD [] nameFinal paramsFinal
                 Nothing
                 constrs
                 <$> fmap (pure . DerivClause Nothing) (mapM conT names)
-#else
-    DataD [] nameFinal paramsFinal
-                Nothing
-                constrs
-                <$> mapM conT names
-#endif
   where
     mkCol x fd@FieldDef {..} =
         (mkName $ unpack $ recName mps x fieldHaskell,
@@ -555,11 +552,7 @@ uniqueTypeDec mps t =
 #endif
   where
     derivClause [] = []
-#if MIN_VERSION_template_haskell(2,12,0)
     derivClause _  = [DerivClause Nothing [ConT ''Show]]
-#else
-    derivClause _  = [ConT ''Show]
-#endif
 
 mkUnique :: MkPersistSettings -> EntityDef -> UniqueDef -> Con
 mkUnique mps t (UniqueDef (HaskellName constr) _ fields attrs) =
@@ -809,21 +802,18 @@ mkKeyTypeDec mps t = do
                         bi <- backendKeyI
                         return (bi, allInstances)
 
+    requirePersistentExtensions
+
 #if MIN_VERSION_template_haskell(2,15,0)
     cxti <- mapM conT i
     let kd = if useNewtype
-               then NewtypeInstD [] Nothing (AppT (ConT k) recordType) Nothing dec [DerivClause Nothing cxti]
-               else DataInstD    [] Nothing (AppT (ConT k) recordType) Nothing [dec] [DerivClause Nothing cxti]
-#elif MIN_VERSION_template_haskell(2,12,0)
-    cxti <- mapM conT i
-    let kd = if useNewtype
-               then NewtypeInstD [] k [recordType] Nothing dec [DerivClause Nothing cxti]
-               else DataInstD    [] k [recordType] Nothing [dec] [DerivClause Nothing cxti]
+               then NewtypeInstD [] Nothing (AppT (ConT k) recordType) Nothing dec [DerivClause (Just NewtypeStrategy) cxti]
+               else DataInstD    [] Nothing (AppT (ConT k) recordType) Nothing [dec] [DerivClause (Just StockStrategy) cxti]
 #else
     cxti <- mapM conT i
     let kd = if useNewtype
-               then NewtypeInstD [] k [recordType] Nothing dec cxti
-               else DataInstD    [] k [recordType] Nothing [dec] cxti
+               then NewtypeInstD [] k [recordType] Nothing dec [DerivClause (Just NewtypeStrategy) cxti]
+               else DataInstD    [] k [recordType] Nothing [dec] [DerivClause (Just StockStrategy) cxti]
 #endif
     return (kd, instDecs)
   where
@@ -859,43 +849,22 @@ mkKeyTypeDec mps t = do
                 fromBackendKey = $(return keyConE)
         |]
 
-    -- truly unfortunate that TH doesn't support standalone deriving
-    -- https://ghc.haskell.org/trac/ghc/ticket/8100
     genericNewtypeInstances = do
-      instances <- [|lexP|] >>= \lexPE -> [| step readPrec >>= return . ($(pure keyConE) )|] >>= \readE -> do
+      requirePersistentExtensions
+
+      instances <- do
         alwaysInstances <-
-          [d|instance Show (BackendKey $(pure backendT)) => Show (Key $(pure recordType)) where
-              showsPrec i x = showParen (i > app_prec) $
-                (showString $ $(pure $ LitE $ keyStringL t) `mappend` " ") .
-                showsPrec i ($(return unKeyE) x)
-                where app_prec = (10::Int)
-             instance Read (BackendKey $(pure backendT)) => Read (Key $(pure recordType)) where
-                readPrec = parens $ (prec app_prec $ $(pure $ DoE [keyPattern lexPE, NoBindS readE]))
-                  where app_prec = (10::Int)
-             instance Eq (BackendKey $(pure backendT)) => Eq (Key $(pure recordType)) where
-                x == y =
-                    ($(return unKeyE) x) ==
-                    ($(return unKeyE) y)
-             instance Ord (BackendKey $(pure backendT)) => Ord (Key $(pure recordType)) where
-                compare x y = compare
-                    ($(return unKeyE) x)
-                    ($(return unKeyE) y)
-             instance ToHttpApiData (BackendKey $(pure backendT)) => ToHttpApiData (Key $(pure recordType)) where
-                toUrlPiece = toUrlPiece . $(return unKeyE)
-             instance FromHttpApiData (BackendKey $(pure backendT)) => FromHttpApiData(Key $(pure recordType)) where
-                parseUrlPiece = fmap $(return keyConE) . parseUrlPiece
-             instance PathPiece (BackendKey $(pure backendT)) => PathPiece (Key $(pure recordType)) where
-                toPathPiece = toPathPiece . $(return unKeyE)
-                fromPathPiece = fmap $(return keyConE) . fromPathPiece
-             instance PersistField (BackendKey $(pure backendT)) => PersistField (Key $(pure recordType)) where
-                toPersistValue = toPersistValue . $(return unKeyE)
-                fromPersistValue = fmap $(return keyConE) . fromPersistValue
-             instance PersistFieldSql (BackendKey $(pure backendT)) => PersistFieldSql (Key $(pure recordType)) where
-                sqlType = sqlType . fmap $(return unKeyE)
-             instance ToJSON (BackendKey $(pure backendT)) => ToJSON (Key $(pure recordType)) where
-                toJSON = toJSON . $(return unKeyE)
-             instance FromJSON (BackendKey $(pure backendT)) => FromJSON (Key $(pure recordType)) where
-                parseJSON = fmap $(return keyConE) . parseJSON
+          [d|deriving newtype instance Show (BackendKey $(pure backendT)) => Show (Key $(pure recordType))
+             deriving newtype instance Read (BackendKey $(pure backendT)) => Read (Key $(pure recordType))
+             deriving newtype instance Eq (BackendKey $(pure backendT)) => Eq (Key $(pure recordType))
+             deriving newtype instance Ord (BackendKey $(pure backendT)) => Ord (Key $(pure recordType))
+             deriving newtype instance ToHttpApiData (BackendKey $(pure backendT)) => ToHttpApiData (Key $(pure recordType))
+             deriving newtype instance FromHttpApiData (BackendKey $(pure backendT)) => FromHttpApiData(Key $(pure recordType))
+             deriving newtype instance PathPiece (BackendKey $(pure backendT)) => PathPiece (Key $(pure recordType))
+             deriving newtype instance PersistField (BackendKey $(pure backendT)) => PersistField (Key $(pure recordType))
+             deriving newtype instance PersistFieldSql (BackendKey $(pure backendT)) => PersistFieldSql (Key $(pure recordType))
+             deriving newtype instance ToJSON (BackendKey $(pure backendT)) => ToJSON (Key $(pure recordType))
+             deriving newtype instance FromJSON (BackendKey $(pure backendT)) => FromJSON (Key $(pure recordType))
               |]
 
         if customKeyType then return alwaysInstances
@@ -1863,3 +1832,29 @@ instanceD = InstanceD Nothing
 --         let x = mkName "x"
 --          in normalClause [ConP (mkName constr) [VarP x]]
 --                    (VarE 'toPersistValue `AppE` VarE x)
+
+-- | Check that all of Persistent's required extensions are enabled, or else fail compilation
+--
+-- This function should be called before any code that depends on one of the required extensions being enabled.
+requirePersistentExtensions :: Q ()
+requirePersistentExtensions = do
+  unenabledExtensions <- filterM (fmap not . isExtEnabled) requiredExtensions
+
+  case unenabledExtensions of
+    [] -> pure ()
+    [extension] -> fail $ mconcat 
+                     [ "Generating Persistent entities now requires the "
+                     , show extension
+                     , " language extension. Please enable it by copy/pasting this line to the top of your file:\n\n"
+                     , extensionToPragma extension
+                     ]
+    extensions -> fail $ mconcat 
+                    [ "Generating Persistent entities now requires the following language extensions:\n\n"
+                    , List.intercalate "\n" (map show extensions)
+                    , "\n\nPlease enable the extensions by copy/pasting these lines into the top of your file:\n\n"
+                    , List.intercalate "\n" (map extensionToPragma extensions)
+                    ]
+        
+  where
+    requiredExtensions = [DerivingStrategies, GeneralizedNewtypeDeriving, StandaloneDeriving]
+    extensionToPragma ext = "{-# LANGUAGE " <> show ext <> " #-}"

--- a/persistent-template/persistent-template.cabal
+++ b/persistent-template/persistent-template.cabal
@@ -1,5 +1,5 @@
 name:            persistent-template
-version:         2.7.4
+version:         2.7.5
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/persistent-template/persistent-template.cabal
+++ b/persistent-template/persistent-template.cabal
@@ -1,5 +1,5 @@
 name:            persistent-template
-version:         2.7.5
+version:         2.8.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/persistent-template/persistent-template.cabal
+++ b/persistent-template/persistent-template.cabal
@@ -15,7 +15,7 @@ bug-reports:     https://github.com/yesodweb/persistent/issues
 extra-source-files: test/main.hs ChangeLog.md README.md
 
 library
-    build-depends:   base                     >= 4.9       && < 5
+    build-depends:   base                     >= 4.10      && < 5
                    , persistent               >= 2.10      && < 3
                    , aeson                    >= 1.0       && < 1.5
                    , bytestring               >= 0.10
@@ -40,7 +40,7 @@ test-suite test
     other-modules:   TemplateTestImports
     ghc-options:     -Wall
 
-    build-depends:   base                     >= 4.9 && < 5
+    build-depends:   base                     >= 4.10 && < 5
                    , persistent
                    , persistent-template
                    , aeson

--- a/persistent-template/test/main.hs
+++ b/persistent-template/test/main.hs
@@ -7,10 +7,13 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE StandaloneDeriving #-}
 
 -- DeriveAnyClass is not actually used by persistent-template
 -- But a long standing bug was that if it was enabled, it was used to derive instead of GeneralizedNewtypeDeriving
 -- This was fixed by using DerivingStrategies to specify newtype deriving should be used.
+-- This pragma is left here as a "test" that deriving works when DeriveAnyClass is enabled.
 -- See https://github.com/yesodweb/persistent/issues/578
 {-# LANGUAGE DeriveAnyClass #-}
 module Main

--- a/persistent-template/test/main.hs
+++ b/persistent-template/test/main.hs
@@ -7,6 +7,12 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
+
+-- DeriveAnyClass is not actually used by persistent-template
+-- But a long standing bug was that if it was enabled, it was used to derive instead of GeneralizedNewtypeDeriving
+-- This was fixed by using DerivingStrategies to specify newtype deriving should be used.
+-- See https://github.com/yesodweb/persistent/issues/578
+{-# LANGUAGE DeriveAnyClass #-}
 module Main
   (
   -- avoid unused ident warnings

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -88,6 +88,9 @@ library
                     QuasiQuotes
                     TemplateHaskell
                     TypeFamilies
+                    StandaloneDeriving
+                    DerivingStrategies
+                    GeneralizedNewtypeDeriving
 
 source-repository head
   type:     git


### PR DESCRIPTION
This PR uses StandaloneDeriving to avoid the handwritten instances that currently exist in persistent-template.

In addition, it uses deriving strategies to specify that GeneralizedNewtypeDeriving should be used to derive the instances. This fixes the long-standing issue that derivation would fail if DeriveAnyClass was enabled

* Closes #578
* Closes #738
* Closes #908

I think this is working, but I'd ideally like to test in a larger project to make sure this doesn't massively increase compile times or break any derived instances.

<hr>

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html) (No new APIs)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock (no new APIs)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->