### PR TITLE
Bump versions for test-suite compatibility with persistent-template 2…

### DIFF
--- a/persistent-mongoDB/ChangeLog.md
+++ b/persistent-mongoDB/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for persistent-mongoDB
 
+## 2.9.0.1
+
+* Compatibility with latest persistent-template for test suite [#1002](https://github.com/yesodweb/persistent/pull/1002/files)
+
 ## 2.9.0
 
 * Removed deprecated `entityToDocument`. Please use `recordToDocument` instead. [#894](https://github.com/yesodweb/persistent/pull/894)

--- a/persistent-mongoDB/persistent-mongoDB.cabal
+++ b/persistent-mongoDB/persistent-mongoDB.cabal
@@ -1,5 +1,5 @@
 name:            persistent-mongoDB
-version:         2.9.0
+version:         2.9.0.1
 license:         MIT
 license-file:    LICENSE
 author:          Greg Weber <greg@gregweber.info>

--- a/persistent-mysql/ChangeLog.md
+++ b/persistent-mysql/ChangeLog.md
@@ -3,6 +3,7 @@
 ## 2.10.2.1
 
 * Changed persistent-mysql to use 'utf8mb4' instead of 'utf8' in migrations [#980](https://github.com/yesodweb/persistent/pull/980) @charukiewicz
+* Compatibility with latest persistent-template for test suite [#1002](https://github.com/yesodweb/persistent/pull/1002/files)
 
 ## 2.10.2
 

--- a/persistent-postgresql/ChangeLog.md
+++ b/persistent-postgresql/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for persistent-postgresql
 
+## 2.10.1.1
+
+* Compatibility with latest persistent-template for test suite [#1002](https://github.com/yesodweb/persistent/pull/1002/files)
+
 ## 2.10.1
 
 * Added support for the `constraint=` attribute to the Postgresql backend. [#979](https://github.com/yesodweb/persistent/pull/979)

--- a/persistent-postgresql/persistent-postgresql.cabal
+++ b/persistent-postgresql/persistent-postgresql.cabal
@@ -1,5 +1,5 @@
 name:            persistent-postgresql
-version:         2.10.1
+version:         2.10.1.1
 license:         MIT
 license-file:    LICENSE
 author:          Felipe Lessa, Michael Snoyman <michael@snoyman.com>

--- a/persistent-qq/ChangeLog.md
+++ b/persistent-qq/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for persistent-qq
 
+## 2.9.1.1
+
+* Compatibility with latest persistent-template for test suite [#1002](https://github.com/yesodweb/persistent/pull/1002/files)
+
 ## 2.9.1
 
 * Added support for list of values in `sqlQQ`. [#819](https://github.com/yesodweb/persistent/pull/819)

--- a/persistent-qq/persistent-qq.cabal
+++ b/persistent-qq/persistent-qq.cabal
@@ -7,7 +7,7 @@ cabal-version: 1.12
 -- hash: bef2b585278826bc60fe813d4918833dc06cec43f2a8e4567190448ccfdee163
 
 name:           persistent-qq
-version:        2.9.1
+version:        2.9.1.1
 synopsis:       Provides a quasi-quoter for raw SQL for persistent
 description:    Please see README and API docs at <http://www.stackage.org/package/persistent>.
 category:       Database, Yesod

--- a/persistent-redis/ChangeLog.md
+++ b/persistent-redis/ChangeLog.md
@@ -1,3 +1,7 @@
+# 2.5.2.4
+
+* Compatibility with latest persistent-template for test suite [#1002](https://github.com/yesodweb/persistent/pull/1002/files)
+
 # 2.5.2.3
 
 * Added support for GHC 8.8 [#977](https://github.com/yesodweb/persistent/pull/977)

--- a/persistent-redis/persistent-redis.cabal
+++ b/persistent-redis/persistent-redis.cabal
@@ -1,5 +1,5 @@
 name:            persistent-redis
-version:         2.5.2.3
+version:         2.5.2.4
 license:         BSD3
 license-file:    LICENSE
 author:          Pavel Ryzhov <paul@paulrz.cz>

--- a/persistent-sqlite/ChangeLog.md
+++ b/persistent-sqlite/ChangeLog.md
@@ -3,6 +3,7 @@
 ## 2.10.5.1
 
 * a fix for template-haskell 2.16, GHC 8.10 alpha [#993](https://github.com/yesodweb/persistent/pull/993) @simonmichael
+* Compatibility with latest persistent-template for test suite [#1002](https://github.com/yesodweb/persistent/pull/1002/files)
 
 ## 2.10.5
 

--- a/persistent-test/ChangeLog.md
+++ b/persistent-test/ChangeLog.md
@@ -1,0 +1,5 @@
+## Unreleased changes
+
+## 2.0.3.1
+
+* Compatibility with latest persistent-template for test suite [#1002](https://github.com/yesodweb/persistent/pull/1002/files)

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -1,5 +1,5 @@
 name:            persistent-test
-version:         2.0.3.0
+version:         2.0.3.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
….8.0

This should let people who run the persistent test suites (notably stackage + Nix packages) to get a working version

Before submitting your PR, check that you've:

- [x] Bumped the version number

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->