### PR TITLE
Fix multiple fk issue with PostgreSQL migrations

### DIFF
--- a/persistent-postgresql/ChangeLog.md
+++ b/persistent-postgresql/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for persistent-postgresql
 
+## 2.10.1.2
+
+* Fix issue with multiple foreign keys on single column. [#1010](https://github.com/yesodweb/persistent/pull/1010)
+
 ## 2.10.1.1
 
 * Compatibility with latest persistent-template for test suite [#1002](https://github.com/yesodweb/persistent/pull/1002/files)

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -819,7 +819,15 @@ getColumn getter tableName' [PersistText columnName, PersistText isNullable, Per
           [] -> return Nothing
           [[PersistText table, PersistText constraint]] ->
             return $ Just (DBName table, DBName constraint)
-          _ -> error "Postgresql.getColumn: error fetching constraints"
+          xs ->
+            error $ mconcat
+              [ "Postgresql.getColumn: error fetching constraints. Expected a single table and a single constraint for table: "
+              , T.unpack (unDBName tableName')
+              , " and a column: "
+              , T.unpack (unDBName cname)
+              , " but got: "
+              , show xs
+              ]
     d' = case defaultValue of
             PersistNull   -> Right Nothing
             PersistText t -> Right $ Just t

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -829,9 +829,9 @@ getColumn getter tableName' [PersistText columnName, PersistText isNullable, Per
             return $ Just (DBName table, DBName constraint)
           xs ->
             error $ mconcat
-              [ "Postgresql.getColumn: error fetching constraints. Expected a single table and a single constraint for table: "
+              [ "Postgresql.getColumn: error fetching constraints. Expected a single result for foreign key query for table: "
               , T.unpack (unDBName tableName')
-              , " and a column: "
+              , " and column: "
               , T.unpack (unDBName cname)
               , " but got: "
               , show xs

--- a/persistent-postgresql/persistent-postgresql.cabal
+++ b/persistent-postgresql/persistent-postgresql.cabal
@@ -1,5 +1,5 @@
 name:            persistent-postgresql
-version:         2.10.1.1
+version:         2.10.1.2
 license:         MIT
 license-file:    LICENSE
 author:          Felipe Lessa, Michael Snoyman <michael@snoyman.com>

--- a/persistent-postgresql/test/CustomConstraintTest.hs
+++ b/persistent-postgresql/test/CustomConstraintTest.hs
@@ -23,6 +23,12 @@ CustomConstraint1
 CustomConstraint2
     cc_id CustomConstraint1Id constraint=custom_constraint
     deriving Show
+
+CustomConstraint3
+    -- | This will lead to a constraint with the name custom_constraint3_cc_id1_fkey
+    cc_id1 CustomConstraint1Id
+    cc_id2 CustomConstraint1Id
+    deriving Show
 |]
 
 specs :: (MonadIO m, MonadFail m) => RunDb SqlBackend m -> Spec
@@ -51,3 +57,10 @@ specs runDb = do
                                       ,PersistText "custom_constraint"]
       liftIO $ 1 @?= (exists :: Int)
 
+    it "allows multiple constraints on a single column" $ runDb $ do
+      runMigration customConstraintMigrate
+      -- | Here we add another foreign key on the same column where the default one already exists. In practice, this could be a compound key with another field.
+      rawExecute "ALTER TABLE \"custom_constraint3\" ADD CONSTRAINT \"extra_constraint\" FOREIGN KEY(\"cc_id1\") REFERENCES \"custom_constraint1\"(\"id\")" []
+      -- | This is where the error is thrown in `getColumn`
+      _ <- getMigration customConstraintMigrate
+      pure ()


### PR DESCRIPTION
This PR addresses issue #1009 for the PostgreSQL backend. In order to support multiple foreign keys on a single column, we now pass the reference name to `getColumn`, and use it in the where clause when querying foreign keys for the column.

Before submitting your PR, check that you've:

- [x] Bumped the version number

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)