### PR TITLE
Compatibility with mongoDB-2.6.0.0

### DIFF
--- a/persistent-mongoDB/ChangeLog.md
+++ b/persistent-mongoDB/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for persistent-mongoDB
 
+## 2.9.0.2
+
+* Compatibility with latest mongoDB
+
 ## 2.9.0.1
 
 * Compatibility with latest persistent-template for test suite [#1002](https://github.com/yesodweb/persistent/pull/1002/files)

--- a/persistent-mongoDB/ChangeLog.md
+++ b/persistent-mongoDB/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 2.9.0.2
 
-* Compatibility with latest mongoDB
+* Compatibility with latest mongoDB [#1012](https://github.com/yesodweb/persistent/pull/1012)
 
 ## 2.9.0.1
 

--- a/persistent-mongoDB/Database/Persist/MongoDB.hs
+++ b/persistent-mongoDB/Database/Persist/MongoDB.hs
@@ -548,7 +548,8 @@ instance PersistStoreWrite DB.MongoContext where
            $ updatesToDoc upds
 
     updateGet key upds = do
-        result <- DB.findAndModify (queryByKey key) (updatesToDoc upds)
+        context <- ask
+        result <- liftIO $ runReaderT (DB.findAndModify (queryByKey key) (updatesToDoc upds)) context
         either err instantiate result
       where
         instantiate doc = do

--- a/persistent-mongoDB/persistent-mongoDB.cabal
+++ b/persistent-mongoDB/persistent-mongoDB.cabal
@@ -27,7 +27,7 @@ library
                    , cereal             >= 0.5
                    , conduit            >= 1.2
                    , http-api-data      >= 0.3.7     && < 0.5
-                   , mongoDB            >= 2.3       && < 2.6
+                   , mongoDB            >= 2.3       && < 2.7
                    , network            >= 2.6
                    , path-pieces        >= 0.2
                    , resource-pool      >= 0.2       && < 0.3

--- a/persistent-mongoDB/persistent-mongoDB.cabal
+++ b/persistent-mongoDB/persistent-mongoDB.cabal
@@ -1,5 +1,5 @@
 name:            persistent-mongoDB
-version:         2.9.0.1
+version:         2.9.0.2
 license:         MIT
 license-file:    LICENSE
 author:          Greg Weber <greg@gregweber.info>


### PR DESCRIPTION
The latest version adds a MonadFail constraint to some functions

I've never used persistent-mongoDB and I'm pretty unfamiliar with it. I also was having trouble installing mongoDB itself to run the tests (admittedly not putting in a ton of effort). However, this change makes the package compile and matches a pattern used elsewhere in the persistent-mongoDB package, so it might be good?

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html) (n/a)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock  (n/a)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->