### PR TITLE
Move Template Haskell splices to end of the file.

### DIFF
--- a/persistent-sqlite/ChangeLog.md
+++ b/persistent-sqlite/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for persistent-sqlite
 
+## 2.10.6.2
+
+* Move template haskell splices to be correct (and GHC 8.10 compatible) [#1034](https://github.com/yesodweb/persistent/pull/1034)
+
 ## 2.10.6.1
 
 * Missing `includes` and `install-includes` cabal fields added, to allow

--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -717,8 +717,6 @@ instance FromJSON SqliteConnectionInfo where
         <*> o .: "fkEnabled"
         <*> o .:? "extraPragmas" .!= []
 
-makeLenses ''SqliteConnectionInfo
-
 -- | Like `withSqliteConnInfo`, but exposes the internal `Sqlite.Connection`.
 -- For power users who want to manually interact with SQLite's C API via
 -- internals exposed by "Database.Sqlite.Internal"
@@ -809,7 +807,6 @@ data RawSqlite backend = RawSqlite
     { _persistentBackend :: backend -- ^ The persistent backend
     , _rawSqliteConnection :: Sqlite.Connection -- ^ The underlying `Sqlite.Connection`
     }
-makeLenses ''RawSqlite
 
 instance HasPersistBackend b => HasPersistBackend (RawSqlite b) where
     type BaseBackend (RawSqlite b) = BaseBackend b
@@ -872,3 +869,6 @@ instance (PersistUniqueWrite b) => PersistUniqueWrite (RawSqlite b) where
     upsert rec = withReaderT _persistentBackend . upsert rec
     upsertBy uniq rec = withReaderT _persistentBackend . upsertBy uniq rec
     putMany = withReaderT _persistentBackend . putMany
+
+makeLenses ''RawSqlite
+makeLenses ''SqliteConnectionInfo

--- a/persistent-sqlite/persistent-sqlite.cabal
+++ b/persistent-sqlite/persistent-sqlite.cabal
@@ -1,5 +1,5 @@
 name:            persistent-sqlite
-version:         2.10.6.1
+version:         2.10.6.2
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
Accessing definition across TH splices is an error and 8.10 seems to break on this. See #1033.

Before submitting your PR, check that you've:

- [x] Bumped the version number

After submitting your PR:
- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->