### PR TITLE
Fix foreign key constraints on custom table names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
 
   allow_failures:
   - env: BUILD=cabal GHCVER=head  CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7
-  - env: BUILD=stack ARGS="--resolver nightly"
+  - env: BUILD=stack ARGS="--resolver nightly --stack-yaml stack-nightly.yaml"
 
 before_install:
 # Using compiler above sets CC to an invalid value, so unset it

--- a/persistent-mysql/test/CustomConstraintTest.hs
+++ b/persistent-mysql/test/CustomConstraintTest.hs
@@ -35,8 +35,8 @@ specs :: (MonadIO m, MonadFail m) => RunDb SqlBackend m -> Spec
 specs runDb = do
   describe "custom constraint used in migration" $ do
     it "custom constraint is actually created" $ runDb $ do
-      runMigration customConstraintMigrate
-      runMigration customConstraintMigrate -- run a second time to ensure the constraint isn't dropped
+      runMigrationSilent customConstraintMigrate
+      runMigrationSilent customConstraintMigrate -- run a second time to ensure the constraint isn't dropped
       let query = T.concat ["SELECT COUNT(*) "
                            ,"FROM information_schema.key_column_usage "
                            ,"WHERE ordinal_position=1 "
@@ -52,7 +52,7 @@ specs runDb = do
                                       ,PersistText "custom_constraint"]
       liftIO $ 1 @?= (exists :: Int)
     it "allows multiple constraints on a single column" $ runDb $ do
-      runMigration customConstraintMigrate
+      runMigrationSilent customConstraintMigrate
       -- | Here we add another foreign key on the same column where the default one already exists. In practice, this could be a compound key with another field.
       rawExecute "ALTER TABLE custom_constraint3 ADD CONSTRAINT extra_constraint FOREIGN KEY(cc_id1) REFERENCES custom_constraint1(id)" []
       -- | This is where the error is thrown in `getColumn`

--- a/persistent-mysql/test/CustomConstraintTest.hs
+++ b/persistent-mysql/test/CustomConstraintTest.hs
@@ -31,11 +31,17 @@ CustomConstraint3
     deriving Show
 |]
 
-specs :: (MonadIO m, MonadFail m) => RunDb SqlBackend m -> Spec
+clean :: MonadUnliftIO m => SqlPersistT m ()
+clean = do
+    rawExecute "drop table custom_constraint3" []
+    rawExecute "drop table custom_constraint2" []
+    rawExecute "drop table custom_constraint1" []
+
+specs :: (MonadUnliftIO m, MonadFail m) => RunDb SqlBackend m -> Spec
 specs runDb = do
-  describe "custom constraint used in migration" $ do
+  describe "custom constraint used in migration" $ before_ (runDb $ void $ runMigrationSilent customConstraintMigrate) $ after_ (runDb clean) $ do
+
     it "custom constraint is actually created" $ runDb $ do
-      runMigrationSilent customConstraintMigrate
       runMigrationSilent customConstraintMigrate -- run a second time to ensure the constraint isn't dropped
       let query = T.concat ["SELECT COUNT(*) "
                            ,"FROM information_schema.key_column_usage "
@@ -51,10 +57,12 @@ specs runDb = do
                                       ,PersistText "cc_id"
                                       ,PersistText "custom_constraint"]
       liftIO $ 1 @?= (exists :: Int)
+
     it "allows multiple constraints on a single column" $ runDb $ do
-      runMigrationSilent customConstraintMigrate
-      -- | Here we add another foreign key on the same column where the default one already exists. In practice, this could be a compound key with another field.
+      -- Here we add another foreign key on the same column where the
+      -- default one already exists. In practice, this could be
+      -- a compound key with another field.
       rawExecute "ALTER TABLE custom_constraint3 ADD CONSTRAINT extra_constraint FOREIGN KEY(cc_id1) REFERENCES custom_constraint1(id)" []
-      -- | This is where the error is thrown in `getColumn`
+      -- This is where the error is thrown in `getColumn`
       _ <- getMigration customConstraintMigrate
       pure ()

--- a/persistent-mysql/test/MyInit.hs
+++ b/persistent-mysql/test/MyInit.hs
@@ -23,6 +23,7 @@ module MyInit (
   , module Database.Persist.Sql.Raw.QQ
   , module Test.Hspec
   , module Test.HUnit
+  , MonadUnliftIO
   , liftIO
   , mkPersist, mkMigrate, share, sqlSettings, persistLowerCase, persistUpperCase
   , Int32, Int64

--- a/persistent-mysql/test/main.hs
+++ b/persistent-mysql/test/main.hs
@@ -96,10 +96,11 @@ instance Arbitrary (DataTypeTableGeneric backend) where
      <*> (truncateTimeOfDay =<< arbitrary) -- timeFrac
      <*> (truncateUTCTime   =<< arbitrary) -- utcFrac
 
-setup :: MonadIO m => Migration -> ReaderT SqlBackend m ()
+setup :: MonadUnliftIO m => Migration -> ReaderT SqlBackend m ()
 setup migration = do
   printMigration migration
-  runMigrationUnsafe migration
+  _ <- runMigrationSilent migration
+  pure ()
 
 main :: IO ()
 main = do

--- a/persistent-postgresql/test/CustomConstraintTest.hs
+++ b/persistent-postgresql/test/CustomConstraintTest.hs
@@ -13,6 +13,7 @@
 module CustomConstraintTest where
 
 import PgInit
+import Control.Monad.IO.Unlift
 import qualified Data.Text as T
 
 share [mkPersist sqlSettings, mkMigrate "customConstraintMigrate"] [persistLowerCase|
@@ -31,12 +32,12 @@ CustomConstraint3
     deriving Show
 |]
 
-specs :: (MonadIO m, MonadFail m) => RunDb SqlBackend m -> Spec
+specs :: (MonadUnliftIO m, MonadFail m) => RunDb SqlBackend m -> Spec
 specs runDb = do
   describe "custom constraint used in migration" $ do
     it "custom constraint is actually created" $ runDb $ do
-      runMigration customConstraintMigrate
-      runMigration customConstraintMigrate -- run a second time to ensure the constraint isn't dropped
+      runMigrationSilent customConstraintMigrate
+      runMigrationSilent customConstraintMigrate -- run a second time to ensure the constraint isn't dropped
       let query = T.concat ["SELECT DISTINCT COUNT(*) "
                            ,"FROM information_schema.constraint_column_usage ccu, "
                            ,"information_schema.key_column_usage kcu, "
@@ -58,7 +59,7 @@ specs runDb = do
       liftIO $ 1 @?= (exists :: Int)
 
     it "allows multiple constraints on a single column" $ runDb $ do
-      runMigration customConstraintMigrate
+      runMigrationSilent customConstraintMigrate
       -- | Here we add another foreign key on the same column where the default one already exists. In practice, this could be a compound key with another field.
       rawExecute "ALTER TABLE \"custom_constraint3\" ADD CONSTRAINT \"extra_constraint\" FOREIGN KEY(\"cc_id1\") REFERENCES \"custom_constraint1\"(\"id\")" []
       -- | This is where the error is thrown in `getColumn`

--- a/persistent-postgresql/test/JSONTest.hs
+++ b/persistent-postgresql/test/JSONTest.hs
@@ -67,7 +67,7 @@ specs :: Spec
 specs = describe "postgresql's JSON operators behave" $ do
 
   it "migrate, clean table, insert values and check queries" $ asIO $ runConn $ do
-      runMigration jsonTestMigrate
+      runMigrationSilent jsonTestMigrate
       cleanDB
 
       liftIO $ putStrLn "\n- - - - -  Inserting JSON values  - - - - -\n"

--- a/persistent-postgresql/test/main.hs
+++ b/persistent-postgresql/test/main.hs
@@ -102,6 +102,7 @@ main = do
     mapM_ setup
       [ PersistentTest.testMigrate
       , PersistentTest.noPrefixMigrate
+      , PersistentTest.treeMigrate
       , EmbedTest.embedMigrate
       , EmbedOrderTest.embedOrderMigrate
       , LargeNumberTest.numberMigrate

--- a/persistent-qq/test/Spec.hs
+++ b/persistent-qq/test/Spec.hs
@@ -40,7 +40,7 @@ runConn f = do
 db :: SqlPersistT (LoggingT (ResourceT IO)) () -> IO ()
 db actions = do
   runResourceT $ runConn $ do
-      runMigration testMigrate
+      runMigrationSilent testMigrate
       actions
       transactionUndo
 

--- a/persistent-sqlite/test/main.hs
+++ b/persistent-sqlite/test/main.hs
@@ -231,6 +231,7 @@ main = do
     it "properly migrates to a composite primary key (issue #669)" $ asIO $ runSqliteInfo (mkSqliteConnectionInfo ":memory:") $ do
         runMigrationSilent compositeSetup
         runMigrationSilent compositeMigrateTest
+        pure ()
 
     it "afterException" $ asIO $ runSqliteInfo (mkSqliteConnectionInfo ":memory:") $ do
         runMigrationSilent testMigrate

--- a/persistent-sqlite/test/main.hs
+++ b/persistent-sqlite/test/main.hs
@@ -209,12 +209,12 @@ main = do
     MigrationTest.specsWith db
 
     it "issue #328" $ asIO $ runSqliteInfo (mkSqliteConnectionInfo ":memory:") $ do
-        runMigration migrateAll
+        runMigrationSilent migrateAll
         _ <- insert . Test $ read "2014-11-30 05:15:25.123Z"
         [Single x] <- rawSql "select strftime('%s%f',time) from test" []
         liftIO $ x `shouldBe` Just ("141732452525.123" :: String)
     it "issue #339" $ asIO $ runSqliteInfo (mkSqliteConnectionInfo ":memory:") $ do
-        runMigration migrateAll
+        runMigrationSilent migrateAll
         now <- liftIO getCurrentTime
         tid <- insert $ Test now
         Just (Test now') <- get tid
@@ -225,15 +225,15 @@ main = do
         Sqlite.close conn
         return ()
     it "issue #527" $ asIO $ runSqliteInfo (mkSqliteConnectionInfo ":memory:") $ do
-        runMigration migrateAll
+        runMigrationSilent migrateAll
         insertMany_ $ replicate 1000 (Test $ read "2014-11-30 05:15:25.123Z")
 
     it "properly migrates to a composite primary key (issue #669)" $ asIO $ runSqliteInfo (mkSqliteConnectionInfo ":memory:") $ do
-        runMigration compositeSetup
-        runMigration compositeMigrateTest
+        runMigrationSilent compositeSetup
+        runMigrationSilent compositeMigrateTest
 
     it "afterException" $ asIO $ runSqliteInfo (mkSqliteConnectionInfo ":memory:") $ do
-        runMigration testMigrate
+        runMigrationSilent testMigrate
         let catcher :: forall m. Monad m => SomeException -> m ()
             catcher _ = return ()
         _ <- insert $ Person "A" 0 Nothing

--- a/persistent-template/Database/Persist/TH.hs
+++ b/persistent-template/Database/Persist/TH.hs
@@ -65,6 +65,9 @@ import Data.Aeson
     , eitherDecodeStrict'
     )
 import qualified Data.ByteString as BS
+import Data.Typeable (Typeable)
+import Data.Ix (Ix)
+import Data.Data (Data)
 import Data.Char (toLower, toUpper)
 import qualified Data.HashMap.Strict as HM
 import Data.Int (Int64)
@@ -538,9 +541,12 @@ dataTypeDec mps t = do
         else
             Right n
 
-    stockClasses = Set.fromList . map mkName $
+    stockClasses =
+        Set.fromList (map mkName
         [ "Eq", "Ord", "Show", "Read", "Bounded", "Enum", "Ix", "Generic", "Data", "Typeable"
+        ] <> [''Eq, ''Ord, ''Show, ''Read, ''Bounded, ''Enum, ''Ix, ''Generic, ''Data, ''Typeable
         ]
+        )
     mkCol x fd@FieldDef {..} =
         (mkName $ unpack $ recName mps x fieldHaskell,
          if fieldStrict then isStrict else notStrict,

--- a/persistent-test/src/Init.hs
+++ b/persistent-test/src/Init.hs
@@ -30,6 +30,7 @@ module Init (
   , Text
   , module Control.Monad.Reader
   , module Control.Monad
+  , module Control.Monad.IO.Unlift
   , BS.ByteString
   , SomeException
   , MonadFail
@@ -45,6 +46,7 @@ module Init (
 -- needed for backwards compatibility
 import Control.Monad.Base
 import Control.Monad.Catch
+import Control.Monad.IO.Unlift
 import qualified Control.Monad.Fail as MonadFail
 import Control.Monad.Logger
 import Control.Monad.Trans.Class

--- a/persistent-test/src/MigrationTest.hs
+++ b/persistent-test/src/MigrationTest.hs
@@ -32,7 +32,7 @@ Source1 sql=source
     field4 Target1Id
 |]
 
-specsWith :: (MonadIO m) => RunDb SqlBackend m -> Spec
+specsWith :: (MonadUnliftIO m) => RunDb SqlBackend m -> Spec
 specsWith runDb = describe "Migration" $ do
     it "is idempotent" $ runDb $ do
       again <- getMigration migrationMigrate

--- a/persistent-test/src/MigrationTest.hs
+++ b/persistent-test/src/MigrationTest.hs
@@ -38,13 +38,13 @@ specsWith runDb = describe "Migration" $ do
       again <- getMigration migrationMigrate
       liftIO $ again @?= []
     it "really is idempotent" $ runDb $ do
-      runMigration migrationMigrate
+      runMigrationSilent migrationMigrate
       again <- getMigration migrationMigrate
       liftIO $ again @?= []
     it "can add an extra column" $ runDb $ do
       -- Failing test case for #735.  Foreign-key checking, switched on in
       -- version 2.6.1, caused persistent-sqlite to generate a `references`
       -- constraint in a *temporary* table during migration, which fails.
-      _ <- runMigration migrationAddCol
+      _ <- runMigrationSilent migrationAddCol
       again <- getMigration migrationAddCol
       liftIO $ again @?= []

--- a/persistent-test/src/PersistentTest.hs
+++ b/persistent-test/src/PersistentTest.hs
@@ -5,6 +5,7 @@ module PersistentTest
     , cleanDB
     , testMigrate
     , noPrefixMigrate
+    , treeMigrate
     ) where
 
 import Control.Monad.Fail

--- a/persistent-test/src/PersistentTestModels.hs
+++ b/persistent-test/src/PersistentTestModels.hs
@@ -101,6 +101,13 @@ share [mkPersist persistSettings { mpsGeneric = True },  mkMigrate "testMigrate"
       -- | Fields should be documentable.
       name String
       parent RelationshipId Maybe
+
+  MutA
+    mutB    MutBId
+
+  MutB
+    mutA    MutAId
+
 |]
 
 deriving instance Show (BackendKey backend) => Show (PetGeneric backend)
@@ -128,6 +135,17 @@ deriving instance Eq (BackendKey backend) => Eq (NoPrefix2Generic backend)
 
 deriving instance Show (BackendKey backend) => Show (RelationshipGeneric backend)
 deriving instance Eq (BackendKey backend) => Eq (RelationshipGeneric backend)
+
+share [mkPersist persistSettings { mpsPrefixFields = False, mpsGeneric = False }
+      , mkMigrate "treeMigrate"
+      ] [persistLowerCase|
+
+Tree sql=trees
+  name String
+  parent String Maybe
+  Primary name
+  Foreign Tree fkparent parent
+|]
 
 -- | Reverses the order of the fields of an entity.  Used to test
 -- @??@ placeholders of 'rawSql'.

--- a/persistent-test/src/TreeTest.hs
+++ b/persistent-test/src/TreeTest.hs
@@ -1,10 +1,12 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE UndecidableInstances #-} -- FIXME
+{-# LANGUAGE RecordWildCards, UndecidableInstances #-}
+
 module TreeTest where
 
-import Database.Persist.TH (mkDeleteCascade)
-
 import Init
+
+import Database.Persist.TH (mkDeleteCascade)
+import Data.Proxy
 
 
 -- mpsGeneric = False is due to a bug or at least lack of a feature in
@@ -13,7 +15,7 @@ share
     [ mkPersist persistSettings { mpsGeneric = False }
     , mkMigrate "treeMigrate"
     , mkDeleteCascade persistSettings { mpsGeneric = False } ] [persistLowerCase|
-  Tree
+  Tree sql=trees
       name    Text
       parent  Text Maybe
       Primary name
@@ -28,14 +30,41 @@ cleanDB = do
   deleteWhere ([] :: [Filter Tree])
 
 specsWith :: (MonadIO m, MonadFail m) => RunDb SqlBackend m -> Spec
-specsWith runDb = describe "tree" $
+specsWith runDb = describe "tree" $ do
     it "Tree relationships" $ runDb $ do
-      kgp@(TreeKey gpt) <- insert $ Tree "grandpa" Nothing
-      kdad@(TreeKey dadt) <- insert $ Tree "dad" $ Just gpt
-      kc <- insert $ Tree "child" $ Just dadt
-      c <- getJust kc
-      treeFkparent c @== Just kdad
-      dad <- getJust kdad
-      treeFkparent dad @== Just kgp
-      gp <- getJust kgp
-      treeFkparent gp @== Nothing
+        kgp@(TreeKey gpt) <- insert $ Tree "grandpa" Nothing
+        kdad@(TreeKey dadt) <- insert $ Tree "dad" $ Just gpt
+        kc <- insert $ Tree "child" $ Just dadt
+        c <- getJust kc
+        treeFkparent c @== Just kdad
+        dad <- getJust kdad
+        treeFkparent dad @== Just kgp
+        gp <- getJust kgp
+        treeFkparent gp @== Nothing
+    describe "entityDef" $ do
+        let EntityDef{..} = entityDef (Proxy :: Proxy Tree)
+        it "has the right haskell name" $ do
+            entityHaskell `shouldBe` HaskellName "Tree"
+        it "has the right DB name" $ do
+            entityDB `shouldBe` DBName "trees"
+
+    describe "foreign ref" $ do
+        let [ForeignDef{..}] = entityForeigns (entityDef (Proxy :: Proxy Tree))
+        it "has the right haskell name" $ do
+            foreignRefTableHaskell `shouldBe`
+                HaskellName "Tree"
+        it "has the right db name" $ do
+            foreignRefTableDBName `shouldBe`
+                DBName "trees"
+        it "has the right constraint name" $ do
+            foreignConstraintNameHaskell `shouldBe`
+                HaskellName "fkparent"
+        it "has the right DB constraint name" $ do
+            foreignConstraintNameDBName `shouldBe`
+                DBName "treesfkparent"
+        it "has the right fields" $ do
+            foreignFields `shouldBe`
+                [ ( (HaskellName "parent", DBName "parent")
+                  , (HaskellName "name", DBName "name")
+                  )
+                ]

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -4,6 +4,7 @@
 
 * [#1041](https://github.com/yesodweb/persistent/pull/1041)
   * Explicit foreign keys can now reference tables with custom sql name
+  * Add qualified names to the stock classes list.
 
 ## 2.10.5.1
 

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for persistent
 
+## 2.10.5.2
+
+* [#1041](https://github.com/yesodweb/persistent/pull/1041)
+  * Explicit foreign keys can now reference tables with custom sql name
+
 ## 2.10.5.1
 
 * [#1024](https://github.com/yesodweb/persistent/pull/1024)

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:            persistent
-version:         2.10.5.1
+version:         2.10.5.2
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/persistent/test/main.hs
+++ b/persistent/test/main.hs
@@ -499,3 +499,4 @@ main = hspec $ do
                         `shouldBe` Just
                             [ ["something"]
                             ]
+


### PR DESCRIPTION
This PR adds tests for some old issues.

This PR also fixes #373 finally by using the specified tablename in `fixForeignKey`