### PR TITLE
Foreign key cascade

### DIFF
--- a/persistent-sqlite/test/main.hs
+++ b/persistent-sqlite/test/main.hs
@@ -22,6 +22,7 @@ import qualified EmptyEntityTest
 import qualified EmbedOrderTest
 import qualified EmbedTest
 import qualified EquivalentTypeTest
+import qualified ForeignKey
 import qualified HtmlTest
 import qualified LargeNumberTest
 import qualified MaxLenTest
@@ -141,6 +142,7 @@ main = do
       , MaxLenTest.maxlenMigrate
       , Recursive.recursiveMigrate
       , CompositeTest.compositeMigrate
+      , ForeignKey.compositeMigrate
       , MigrationTest.migrationMigrate
       , PersistUniqueTest.migration
       , RenameTest.migration
@@ -205,6 +207,7 @@ main = do
     CustomPrimaryKeyReferenceTest.specsWith db
     MigrationColumnLengthTest.specsWith db
     EquivalentTypeTest.specsWith db
+    ForeignKey.specsWith db
     TransactionLevelTest.specsWith db
     MigrationTest.specsWith db
 

--- a/persistent-template/Database/Persist/TH.hs
+++ b/persistent-template/Database/Persist/TH.hs
@@ -1666,7 +1666,13 @@ instance Lift CompositeDef where
     lift (CompositeDef a b) = [|CompositeDef a b|]
 
 instance Lift ForeignDef where
-    lift (ForeignDef a b c d e f g) = [|ForeignDef a b c d e f g|]
+    lift (ForeignDef a b c d e f g h i) = [|ForeignDef a b c d e f g h i|]
+
+instance Lift CascadeAction where
+    lift Cascade = [|Cascade|]
+    lift Restrict = [|Restrict|]
+    lift SetNull = [|SetNull|]
+    lift SetDefault = [|SetDefault|]
 
 instance Lift HaskellName where
     lift (HaskellName t) = [|HaskellName t|]

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -24,6 +24,7 @@ library
                      EmptyEntityTest
                      EntityEmbedTest
                      EquivalentTypeTest
+                     ForeignKey
                      HtmlTest
                      Init
                      LargeNumberTest

--- a/persistent-test/src/ForeignKey.hs
+++ b/persistent-test/src/ForeignKey.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
+module ForeignKey where
+
+import Init
+
+-- mpsGeneric = False is due to a bug or at least lack of a feature in mkKeyTypeDec TH.hs
+share [mkPersist persistSettings { mpsGeneric = False }, mkMigrate "compositeMigrate"] [persistLowerCase|
+  Parent
+    name String
+    Primary name
+
+  Child
+    pname String
+    Foreign Parent OnDeleteCascade OnUpdateCascade fkparent pname
+    deriving Show Eq
+
+  ParentComposite
+    name String
+    lastName String
+    Primary name lastName
+
+  ChildComposite
+    pname String
+    plastName String
+    Foreign ParentComposite OnDeleteCascade fkparent pname plastName
+    deriving Show Eq
+
+  SelfReferenced
+    name String
+    pname String
+    Primary name
+    Foreign SelfReferenced OnDeleteCascade fkparent pname
+    deriving Show Eq
+|]
+
+specsWith :: (MonadIO m, MonadFail m) => RunDb SqlBackend m -> Spec
+specsWith runDb = describe "foreign keys options" $ do
+  it "delete cascades" $ runDb $ do
+    kf <- insert $ Parent "A"
+    kc <- insert $ Child "A"
+    delete kf
+    cs <- selectList [] []
+    let expected = [] :: [Entity Child]
+    cs @== expected
+  it "update cascades" $ runDb $ do
+    kf <- insert $ Parent "A"
+    kc <- insert $ Child "A"
+    update kf [ParentName =. "B"]
+    cs <- selectList [] []
+    fmap (childPname . entityVal) cs @== ["B"]
+  it "delete Composite cascades" $ runDb $ do
+    kf <- insert $ ParentComposite "A" "B"
+    kc <- insert $ ChildComposite "A" "B"
+    delete kf
+    cs <- selectList [] []
+    let expected = [] :: [Entity ChildComposite]
+    cs @== expected
+  it "delete self referenced cascades" $ runDb $ do
+    kf <- insert $ SelfReferenced "A" "A" -- bootstrap self reference
+    kc <- insert $ SelfReferenced "B" "A"
+    delete kf
+    srs <- selectList [] []
+    let expected = [] :: [Entity SelfReferenced]
+    srs @== expected

--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -295,10 +295,15 @@ data ForeignDef = ForeignDef
     , foreignRefTableDBName        :: !DBName
     , foreignConstraintNameHaskell :: !HaskellName
     , foreignConstraintNameDBName  :: !DBName
+    , foreignOnDelete              :: !(Maybe CascadeAction)
+    , foreignOnUpdate              :: !(Maybe CascadeAction)
     , foreignFields                :: ![(ForeignFieldDef, ForeignFieldDef)] -- this entity plus the primary entity
     , foreignAttrs                 :: ![Attr]
     , foreignNullable              :: Bool
     }
+    deriving (Show, Eq, Read, Ord)
+
+data CascadeAction = Cascade | Restrict | SetNull | SetDefault
     deriving (Show, Eq, Read, Ord)
 
 data PersistException


### PR DESCRIPTION
I tried to fix https://github.com/yesodweb/persistent/issues/910. It works only for table constaints and not for field constraints. Also it only works and is tested on SQLite, but I think making postgres work is just a matter of copy-pase. No existing migrations break.

Some of the options, like 'OnDeleteSetNull' are not useful at the moment, because of the limitation of persistent to only make possible to refer to primary keys of other tables (which can't be NULL anyway).

Not to be confused with what `mkDeleteCascade` does. The approach here is to let the db do all the cascading changes, instead of manually updating other tables. 

Before submitting your PR, check that you've:

- [ ] Bumped the version number
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->