### PR TITLE
mongodb: Fix `ninList` filter operator

### DIFF
--- a/persistent-mongoDB/ChangeLog.md
+++ b/persistent-mongoDB/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for persistent-mongoDB
 
+## 2.10.0.0
+
+* Fix `ninList` filter operator [#1058](https://github.com/yesodweb/persistent/pull/1058)
+
 ## 2.9.0.2
 
 * Compatibility with latest mongoDB [#1012](https://github.com/yesodweb/persistent/pull/1012)

--- a/persistent-mongoDB/Database/Persist/MongoDB.hs
+++ b/persistent-mongoDB/Database/Persist/MongoDB.hs
@@ -1472,5 +1472,5 @@ infix 4 `inList`
 
 -- | No intersection of lists: if no value in the field is found in the list.
 ninList :: PersistField typ => EntityField v [typ] -> [typ] -> Filter v
-f `ninList` a = Filter (unsafeCoerce f) (FilterValues a) In
+f `ninList` a = Filter (unsafeCoerce f) (FilterValues a) NotIn
 infix 4 `ninList`

--- a/persistent-mongoDB/persistent-mongoDB.cabal
+++ b/persistent-mongoDB/persistent-mongoDB.cabal
@@ -1,5 +1,5 @@
 name:            persistent-mongoDB
-version:         2.9.0.2
+version:         2.9.0.3
 license:         MIT
 license-file:    LICENSE
 author:          Greg Weber <greg@gregweber.info>

--- a/persistent-mongoDB/persistent-mongoDB.cabal
+++ b/persistent-mongoDB/persistent-mongoDB.cabal
@@ -1,5 +1,5 @@
 name:            persistent-mongoDB
-version:         2.9.0.3
+version:         2.10.0.0
 license:         MIT
 license-file:    LICENSE
 author:          Greg Weber <greg@gregweber.info>


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [x] Bumped the version number

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

===

Currently, the `inList` and `ninList` definitions are the same, I think the latter should use the `NotIn` query operator.