### PR TITLE
Foreign key cascades

### DIFF
--- a/persistent-postgresql/ChangeLog.md
+++ b/persistent-postgresql/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for persistent-postgresql
 
+## 2.11.0.0
+
+* [#1060](https://github.com/yesodweb/persistent/pull/1060)
+  * The QuasiQuoter now supports `OnDelete` and `OnUpdate` cascade options.
+
 ## 2.10.1.2
 
 * Fix issue with multiple foreign keys on single column. [#1010](https://github.com/yesodweb/persistent/pull/1010)

--- a/persistent-postgresql/persistent-postgresql.cabal
+++ b/persistent-postgresql/persistent-postgresql.cabal
@@ -1,5 +1,5 @@
 name:            persistent-postgresql
-version:         2.10.1.2
+version:         2.11.0.0
 license:         MIT
 license-file:    LICENSE
 author:          Felipe Lessa, Michael Snoyman <michael@snoyman.com>
@@ -16,7 +16,7 @@ extra-source-files: ChangeLog.md
 
 library
     build-depends:   base                  >= 4.9      && < 5
-                   , persistent            >= 2.10     && < 3
+                   , persistent            >= 2.11     && < 3
                    , aeson                 >= 1.0
                    , blaze-builder
                    , bytestring            >= 0.10

--- a/persistent-postgresql/test/main.hs
+++ b/persistent-postgresql/test/main.hs
@@ -23,6 +23,7 @@ import Test.QuickCheck
 -- FIXME: should probably be used?
 -- import qualified ArrayAggTest
 import qualified CompositeTest
+import qualified ForeignKey
 import qualified CustomPersistFieldTest
 import qualified CustomPrimaryKeyReferenceTest
 import qualified DataTypeTest
@@ -118,6 +119,7 @@ main = do
       , CustomPrimaryKeyReferenceTest.migration
       , MigrationColumnLengthTest.migration
       , TransactionLevelTest.migration
+      , ForeignKey.compositeMigrate
       ]
     PersistentTest.cleanDB
 
@@ -147,6 +149,7 @@ main = do
     EmbedTest.specsWith db
     EmbedOrderTest.specsWith db
     LargeNumberTest.specsWith db
+    ForeignKey.specsWith db
     UniqueTest.specsWith db
     MaxLenTest.specsWith db
     Recursive.specsWith db

--- a/persistent-sqlite/ChangeLog.md
+++ b/persistent-sqlite/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for persistent-sqlite
 
+## 2.11.0.0
+
+* [#1060](https://github.com/yesodweb/persistent/pull/1060)
+  * The QuasiQuoter now supports `OnDelete` and `OnUpdate` cascade options.
+
 ## 2.10.6.2
 
 * Move template haskell splices to be correct (and GHC 8.10 compatible) [#1034](https://github.com/yesodweb/persistent/pull/1034)

--- a/persistent-sqlite/persistent-sqlite.cabal
+++ b/persistent-sqlite/persistent-sqlite.cabal
@@ -1,5 +1,5 @@
 name:            persistent-sqlite
-version:         2.10.6.2
+version:         2.11.0.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -44,7 +44,7 @@ flag use-stat4
 
 library
     build-depends:   base                    >= 4.9         && < 5
-                   , persistent              >= 2.10        && < 3
+                   , persistent              >= 2.11        && < 3
                    , aeson                   >= 1.0
                    , bytestring              >= 0.10
                    , conduit                 >= 1.2.12

--- a/persistent-sqlite/test/main.hs
+++ b/persistent-sqlite/test/main.hs
@@ -22,6 +22,7 @@ import qualified EmptyEntityTest
 import qualified EmbedOrderTest
 import qualified EmbedTest
 import qualified EquivalentTypeTest
+import qualified ForeignKey
 import qualified HtmlTest
 import qualified LargeNumberTest
 import qualified MaxLenTest
@@ -141,6 +142,7 @@ main = do
       , MaxLenTest.maxlenMigrate
       , Recursive.recursiveMigrate
       , CompositeTest.compositeMigrate
+      , ForeignKey.compositeMigrate
       , MigrationTest.migrationMigrate
       , PersistUniqueTest.migration
       , RenameTest.migration
@@ -205,6 +207,7 @@ main = do
     CustomPrimaryKeyReferenceTest.specsWith db
     MigrationColumnLengthTest.specsWith db
     EquivalentTypeTest.specsWith db
+    ForeignKey.specsWith db
     TransactionLevelTest.specsWith db
     MigrationTest.specsWith db
 

--- a/persistent-template/ChangeLog.md
+++ b/persistent-template/ChangeLog.md
@@ -1,5 +1,9 @@
 ## Unreleased changes
 
+## 2.8.3.0
+
+* Add `Lift` instances for the cascade types. [#1060](https://github.com/yesodweb/persistent/pull/1060)
+
 ## 2.8.2.3
 
 * Require extensions in a more friendly manner. [#1030](https://github.com/yesodweb/persistent/pull/1030)

--- a/persistent-template/Database/Persist/TH.hs
+++ b/persistent-template/Database/Persist/TH.hs
@@ -1668,9 +1668,15 @@ instance Lift CompositeDef where
 instance Lift ForeignDef where
     lift (ForeignDef a b c d e f g h) = [|ForeignDef a b c d e f g h|]
 
+-- |
+--
+-- @since 2.8.3.0
 instance Lift FieldCascade where
     lift (FieldCascade a b) = [|FieldCascade a b|]
 
+-- |
+--
+-- @since 2.8.3.0
 instance Lift CascadeAction where
     lift Cascade = [|Cascade|]
     lift Restrict = [|Restrict|]

--- a/persistent-template/Database/Persist/TH.hs
+++ b/persistent-template/Database/Persist/TH.hs
@@ -1666,7 +1666,10 @@ instance Lift CompositeDef where
     lift (CompositeDef a b) = [|CompositeDef a b|]
 
 instance Lift ForeignDef where
-    lift (ForeignDef a b c d e f g h i) = [|ForeignDef a b c d e f g h i|]
+    lift (ForeignDef a b c d e f g h) = [|ForeignDef a b c d e f g h|]
+
+instance Lift FieldCascade where
+    lift (FieldCascade a b) = [|FieldCascade a b|]
 
 instance Lift CascadeAction where
     lift Cascade = [|Cascade|]

--- a/persistent-template/Database/Persist/TH.hs
+++ b/persistent-template/Database/Persist/TH.hs
@@ -1666,7 +1666,13 @@ instance Lift CompositeDef where
     lift (CompositeDef a b) = [|CompositeDef a b|]
 
 instance Lift ForeignDef where
-    lift (ForeignDef a b c d e f g) = [|ForeignDef a b c d e f g|]
+    lift (ForeignDef a b c d e f g h i) = [|ForeignDef a b c d e f g h i|]
+
+instance Lift CascadeAction where
+    lift Cascade = [|Cascade|]
+    lift Restrict = [|Restrict|]
+    lift SetNull = [|SetNull|]
+    lift SetDefault = [|SetDefault|]
 
 instance Lift HaskellName where
     lift (HaskellName t) = [|HaskellName t|]

--- a/persistent-template/persistent-template.cabal
+++ b/persistent-template/persistent-template.cabal
@@ -1,5 +1,5 @@
 name:            persistent-template
-version:         2.8.2.3
+version:         2.8.3.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -16,7 +16,7 @@ extra-source-files: test/main.hs ChangeLog.md README.md
 
 library
     build-depends:   base                     >= 4.10      && < 5
-                   , persistent               >= 2.10      && < 3
+                   , persistent               >= 2.11      && < 3
                    , aeson                    >= 1.0       && < 1.5
                    , bytestring               >= 0.10
                    , containers

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -24,6 +24,7 @@ library
                      EmptyEntityTest
                      EntityEmbedTest
                      EquivalentTypeTest
+                     ForeignKey
                      HtmlTest
                      Init
                      LargeNumberTest

--- a/persistent-test/src/ForeignKey.hs
+++ b/persistent-test/src/ForeignKey.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
+module ForeignKey where
+
+import Init
+
+-- mpsGeneric = False is due to a bug or at least lack of a feature in mkKeyTypeDec TH.hs
+share [mkPersist persistSettings { mpsGeneric = False }, mkMigrate "compositeMigrate"] [persistLowerCase|
+  Parent
+    name String
+    Primary name
+
+  Child
+    pname String
+    Foreign Parent OnDeleteCascade OnUpdateCascade fkparent pname
+    deriving Show Eq
+
+  ParentComposite
+    name String
+    lastName String
+    Primary name lastName
+
+  ChildComposite
+    pname String
+    plastName String
+    Foreign ParentComposite OnDeleteCascade fkparent pname plastName
+    deriving Show Eq
+
+  SelfReferenced
+    name String
+    pname String
+    Primary name
+    Foreign SelfReferenced OnDeleteCascade fkparent pname
+    deriving Show Eq
+|]
+
+specsWith :: (MonadIO m, MonadFail m) => RunDb SqlBackend m -> Spec
+specsWith runDb = describe "foreign keys options" $ do
+  it "delete cascades" $ runDb $ do
+    kf <- insert $ Parent "A"
+    kc <- insert $ Child "A"
+    delete kf
+    cs <- selectList [] []
+    let expected = [] :: [Entity Child]
+    cs @== expected
+  it "update cascades" $ runDb $ do
+    kf <- insert $ Parent "A"
+    kc <- insert $ Child "A"
+    update kf [ParentName =. "B"]
+    cs <- selectList [] []
+    fmap (childPname . entityVal) cs @== ["B"]
+  it "delete Composite cascades" $ runDb $ do
+    kf <- insert $ ParentComposite "A" "B"
+    kc <- insert $ ChildComposite "A" "B"
+    delete kf
+    cs <- selectList [] []
+    let expected = [] :: [Entity ChildComposite]
+    cs @== expected
+  it "delete self referenced cascades" $ runDb $ do
+    kf <- insert $ SelfReferenced "A" "A" -- bootstrap self reference
+    kc <- insert $ SelfReferenced "B" "A"
+    delete kf
+    srs <- selectList [] []
+    let expected = [] :: [Entity SelfReferenced]
+    srs @== expected

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for persistent
 
+## 2.11.0.0
+
+* [#1060](https://github.com/yesodweb/persistent/pull/1060)
+  * The QuasiQuoter now supports `OnDelete` and `OnUpdate` cascade options.
+
 ## 2.10.5.2
 
 * [#1041](https://github.com/yesodweb/persistent/pull/1041)

--- a/persistent/Database/Persist/Quasi.hs
+++ b/persistent/Database/Persist/Quasi.hs
@@ -929,8 +929,10 @@ takeForeign ps tableName _defs = takeRefTable
                     HaskellName n
                 , foreignConstraintNameDBName =
                     DBName $ psToDBName ps (tableName `T.append` n)
-                , foreignOnDelete = onDelete
-                , foreignOnUpdate = onUpdate
+                , foreignFieldCascade = FieldCascade
+                    { fcOnDelete = onDelete
+                    , fcOnUpdate = onUpdate
+                    }
                 , foreignFields =
                     []
                 , foreignAttrs =

--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -295,16 +295,28 @@ data ForeignDef = ForeignDef
     , foreignRefTableDBName        :: !DBName
     , foreignConstraintNameHaskell :: !HaskellName
     , foreignConstraintNameDBName  :: !DBName
-    , foreignOnDelete              :: !(Maybe CascadeAction)
-    , foreignOnUpdate              :: !(Maybe CascadeAction)
+    , foreignFieldCascade          :: !FieldCascade
     , foreignFields                :: ![(ForeignFieldDef, ForeignFieldDef)] -- this entity plus the primary entity
     , foreignAttrs                 :: ![Attr]
     , foreignNullable              :: Bool
     }
     deriving (Show, Eq, Read, Ord)
 
+data FieldCascade = FieldCascade
+    { fcOnUpdate :: !(Maybe CascadeAction)
+    , fcOnDelete :: !(Maybe CascadeAction)
+    }
+    deriving (Show, Eq, Read, Ord)
+
 data CascadeAction = Cascade | Restrict | SetNull | SetDefault
     deriving (Show, Eq, Read, Ord)
+
+renderCascadeAction :: CascadeAction -> Text
+renderCascadeAction action = case action of
+  Cascade    -> "CASCADE"
+  Restrict   -> "RESTRICT"
+  SetNull    -> "SET NULL"
+  SetDefault -> "SET DEFAULT"
 
 data PersistException
   = PersistError Text -- ^ Generic Exception

--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -295,10 +295,15 @@ data ForeignDef = ForeignDef
     , foreignRefTableDBName        :: !DBName
     , foreignConstraintNameHaskell :: !HaskellName
     , foreignConstraintNameDBName  :: !DBName
+    , foreignOnDelete              :: !(Maybe CascadeAction)
+    , foreignOnUpdate              :: !(Maybe CascadeAction)
     , foreignFields                :: ![(ForeignFieldDef, ForeignFieldDef)] -- this entity plus the primary entity
     , foreignAttrs                 :: ![Attr]
     , foreignNullable              :: Bool
     }
+    deriving (Show, Eq, Read, Ord)
+
+data CascadeAction = Cascade | Restrict | SetNull | SetDefault
     deriving (Show, Eq, Read, Ord)
 
 data PersistException

--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -296,21 +296,35 @@ data ForeignDef = ForeignDef
     , foreignConstraintNameHaskell :: !HaskellName
     , foreignConstraintNameDBName  :: !DBName
     , foreignFieldCascade          :: !FieldCascade
+    -- ^ Determine how the field will cascade on updates and deletions.
+    --
+    -- @since 2.11.0
     , foreignFields                :: ![(ForeignFieldDef, ForeignFieldDef)] -- this entity plus the primary entity
     , foreignAttrs                 :: ![Attr]
     , foreignNullable              :: Bool
     }
     deriving (Show, Eq, Read, Ord)
 
+-- | This datatype describes how a foreign reference field cascades deletes
+-- or updates.
+--
+-- @since 2.11.0
 data FieldCascade = FieldCascade
     { fcOnUpdate :: !(Maybe CascadeAction)
     , fcOnDelete :: !(Maybe CascadeAction)
     }
     deriving (Show, Eq, Read, Ord)
 
+-- | A 'FieldCascade' that does nothing.
+--
+-- @since 2.11.0
 noCascade :: FieldCascade
 noCascade = FieldCascade Nothing Nothing
 
+-- | Renders a 'FieldCascade' value such that it can be used in SQL
+-- migrations.
+--
+-- @since 2.11.0
 renderFieldCascade :: FieldCascade -> Text
 renderFieldCascade (FieldCascade onUpdate onDelete) =
     T.unwords
@@ -318,9 +332,17 @@ renderFieldCascade (FieldCascade onUpdate onDelete) =
         , foldMap (mappend "ON UPDATE " . renderCascadeAction) onUpdate
         ]
 
+-- | An action that might happen on a deletion or update on a foreign key
+-- change.
+--
+-- @since 2.11.0
 data CascadeAction = Cascade | Restrict | SetNull | SetDefault
     deriving (Show, Eq, Read, Ord)
 
+-- | Render a 'CascadeAction' to 'Text' such that it can be used in a SQL
+-- command.
+--
+-- @since 2.11.0
 renderCascadeAction :: CascadeAction -> Text
 renderCascadeAction action = case action of
   Cascade    -> "CASCADE"

--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -308,6 +308,16 @@ data FieldCascade = FieldCascade
     }
     deriving (Show, Eq, Read, Ord)
 
+noCascade :: FieldCascade
+noCascade = FieldCascade Nothing Nothing
+
+renderFieldCascade :: FieldCascade -> Text
+renderFieldCascade (FieldCascade onUpdate onDelete) =
+    T.unwords
+        [ foldMap (mappend "ON DELETE " . renderCascadeAction) onDelete
+        , foldMap (mappend "ON UPDATE " . renderCascadeAction) onUpdate
+        ]
+
 data CascadeAction = Cascade | Restrict | SetNull | SetDefault
     deriving (Show, Eq, Read, Ord)
 

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:            persistent
-version:         2.10.5.2
+version:         2.11.0.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

A continuation on #1056 implementing it in Postgresql.

We can't implement this for MySQL until we figure out how to set a `maxlen` on the keys for strings. :\ Well, we could, but we'd need a different set of tests, and I don't feel like writing that out right now. Might as well get sqlite and postgres supported and released.

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->