### PR TITLE
Use DeriveLift to generate persistent-template's Lift instances

### DIFF
--- a/persistent-template/ChangeLog.md
+++ b/persistent-template/ChangeLog.md
@@ -3,6 +3,9 @@
 ## 2.8.3.0
 
 * Add `Lift` instances for the cascade types. [#1060](https://github.com/yesodweb/persistent/pull/1060)
+* Use `DeriveLift` to implement all `Lift` instances. Among other benefits,
+  this provides implementations of `liftTyped` on `template-haskell-2.16` (GHC
+  8.10) or later. [#1064](https://github.com/yesodweb/persistent/pull/1064)
 
 ## 2.8.2.3
 


### PR DESCRIPTION
GHC 8.0 and later come with the `DeriveLift` extension for deriving instances of `Language.Haskell.TH.Syntax.Lift`. `persistent-template` supports GHC 8.2 and up, so it is able to make use of this. Not only does `DeriveLift` make for much shorter code, but it also fixes warnings that you get when compiling `persistent-template` with GHC 8.10 or later:

```
[1 of 1] Compiling Database.Persist.TH ( Database/Persist/TH.hs, interpreted )

Database/Persist/TH.hs:267:10: warning: [-Wmissing-methods]
    • No explicit implementation for
        ‘liftTyped’
    • In the instance declaration for ‘Lift SqlTypeExp’
    |
267 | instance Lift SqlTypeExp where
    |          ^^^^^^^^^^^^^^^

Database/Persist/TH.hs:278:10: warning: [-Wmissing-methods]
    • No explicit implementation for
        ‘liftTyped’
    • In the instance declaration for ‘Lift FieldsSqlTypeExp’
    |
278 | instance Lift FieldsSqlTypeExp where
    |          ^^^^^^^^^^^^^^^^^^^^^

Database/Persist/TH.hs:284:10: warning: [-Wmissing-methods]
    • No explicit implementation for
        ‘liftTyped’
    • In the instance declaration for ‘Lift FieldSqlTypeExp’
    |
284 | instance Lift FieldSqlTypeExp where
    |          ^^^^^^^^^^^^^^^^^^^^

Database/Persist/TH.hs:288:10: warning: [-Wmissing-methods]
    • No explicit implementation for
        ‘liftTyped’
    • In the instance declaration for ‘Lift EntityDefSqlTypeExp’
    |
288 | instance Lift EntityDefSqlTypeExp where
    |          ^^^^^^^^^^^^^^^^^^^^^^^^

Database/Persist/TH.hs:295:10: warning: [-Wmissing-methods]
    • No explicit implementation for
        ‘liftTyped’
    • In the instance declaration for ‘Lift ReferenceDef’
    |
295 | instance Lift ReferenceDef where
    |          ^^^^^^^^^^^^^^^^^

Database/Persist/TH.hs:302:10: warning: [-Wmissing-methods]
    • No explicit implementation for
        ‘liftTyped’
    • In the instance declaration for ‘Lift EmbedEntityDef’
    |
302 | instance Lift EmbedEntityDef where
    |          ^^^^^^^^^^^^^^^^^^^

Database/Persist/TH.hs:305:10: warning: [-Wmissing-methods]
    • No explicit implementation for
        ‘liftTyped’
    • In the instance declaration for ‘Lift EmbedFieldDef’
    |
305 | instance Lift EmbedFieldDef where
    |          ^^^^^^^^^^^^^^^^^^

Database/Persist/TH.hs:1693:10: warning: [-Wmissing-methods]
    • No explicit implementation for
        ‘liftTyped’
    • In the instance declaration for ‘Lift EntityDef’
     |
1693 | instance Lift EntityDef where
     |          ^^^^^^^^^^^^^^

Database/Persist/TH.hs:1709:10: warning: [-Wmissing-methods]
    • No explicit implementation for
        ‘liftTyped’
    • In the instance declaration for ‘Lift FieldDef’
     |
1709 | instance Lift FieldDef where
     |          ^^^^^^^^^^^^^

Database/Persist/TH.hs:1712:10: warning: [-Wmissing-methods]
    • No explicit implementation for
        ‘liftTyped’
    • In the instance declaration for ‘Lift UniqueDef’
     |
1712 | instance Lift UniqueDef where
     |          ^^^^^^^^^^^^^^

Database/Persist/TH.hs:1715:10: warning: [-Wmissing-methods]
    • No explicit implementation for
        ‘liftTyped’
    • In the instance declaration for ‘Lift CompositeDef’
     |
1715 | instance Lift CompositeDef where
     |          ^^^^^^^^^^^^^^^^^

Database/Persist/TH.hs:1718:10: warning: [-Wmissing-methods]
    • No explicit implementation for
        ‘liftTyped’
    • In the instance declaration for ‘Lift ForeignDef’
     |
1718 | instance Lift ForeignDef where
     |          ^^^^^^^^^^^^^^^

Database/Persist/TH.hs:1724:10: warning: [-Wmissing-methods]
    • No explicit implementation for
        ‘liftTyped’
    • In the instance declaration for ‘Lift FieldCascade’
     |
1724 | instance Lift FieldCascade where
     |          ^^^^^^^^^^^^^^^^^

Database/Persist/TH.hs:1730:10: warning: [-Wmissing-methods]
    • No explicit implementation for
        ‘liftTyped’
    • In the instance declaration for ‘Lift CascadeAction’
     |
1730 | instance Lift CascadeAction where
     |          ^^^^^^^^^^^^^^^^^^

Database/Persist/TH.hs:1736:10: warning: [-Wmissing-methods]
    • No explicit implementation for
        ‘liftTyped’
    • In the instance declaration for ‘Lift HaskellName’
     |
1736 | instance Lift HaskellName where
     |          ^^^^^^^^^^^^^^^^

Database/Persist/TH.hs:1738:10: warning: [-Wmissing-methods]
    • No explicit implementation for
        ‘liftTyped’
    • In the instance declaration for ‘Lift DBName’
     |
1738 | instance Lift DBName where
     |          ^^^^^^^^^^^

Database/Persist/TH.hs:1740:10: warning: [-Wmissing-methods]
    • No explicit implementation for
        ‘liftTyped’
    • In the instance declaration for ‘Lift FieldType’
     |
1740 | instance Lift FieldType where
     |          ^^^^^^^^^^^^^^

Database/Persist/TH.hs:1746:10: warning: [-Wmissing-methods]
    • No explicit implementation for
        ‘liftTyped’
    • In the instance declaration for ‘Lift PersistFilter’
     |
1746 | instance Lift PersistFilter where
     |          ^^^^^^^^^^^^^^^^^^

Database/Persist/TH.hs:1757:10: warning: [-Wmissing-methods]
    • No explicit implementation for
        ‘liftTyped’
    • In the instance declaration for ‘Lift PersistUpdate’
     |
1757 | instance Lift PersistUpdate where
     |          ^^^^^^^^^^^^^^^^^^

Database/Persist/TH.hs:1765:10: warning: [-Wmissing-methods]
    • No explicit implementation for
        ‘liftTyped’
    • In the instance declaration for ‘Lift SqlType’
     |
1765 | instance Lift SqlType where
     |          ^^^^^^^^^^^^
```

This is because `DeriveLift` fills in implementations of `liftTyped`, a method that was introduced to `Lift` in `template-haskell-2.16.0.0` (bundled with GHC 8.10).

Note that not all `Lift` instances currently used by `persistent-template` can be derived, since the code that `DeriveLift` would produce would not be equivalent to some of the more exotic hand-written instances. These include the `Lift` instances for `SqlTypeExp`, `FieldsSqlTypeExp`, `FieldSqlTypeExp`, and `EntityDefSqlTypeExp`. For these instance, I simply define `liftTyped` implementations using CPP.

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->