### PR TITLE
Use stock deriving strategy on generated Show instances for Uniques

### DIFF
--- a/persistent-template/ChangeLog.md
+++ b/persistent-template/ChangeLog.md
@@ -1,5 +1,9 @@
 ## Unreleased changes
 
+## 2.8.3.1
+
+* Use `stock` deriving strategy on generated `Show` instances for `Uniques`. [#1068](https://github.com/yesodweb/persistent/pull/1068)
+
 ## 2.8.3.0
 
 * Add `Lift` instances for the cascade types. [#1060](https://github.com/yesodweb/persistent/pull/1060)

--- a/persistent-template/Database/Persist/TH.hs
+++ b/persistent-template/Database/Persist/TH.hs
@@ -624,7 +624,7 @@ uniqueTypeDec mps t =
 #endif
   where
     derivClause [] = []
-    derivClause _  = [DerivClause Nothing [ConT ''Show]]
+    derivClause _  = [DerivClause (Just StockStrategy) [ConT ''Show]]
 
 mkUnique :: MkPersistSettings -> EntityDef -> UniqueDef -> Con
 mkUnique mps t (UniqueDef (HaskellName constr) _ fields attrs) =

--- a/persistent-template/persistent-template.cabal
+++ b/persistent-template/persistent-template.cabal
@@ -1,5 +1,5 @@
 name:            persistent-template
-version:         2.8.3.0
+version:         2.8.3.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/persistent-template/test/main.hs
+++ b/persistent-template/test/main.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -54,11 +55,12 @@ Address json
     deriving Show Eq
 NoJson
     foo Text
+    UniqueNoJsonFoo foo
     deriving Show Eq
 |]
 
 -- TODO: Derive Generic at the source site to get this unblocked.
-deriving instance Generic (BackendKey SqlBackend)
+deriving stock instance Generic (BackendKey SqlBackend)
 
 share [mkPersist sqlSettings { mpsGeneric = False, mpsGenerateLenses = True }] [persistLowerCase|
 Lperson json


### PR DESCRIPTION
Hey we ran into this at Freckle trying to turn on `-Wmissing-deriving-strategies` with `ghc` 8.8.3. Currently, we're seeing warnings when compiling `Entity` declarations with a `Unique`, e.g.:

```haskell
mkPersist sqlSettings [persistUpperCase|
  Thing
    foo Text
    UniqueThingFoo foo
    deriving Show Eq
|]
```

⇒

```plaintext
  <snip>/persistent/persistent-template/test/main.hs:44:1: warning: [-Wmissing-deriving-strategies]
      No deriving strategy specified. Did you want stock, newtype, or anyclass?
     |
  44 | mkPersist sqlSettings [persistUpperCase|
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
```

Specifying the `stock` strategy for the `Unique`'s generated `Show` instance silences this warning:

```diff
 data instance Unique Thing = UniqueThingFoo Text
-  deriving Show
+  deriving stock Show
```

Before submitting your PR, check that you've:

- [x] Bumped the version number

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)