### PR TITLE
Refactor PostgresJSON Tests

### DIFF
--- a/persistent-postgresql/ChangeLog.md
+++ b/persistent-postgresql/ChangeLog.md
@@ -7,6 +7,10 @@
 * [#1060](https://github.com/yesodweb/persistent/pull/1060)
   * The QuasiQuoter now supports `OnDelete` and `OnUpdate` cascade options.
 * Handle foreign key constraint names over 63 characters. See [#996](https://github.com/yesodweb/persistent/pull/996) for details.
+* [#1072](https://github.com/yesodweb/persistent/pull/1072) Refactored `test/JSONTest.hs` to use `hspec`
+  * added `runConn_` to run a db connection and return result
+  * Renamed `db` to `runConnAssert` in `test/PgInit.hs` for clarity
+  * Ran `test/ArrayAggTest.hs` (which was previously written but not being run)
 
 ## 2.10.1.2
 

--- a/persistent-postgresql/persistent-postgresql.cabal
+++ b/persistent-postgresql/persistent-postgresql.cabal
@@ -1,5 +1,5 @@
 name:            persistent-postgresql
-version:         2.11.0.0
+version:         2.11.0.1
 license:         MIT
 license-file:    LICENSE
 author:          Felipe Lessa, Michael Snoyman <michael@snoyman.com>

--- a/persistent-postgresql/test/ArrayAggTest.hs
+++ b/persistent-postgresql/test/ArrayAggTest.hs
@@ -33,11 +33,11 @@ cleanDB = deleteWhere ([] :: [Filter TestValue])
 emptyArr :: Value
 emptyArr = toJSON ([] :: [Value])
 
-specs :: (MonadFail m, MonadIO m) => RunDb SqlBackend m -> Spec
-specs runDb = do
+specs :: Spec
+specs = do
   describe "rawSql/array_agg" $ do
     let runArrayAggTest :: (PersistField [a], Ord a, Show a) => Text -> [a] -> Assertion
-        runArrayAggTest dbField expected = runDb $ do
+        runArrayAggTest dbField expected = runConnAssert $ do
           void $ insertMany
             [ UserPT "a" $ Just "b"
             , UserPT "c" $ Just "d"

--- a/persistent-postgresql/test/ArrayAggTest.hs
+++ b/persistent-postgresql/test/ArrayAggTest.hs
@@ -33,7 +33,7 @@ cleanDB = deleteWhere ([] :: [Filter TestValue])
 emptyArr :: Value
 emptyArr = toJSON ([] :: [Value])
 
-specs :: RunDb SqlBackend IO -> Spec
+specs :: (MonadFail m, MonadIO m) => RunDb SqlBackend m -> Spec
 specs runDb = do
   describe "rawSql/array_agg" $ do
     let runArrayAggTest :: (PersistField [a], Ord a, Show a) => Text -> [a] -> Assertion

--- a/persistent-postgresql/test/CustomConstraintTest.hs
+++ b/persistent-postgresql/test/CustomConstraintTest.hs
@@ -36,8 +36,8 @@ specs :: (MonadUnliftIO m, MonadFail m) => RunDb SqlBackend m -> Spec
 specs runDb = do
   describe "custom constraint used in migration" $ do
     it "custom constraint is actually created" $ runDb $ do
-      runMigrationSilent customConstraintMigrate
-      runMigrationSilent customConstraintMigrate -- run a second time to ensure the constraint isn't dropped
+      void $ runMigrationSilent customConstraintMigrate
+      void $ runMigrationSilent customConstraintMigrate -- run a second time to ensure the constraint isn't dropped
       let query = T.concat ["SELECT DISTINCT COUNT(*) "
                            ,"FROM information_schema.constraint_column_usage ccu, "
                            ,"information_schema.key_column_usage kcu, "

--- a/persistent-postgresql/test/JSONTest.hs
+++ b/persistent-postgresql/test/JSONTest.hs
@@ -32,7 +32,8 @@ share [mkPersist persistSettings,  mkMigrate "jsonTestMigrate"] [persistLowerCas
     deriving Show
 |]
 
-cleanDB :: (BaseBackend backend ~ SqlBackend, PersistQueryWrite backend, MonadIO m) => ReaderT backend m ()
+cleanDB :: (BaseBackend backend ~ SqlBackend, PersistQueryWrite backend, MonadIO m)
+        => ReaderT backend m ()
 cleanDB = deleteWhere ([] :: [Filter TestValue])
 
 emptyArr :: Value
@@ -46,29 +47,30 @@ insert' = insert . TestValue
 matchKeys :: (Show record, Show (Key record), MonadIO m, Eq (Key record))
           => [Key record] -> [Entity record] -> m ()
 matchKeys ys xs = do
-    msg1 `assertBoolIO` (xLen == yLen)
-    forM_ ys $ \y -> msg2 y `assertBoolIO` (y `elem` ks)
-  where ks = entityKey <$> xs
-        xLen = length xs
-        yLen = length ys
-        msg1 = mconcat
-            [ "\nexpected: ", show yLen
-            , "\n but got: ", show xLen
-            , "\n[xs: ", show xs, "]"
-            , "\n[ys: ", show ys, "]"
-            ]
-        msg2 y = mconcat
-            [ "key \"", show y
-            , "\" not in result:\n  ", show ks
-            ]
+  msg1 `assertBoolIO` (xLen == yLen)
+  forM_ ys $ \y -> msg2 y `assertBoolIO` (y `elem` ks)
+    where ks = entityKey <$> xs
+          xLen = length xs
+          yLen = length ys
+          msg1 = mconcat
+              [ "\nexpected: ", show yLen
+              , "\n but got: ", show xLen
+              , "\n[xs: ", show xs, "]"
+              , "\n[ys: ", show ys, "]"
+              ]
+          msg2 y = mconcat
+              [ "key \"", show y
+              , "\" not in result:\n  ", show ks
+              ]
 
-setup :: IO ()
-setup = asIO $ runConn $ do
-    void $ runMigrationSilent jsonTestMigrate
+setup :: IO TestKeys
+setup = asIO $ runConn_ $ do
+  void $ runMigrationSilent jsonTestMigrate
+  testKeys
 
 teardown :: IO ()
-teardown = asIO $ runConn $ do
-  cleanDB
+teardown = asIO $ runConn_ $ do
+    cleanDB
 
 shouldBeIO :: (Show a, Eq a, MonadIO m) => a -> a -> m ()
 shouldBeIO x y = liftIO $ shouldBe x y
@@ -76,144 +78,150 @@ shouldBeIO x y = liftIO $ shouldBe x y
 assertBoolIO :: MonadIO m => String -> Bool -> m ()
 assertBoolIO s b = liftIO $ assertBool s b
 
-edgeCases :: (Monad m, MonadIO m) => ReaderT SqlBackend m (EdgeCaseKeys TestValue)
-edgeCases = do
-  arrList3K <- insert' $ toJSON [toJSON [String "a"], Number 1]
-  arrList4K <- insert' $ toJSON [String "a", String "b", String "c", String "d"]
-  objEmptyK <- insert' $ object ["" .= Number 9001]
-  objFullK  <- insert' $ object ["a" .= Number 1, "b" .= Number 2
-                                , "c" .= Number 3, "d" .= Number 4 ]
-  return $ EdgeCaseKeys {..}
+testKeys :: (Monad m, MonadIO m) => ReaderT SqlBackend m TestKeys
+testKeys = do
+    nullK <- insert' Null
 
-globalKeys :: (Monad m, MonadIO m) => ReaderT SqlBackend m (GlobalKeys TestValue)
-globalKeys = do
-          nullK <- insert' Null
-          let nulls = [nullK]
+    boolTK <- insert' $ Bool True
+    boolFK <- insert' $ toJSON False
 
-          boolTK <- insert' $ Bool True
-          boolFK <- insert' $ toJSON False
-          let bools = [boolTK, boolFK]
+    num0K <- insert' $ Number 0
+    num1K <- insert' $ Number 1
+    numBigK <- insert' $ toJSON (1234567890 :: Int)
+    numFloatK <- insert' $ Number 0.0
+    numSmallK <- insert' $ Number 0.0000000000000000123
+    numFloat2K <- insert' $ Number 1.5
+    -- numBigFloatK will turn into 9876543210.123457 because JSON
+    numBigFloatK <- insert' $ toJSON (9876543210.123456789 :: Double)
 
-          num0K <- insert' $ Number 0
-          num1K <- insert' $ Number 1
-          numBigK <- insert' $ toJSON (1234567890 :: Int)
-          numFloatK <- insert' $ Number 0.0
-          numSmallK <- insert' $ Number 0.0000000000000000123
-          numFloat2K <- insert' $ Number 1.5
-          -- numBigFloatK will turn into 9876543210.123457 because JSON
-          numBigFloatK <- insert' $ toJSON (9876543210.123456789 :: Double)
-          let numbers = [ num0K, num1K, numBigK, numFloatK
-                        , numSmallK, numFloat2K, numBigFloatK ]
+    strNullK <- insert' $ String ""
+    strObjK <- insert' $ String "{}"
+    strArrK <- insert' $ String "[]"
+    strAK <- insert' $ String "a"
+    strTestK <- insert' $ toJSON ("testing" :: Text)
+    str2K <- insert' $ String "2"
+    strFloatK <- insert' $ String "0.45876"
 
-          strNullK <- insert' $ String ""
-          strObjK <- insert' $ String "{}"
-          strArrK <- insert' $ String "[]"
-          strAK <- insert' $ String "a"
-          strTestK <- insert' $ toJSON ("testing" :: Text)
-          str2K <- insert' $ String "2"
-          strFloatK <- insert' $ String "0.45876"
-          let strings = [ strNullK, strObjK, strArrK, strAK
-                        , strTestK, str2K, strFloatK ]
+    arrNullK <- insert' $ Array $ V.fromList []
+    arrListK <- insert' $ toJSON [emptyArr,emptyArr,toJSON [emptyArr,emptyArr]]
+    arrList2K <- insert' $ toJSON [emptyArr,toJSON [Number 3,Bool False]
+                                  ,toJSON [emptyArr,toJSON [Object mempty]]
+                                  ]
+    arrFilledK <- insert' $ toJSON [Null, Number 4, String "b"
+                                   ,Object mempty, emptyArr
+                                   ,object [ "test" .= [Null], "test2" .= String "yes"]
+                                   ]
+    arrList3K <- insert' $ toJSON [toJSON [String "a"], Number 1]
+    arrList4K <- insert' $ toJSON [String "a", String "b", String "c", String "d"]
 
-          arrNullK <- insert' $ Array $ V.fromList []
-          arrListK <- insert' $ toJSON [emptyArr,emptyArr,toJSON [emptyArr,emptyArr]]
-          arrList2K <- insert' $ toJSON [emptyArr,toJSON [Number 3,Bool False]
-                                        ,toJSON [emptyArr,toJSON [Object mempty]]
-                                        ]
-          arrFilledK <- insert' $ toJSON [Null, Number 4, String "b"
-                                         ,Object mempty, emptyArr
-                                         ,object [ "test" .= [Null], "test2" .= String "yes"]]
-          let lists = [ arrNullK, arrListK, arrList2K, arrFilledK ]
+    objNullK <- insert' $ Object mempty
+    objTestK <- insert' $ object ["test" .= Null, "test1" .= String "no"]
+    objDeepK <- insert' $ object ["c" .= Number 24.986, "foo" .= object ["deep1" .= Bool True]]
+    objEmptyK <- insert' $ object ["" .= Number 9001]
+    objFullK  <- insert' $ object ["a" .= Number 1, "b" .= Number 2
+                                  ,"c" .= Number 3, "d" .= Number 4
+                                  ]
+    return TestKeys{..}
 
-          objNullK <- insert' $ Object mempty
-          objTestK <- insert' $ object ["test" .= Null, "test1" .= String "no"]
-          objDeepK <- insert' $ object ["c" .= Number 24.986, "foo" .= object ["deep1" .= Bool True]]
-          let objects = [ objNullK, objTestK, objDeepK ]
-          return GlobalKeys{..}
-
-
-data EdgeCaseKeys record =
-  EdgeCaseKeys { arrList3K  :: Key record
-               , arrList4K  :: Key record
-               , objEmptyK  :: Key record
-               , objFullK   :: Key record }
-
-data GlobalKeys record =
-  GlobalKeys { nulls   :: [Key record]
-             , bools   :: [Key record]
-             , numbers :: [Key record]
-             , strings :: [Key record]
-             , lists   :: [Key record]
-             , objects :: [Key record] }
+data TestKeys =
+  TestKeys { nullK :: Key TestValue
+             , boolTK :: Key TestValue
+             , boolFK :: Key TestValue
+             , num0K :: Key TestValue
+             , num1K :: Key TestValue
+             , numBigK :: Key TestValue
+             , numFloatK :: Key TestValue
+             , numSmallK :: Key TestValue
+             , numFloat2K :: Key TestValue
+             , numBigFloatK :: Key TestValue
+             , strNullK :: Key TestValue
+             , strObjK :: Key TestValue
+             , strArrK :: Key TestValue
+             , strAK :: Key TestValue
+             , strTestK :: Key TestValue
+             , str2K :: Key TestValue
+             , strFloatK :: Key TestValue
+             , arrNullK :: Key TestValue
+             , arrListK :: Key TestValue
+             , arrList2K :: Key TestValue
+             , arrFilledK :: Key TestValue
+             , objNullK :: Key TestValue
+             , objTestK :: Key TestValue
+             , objDeepK :: Key TestValue
+             , arrList3K  :: Key TestValue
+             , arrList4K  :: Key TestValue
+             , objEmptyK  :: Key TestValue
+             , objFullK   :: Key TestValue
+             } deriving (Eq, Ord, Show)
 
 specs :: Spec
-specs =
-    describe "Testing JSON operators"
-    $ beforeAll setup
-    $ afterAll_ teardown $ do
-
-      -- Setup DB and get ahold of keys
-      GlobalKeys {..} <- runIO $ runConn_ $ globalKeys
-      let [ nullK ] = nulls
-      let [ boolTK, boolFK ] = bools
-      let [ num0K, num1K, numBigK, numFloatK, numSmallK, numFloat2K, numBigFloatK ] = numbers
-      let [ strNullK, strObjK, strArrK, strAK, strTestK, str2K, strFloatK ] = strings
-      let [ arrNullK, arrListK, arrList2K, arrFilledK ] = lists
-      let [ objNullK, objTestK, objDeepK ] = objects
-
+specs = afterAll_ teardown $ do
+  beforeAll setup $ do
+    describe "Testing JSON operators" $ do
       describe "@>. object queries" $ do
-        it "matches an empty Object with any object" $ db $ do
+        it "matches an empty Object with any object" $
+          \TestKeys {..} -> db $ do
             vals <- selectList [TestValueJson @>. Object mempty] []
-            objects `matchKeys`  vals
+            [objNullK, objTestK, objDeepK, objEmptyK, objFullK] `matchKeys`  vals
 
-        it "matches a subset of object properties" $ db $ do
+        it "matches a subset of object properties" $
             -- {test: null, test1: no} @>. {test: null} == True
+          \TestKeys {..} -> db $ do
             vals <- selectList [TestValueJson @>. object ["test" .= Null]] []
             [objTestK] `matchKeys`  vals
 
-        it "matches a nested object against an empty object at the same key" $ db $ do
+        it "matches a nested object against an empty object at the same key" $
             -- {c: 24.986, foo: {deep1: true}} @>. {foo: {}} == True
+          \TestKeys {..} -> db $ do
             vals <- selectList [TestValueJson @>. object ["foo" .= object []]] []
             [objDeepK] `matchKeys`  vals
 
-        it "doesn't match a nested object against a string at the same key" $ db $ do
+        it "doesn't match a nested object against a string at the same key" $
             -- {c: 24.986, foo: {deep1: true}} @>. {foo: nope} == False
+          \TestKeys {..} -> db $ do
             vals <- selectList [TestValueJson @>. object ["foo" .= String "nope"]] []
             [] `matchKeys`  vals
 
-        it "matches a nested object when the query object is identical" $ db $ do
+        it "matches a nested object when the query object is identical" $
             -- {c: 24.986, foo: {deep1: true}} @>. {foo: {deep1: true}} == True
+          \TestKeys {..} -> db $ do
             vals <- selectList [TestValueJson @>. (object ["foo" .= object ["deep1" .= True]])] []
             [objDeepK] `matchKeys`  vals
 
-        it "doesn't match a nested object when queried with that exact object" $ db $ do
+        it "doesn't match a nested object when queried with that exact object" $
             -- {c: 24.986, foo: {deep1: true}} @>. {deep1: true} == False
+          \TestKeys {..} -> db $ do
             vals <- selectList [TestValueJson @>. object ["deep1" .= True]] []
             [] `matchKeys`  vals
 
       describe "@>. array queries" $ do
-        it "matches an empty Array with any list" $ db $ do
+        it "matches an empty Array with any list" $
+          \TestKeys {..} -> db $ do
             vals <- selectList [TestValueJson @>. emptyArr] []
-            lists `matchKeys`  vals
+            [arrNullK, arrListK, arrList2K, arrFilledK, arrList3K, arrList4K] `matchKeys`  vals
 
-        it "matches list when queried with subset (1 item)" $ db $ do
+        it "matches list when queried with subset (1 item)" $
             -- [null, 4, 'b', {}, [], {test: [null], test2: 'yes'}] @>. [4] == True
+          \TestKeys {..} -> db $ do
             vals <- selectList [TestValueJson @>. toJSON [4 :: Int]] []
             [arrFilledK] `matchKeys` vals
 
-        it "matches list when queried with subset (2 items)" $ db $ do
+        it "matches list when queried with subset (2 items)" $
             -- [null, 4, 'b', {}, [], {test: [null], test2: 'yes'}] @>. [null,'b'] == True
+          \TestKeys {..} -> db $ do
             vals <- selectList [TestValueJson @>. toJSON [Null, String "b"]] []
             [arrFilledK] `matchKeys` vals
 
-        it "doesn't match list when queried with intersecting list (1 match, 1 diff)" $ db $ do
+        it "doesn't match list when queried with intersecting list (1 match, 1 diff)" $
             -- [null, 4, 'b', {}, [], {test: [null], test2: 'yes'}] @>. [null,'d'] == False
+          \TestKeys {..} -> db $ do
             vals <- selectList [TestValueJson @>. toJSON [emptyArr, String "d"]] []
             [] `matchKeys` vals
 
-        it "matches list when queried with same list in different order" $ db $ do
+        it "matches list when queried with same list in different order" $
             -- [null, 4, 'b', {}, [], {test: [null], test2: 'yes'}] @>.
             -- [[],'b',{test: [null],test2: 'yes'},4,null,{}] == True
+          \TestKeys {..} -> db $ do
             let queryList =
                   toJSON [ emptyArr, String "b"
                          , object [ "test" .= [Null], "test2" .= String "yes"]
@@ -222,9 +230,10 @@ specs =
             vals <- selectList [TestValueJson @>. queryList ] []
             [arrFilledK] `matchKeys` vals
 
-        it "doesn't match list when queried with same list + 1 item" $ db $ do
+        it "doesn't match list when queried with same list + 1 item" $
             -- [null,4,'b',{},[],{test:[null],test2:'yes'}] @>.
             -- [null,4,'b',{},[],{test:[null],test2: 'yes'}, false] == False
+          \TestKeys {..} -> db $ do
             let testList =
                   toJSON [ Null, Number 4, String "b", Object mempty, emptyArr
                          , object [ "test" .= [Null], "test2" .= String "yes"]
@@ -233,463 +242,438 @@ specs =
             vals <- selectList [TestValueJson @>. testList]  []
             [] `matchKeys` vals
 
-        it "matches list when it shares an empty object with the query list" $ db $ do
+        it "matches list when it shares an empty object with the query list" $
             -- [null,4,'b',{},[],{test: [null],test2: 'yes'}] @>. [{}] == True
+          \TestKeys {..} -> db $ do
             vals <- selectList [TestValueJson @>. toJSON [Object mempty]] []
             [arrFilledK] `matchKeys` vals
 
-        it "matches list with nested list, when queried with an empty nested list" $ db $ do
+        it "matches list with nested list, when queried with an empty nested list" $
             -- [null,4,'b',{},[],{test:[null],test2:'yes'}] @>. [{test:[]}] == True
+          \TestKeys {..} -> db $ do
             vals <- selectList [TestValueJson @>. toJSON [object ["test" .= emptyArr]]] []
             [arrFilledK] `matchKeys` vals
 
-        it "doesn't match list with nested list, when queried with a diff. nested list" $ db $ do
-          -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @>.
-          -- [{"test1":[null]}]  == False
-          vals <- selectList [TestValueJson @>. toJSON [object ["test1" .= [Null]]]] []
-          [] `matchKeys` vals
+        it "doesn't match list with nested list, when queried with a diff. nested list" $
+            -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @>.
+            -- [{"test1":[null]}]  == False
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson @>. toJSON [object ["test1" .= [Null]]]] []
+            [] `matchKeys` vals
 
-        it "matches many nested lists when queried with empty nested list" $ db $ do
-          ---- [[],[],[[],[]]]                                  @>. [[]] == True
-          ---- [[],[3,false],[[],[{}]]]                         @>. [[]] == True
-          ---- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @>. [[]] == True
-          vals <- selectList [TestValueJson @>. toJSON [emptyArr]] []
-          [arrListK,arrList2K,arrFilledK] `matchKeys` vals
+        it "matches many nested lists when queried with empty nested list" $
+            -- [[],[],[[],[]]]                                  @>. [[]] == True
+            -- [[],[3,false],[[],[{}]]]                         @>. [[]] == True
+            -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @>. [[]] == True
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson @>. toJSON [emptyArr]] []
+            [arrListK,arrList2K,arrFilledK, arrList3K] `matchKeys` vals
 
-        it "matches nested list when queried with a subset of that list" $ db $ do
-          ---- [[],[3,false],[[],[{}]]] @>. [[3]] == True
-          vals <- selectList [TestValueJson @>. toJSON [[3 :: Int]]] []
-          [arrList2K] `matchKeys` vals
+        it "matches nested list when queried with a subset of that list" $
+            -- [[],[3,false],[[],[{}]]] @>. [[3]] == True
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson @>. toJSON [[3 :: Int]]] []
+            [arrList2K] `matchKeys` vals
 
-        it "doesn't match nested list againts a partial intersection of that list" $ db $ do
-          ---- [[],[3,false],[[],[{}]]] @>. [[true,3]] == False
-          vals <- selectList [TestValueJson @>. toJSON [[Bool True, Number 3]]] []
-          [] `matchKeys` vals
+        it "doesn't match nested list againts a partial intersection of that list" $
+            -- [[],[3,false],[[],[{}]]] @>. [[true,3]] == False
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson @>. toJSON [[Bool True, Number 3]]] []
+            [] `matchKeys` vals
 
-        it "matches list when queried with raw number contained in the list" $ db $ do
-          ---- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @>. 4 == True
-          vals <- selectList [TestValueJson @>. Number 4] []
-          [arrFilledK] `matchKeys` vals
+        it "matches list when queried with raw number contained in the list" $
+            -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @>. 4 == True
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson @>. Number 4] []
+            [arrFilledK] `matchKeys` vals
 
-        it "doesn't match list when queried with raw value not contained in the list" $ db $ do
-          ---- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @>. 99 == False
+        it "doesn't match list when queried with raw value not contained in the list" $
+            -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @>. 99 == False
+          \TestKeys {..} -> db $ do
           vals <- selectList [TestValueJson @>. Number 99] []
           [] `matchKeys` vals
 
-        it "matches list when queried with raw string contained in the list" $ db $ do
-          ---- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @>. "b" == True
-          vals <- selectList [TestValueJson @>. String "b"] []
-          [arrFilledK] `matchKeys` vals
+        it "matches list when queried with raw string contained in the list" $
+            -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @>. "b" == True
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson @>. String "b"] []
+            [arrFilledK, arrList4K] `matchKeys` vals
 
-        it "doesn't match list with empty object when queried with \"{}\" " $ db $ do
-          -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @>. "{}" == False
-          vals <- selectList [TestValueJson @>. String "{}"] []
-          [strObjK] `matchKeys` vals
+        it "doesn't match list with empty object when queried with \"{}\" " $
+            -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @>. "{}" == False
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson @>. String "{}"] []
+            [strObjK] `matchKeys` vals
 
-        it "doesnt match list with nested object when queried with object (not in list)" $ db $ do
-          -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @>.
-          --{"test":[null],"test2":"yes"} == False
-          let queryObject = object [ "test" .= [Null], "test2" .= String "yes"]
-          vals <- selectList [TestValueJson @>. queryObject ] []
-          [] `matchKeys` vals
+        it "doesnt match list with nested object when queried with object (not in list)" $
+            -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @>.
+            -- {"test":[null],"test2":"yes"} == False
+          \TestKeys {..} -> db $ do
+            let queryObject = object [ "test" .= [Null], "test2" .= String "yes"]
+            vals <- selectList [TestValueJson @>. queryObject ] []
+            [] `matchKeys` vals
 
       describe "@>. string queries" $ do
-        it "matches identical strings" $ db $ do
-          -- "testing" @>. "testing" == True
-          vals <- selectList [TestValueJson @>. String "testing"] []
-          [strTestK] `matchKeys` vals
+        it "matches identical strings" $
+            -- "testing" @>. "testing" == True
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson @>. String "testing"] []
+            [strTestK] `matchKeys` vals
 
-        it "doesnt match case insensitive" $ db $ do
-          -- "testing" @>. "Testing" == False
-          vals <- selectList [TestValueJson @>. String "Testing"] []
-          [] `matchKeys` vals
+        it "doesnt match case insensitive" $
+            -- "testing" @>. "Testing" == False
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson @>. String "Testing"] []
+            [] `matchKeys` vals
 
-        it "doesn't match substrings" $ db $ do
-          -- "testing" @>. "test" == False
-          vals <- selectList [TestValueJson @>. String "test"] []
-          [] `matchKeys` vals
+        it "doesn't match substrings" $
+            -- "testing" @>. "test" == False
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson @>. String "test"] []
+            [] `matchKeys` vals
 
-        it "doesn't match strings with object keys" $ db $ do
-          -- "testing" @>. {"testing":1} == False
-          vals <- selectList [TestValueJson @>. object ["testing" .= Number 1]] []
-          [] `matchKeys` vals
+        it "doesn't match strings with object keys" $
+            -- "testing" @>. {"testing":1} == False
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson @>. object ["testing" .= Number 1]] []
+            [] `matchKeys` vals
 
       describe "@>. number queries" $ do
+        it "matches identical numbers" $
+            -- 1   @>. 1 == True
+            -- [1] @>. 1 == True
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson @>. toJSON (1 :: Int)] []
+            [num1K, arrList3K] `matchKeys` vals
 
-        it "matches identical numbers" $ db $ do
-          -- 1 @>. 1 == True
-          vals <- selectList [TestValueJson @>. toJSON (1 :: Int)] []
-          [num1K] `matchKeys` vals
+        it "matches numbers when queried with float" $
+            -- 0 @>. 0.0 == True
+            -- 0.0 @>. 0.0 == True
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson @>. toJSON (0.0 :: Double)] []
+            [num0K,numFloatK] `matchKeys` vals
 
-        it "matches numbers when queried with float" $ db $ do
-          -- 0 @>. 0.0 == True
-          -- 0.0 @>. 0.0 == True
-          vals <- selectList [TestValueJson @>. toJSON (0.0 :: Double)] []
-          [num0K,numFloatK] `matchKeys` vals
+        it "does not match numbers when queried with a substring of that number" $
+            -- 1234567890 @>. 123456789 == False
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson @>. toJSON (123456789 :: Int)] []
+            [] `matchKeys` vals
 
-        it "does not match numbers when queried with a substring of that number" $ db $ do
-          -- 1234567890 @>. 123456789 == False
-          vals <- selectList [TestValueJson @>. toJSON (123456789 :: Int)] []
-          [] `matchKeys` vals
+        it "does not match number when queried with different number" $
+            -- 1234567890 @>. 234567890 == False
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson @>. toJSON (234567890 :: Int)] []
+            [] `matchKeys` vals
 
-        it "does not match number when queried with different number" $ db $ do
-          -- 1234567890 @>. 234567890 == False
-          vals <- selectList [TestValueJson @>. toJSON (234567890 :: Int)] []
-          [] `matchKeys` vals
+        it "does not match number when queried with string of that number" $
+            -- 1 @>. "1" == False
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson @>. String "1"] []
+            [] `matchKeys` vals
 
-        it "does not match number when queried with string of that number" $ db $ do
-          -- 1 @>. "1" == False
-          vals <- selectList [TestValueJson @>. String "1"] []
-          [] `matchKeys` vals
-
-        it "does not match number when queried with list of digits" $ db $ do
-          -- 1234567890 @>. [1,2,3,4,5,6,7,8,9,0] == False
-          vals <- selectList [TestValueJson @>. toJSON ([1,2,3,4,5,6,7,8,9,0] :: [Int])] []
-          [] `matchKeys` vals
+        it "does not match number when queried with list of digits" $
+            -- 1234567890 @>. [1,2,3,4,5,6,7,8,9,0] == False
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson @>. toJSON ([1,2,3,4,5,6,7,8,9,0] :: [Int])] []
+            [] `matchKeys` vals
 
       describe "@>. boolean queries" $ do
+        it "matches identical booleans (True)" $
+            -- true @>. true == True
+            -- false @>. true == False
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson @>. toJSON True] []
+            [boolTK] `matchKeys` vals
 
-        it "matches identical booleans (True)" $ db $ do
-          -- true @>. true == True
-          -- false @>. true == False
-          vals <- selectList [TestValueJson @>. toJSON True] []
-          [boolTK] `matchKeys` vals
+        it "matches identical booleans (False)" $
+            -- false @>. false == True
+            -- true @>. false == False
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson @>. Bool False] []
+            [boolFK] `matchKeys` vals
 
-        it "matches identical booleans (False)" $ db $ do
-          -- false @>. false == True
-          -- true @>. false == False
-          vals <- selectList [TestValueJson @>. Bool False] []
-          [boolFK] `matchKeys` vals
-
-        it "does not match boolean with string of boolean" $ db $ do
-          -- true @>. "true" == False
-          vals <- selectList [TestValueJson @>. String "true"] []
-          [] `matchKeys` vals
+        it "does not match boolean with string of boolean" $
+            -- true @>. "true" == False
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson @>. String "true"] []
+            [] `matchKeys` vals
 
       describe "@>. null queries" $ do
+        it "matches nulls" $
+            -- null @>. null == True
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson @>. Null] []
+            [nullK,arrFilledK] `matchKeys` vals
 
-        it "matches nulls" $ db $ do
-          -- null @>. null == True
-          vals <- selectList [TestValueJson @>. Null] []
-          [nullK,arrFilledK] `matchKeys` vals
-
-        it "does not match null with string of null" $ db $ do
-          -- null @>. "null" == False
-          vals <- selectList [TestValueJson @>. String "null"] []
-          [] `matchKeys` vals
+        it "does not match null with string of null" $
+            -- null @>. "null" == False
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson @>. String "null"] []
+            [] `matchKeys` vals
 
 
       describe "<@. queries" $ do
+        it "matches subobject when queried with superobject" $
+            -- {}                         <@. {"test":null,"test1":"no","blabla":[]} == True
+            -- {"test":null,"test1":"no"} <@. {"test":null,"test1":"no","blabla":[]} == True
+          \TestKeys {..} -> db $ do
+            let queryObject = object ["test" .= Null
+                                     , "test1" .= String "no"
+                                     , "blabla" .= emptyArr
+                                     ]
+            vals <- selectList [TestValueJson <@. queryObject] []
+            [objNullK,objTestK] `matchKeys` vals
 
-        it "matches subobject when queried with superobject" $ db $ do
-          -- {}                         <@. {"test":null,"test1":"no","blabla":[]} == True
-          -- {"test":null,"test1":"no"} <@. {"test":null,"test1":"no","blabla":[]} == True
-          let queryObject = object ["test" .= Null, "test1" .= String "no", "blabla" .= emptyArr]
-          vals <- selectList [TestValueJson <@. queryObject] []
-          [objNullK,objTestK] `matchKeys` vals
+        it "matches raw values and sublists when queried with superlist" $
+            -- []    <@. [null,4,"b",{},[],{"test":[null],"test2":"yes"},false] == True
+            -- null  <@. [null,4,"b",{},[],{"test":[null],"test2":"yes"},false] == True
+            -- false <@. [null,4,"b",{},[],{"test":[null],"test2":"yes"},false] == True
+            -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] <@.
+            -- [null,4,"b",{},[],{"test":[null],"test2":"yes"},false] == True
+          \TestKeys {..} -> db $ do
+            let queryList =
+                  toJSON [ Null, Number 4, String "b", Object mempty, emptyArr
+                         , object [ "test" .= [Null], "test2" .= String "yes"]
+                         , Bool False ]
 
-        it "matches raw values and sublists when queried with superlist" $ db $ do
-          -- []    <@. [null,4,"b",{},[],{"test":[null],"test2":"yes"},false] == True
-          -- null  <@. [null,4,"b",{},[],{"test":[null],"test2":"yes"},false] == True
-          -- false <@. [null,4,"b",{},[],{"test":[null],"test2":"yes"},false] == True
+            vals <- selectList [TestValueJson <@. queryList ] []
+            [arrNullK,arrFilledK,boolFK,nullK] `matchKeys` vals
 
-          -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] <@.
-          -- [null,4,"b",{},[],{"test":[null],"test2":"yes"},false] == True
+        it "matches identical strings" $
+            -- "a" <@. "a" == True
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson <@. String "a"] []
+            [strAK] `matchKeys` vals
 
-          let queryList =
-                toJSON [ Null, Number 4, String "b", Object mempty, emptyArr
-                       , object [ "test" .= [Null], "test2" .= String "yes"]
-                       , Bool False ]
+        it "matches identical big floats" $
+            -- 9876543210.123457 <@ 9876543210.123457 == True
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson <@. Number 9876543210.123457] []
+            [numBigFloatK] `matchKeys` vals
 
-          vals <- selectList [TestValueJson <@. queryList ] []
-          [arrNullK,arrFilledK,boolFK,nullK] `matchKeys` vals
+        it "doesn't match different big floats" $
+            -- 9876543210.123457 <@. 9876543210.123456789 == False
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson <@. Number 9876543210.123456789] []
+            [] `matchKeys` vals
 
-        it "matches identical strings" $ db $ do
-          -- "a" <@. "a" == True
-          vals <- selectList [TestValueJson <@. String "a"] []
-          [strAK] `matchKeys` vals
-
-
-        it "matches identical big floats" $ db $ do
-          -- 9876543210.123457 <@ 9876543210.123457 == True
-          vals <- selectList [TestValueJson <@. Number 9876543210.123457] []
-          [numBigFloatK] `matchKeys` vals
-
-        it "doesn't match different big floats" $ db $ do
-          -- 9876543210.123457 <@. 9876543210.123456789 == False
-          vals <- selectList [TestValueJson <@. Number 9876543210.123456789] []
-          [] `matchKeys` vals
-
-        it "matches nulls" $ db $ do
-          -- null <@. null == True
-          vals <- selectList [TestValueJson <@. Null] []
-          [nullK] `matchKeys` vals
+        it "matches nulls" $
+            -- null <@. null == True
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson <@. Null] []
+            [nullK] `matchKeys` vals
 
       describe "?. queries" $ do
+        it "matches top level keys and not the keys of nested objects" $
+            -- {"test":null,"test1":"no"}                       ?. "test" == True
+            -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] ?. "test" == False
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson ?. "test"] []
+            [objTestK] `matchKeys` vals
 
-        it "matches top level keys and not the keys of nested objects" $ db $ do
-          void $ edgeCases
+        it "doesn't match nested key" $
+            -- {"c":24.986,"foo":{"deep1":true"}} ?. "deep1" == False
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson ?. "deep1"] []
+            [] `matchKeys` vals
 
-          -- {"test":null,"test1":"no"}                       ?. "test" == True
-          -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] ?. "test" == False
+        it "matches \"{}\" but not empty object when queried with \"{}\"" $
+            -- "{}" ?. "{}" == True
+            -- {}   ?. "{}" == False
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson ?. "{}"] []
+            [strObjK] `matchKeys` vals
 
-          vals <- selectList [TestValueJson ?. "test"] []
-          [objTestK] `matchKeys` vals
+        it "matches raw empty str and empty str key when queried with \"\"" $
+            ---- {}        ?. "" == False
+            ---- ""        ?. "" == True
+            ---- {"":9001} ?. "" == True
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson ?. ""] []
+            [strNullK,objEmptyK] `matchKeys` vals
 
-        it "doesn't match nested key" $ db $ do
-          void $ edgeCases
+        it "matches lists containing string value when queried with raw string value" $
+            -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] ?. "b" == True
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson ?. "b"] []
+            [arrFilledK,arrList4K,objFullK] `matchKeys` vals
 
-          -- {"c":24.986,"foo":{"deep1":true"}} ?. "deep1" == False
+        it "matches lists, objects, and raw values correctly when queried with string" $
+            -- [["a"]]                   ?. "a" == False
+            -- "a"                       ?. "a" == True
+            -- ["a","b","c","d"]         ?. "a" == True
+            -- {"a":1,"b":2,"c":3,"d":4} ?. "a" == True
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson ?. "a"] []
+            [strAK,arrList4K,objFullK] `matchKeys` vals
 
-          vals <- selectList [TestValueJson ?. "deep1"] []
-          [] `matchKeys` vals
+        it "matches string list but not real list when queried with \"[]\"" $
+            -- "[]" ?. "[]" == True
+            -- []   ?. "[]" == False
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson ?. "[]"] []
+            [strArrK] `matchKeys` vals
 
-        it "matches \"{}\" but not empty object when queried with \"{}\"" $ db $ do
-          void $ edgeCases
+        it "does not match null when queried with string null" $
+            -- null ?. "null" == False
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson ?. "null"] []
+            [] `matchKeys` vals
 
-          -- "{}" ?. "{}" == True
-          -- {}   ?. "{}" == False
-
-          vals <- selectList [TestValueJson ?. "{}"] []
-          [strObjK] `matchKeys` vals
-
-        it "matches raw empty str and empty str key when queried with \"\"" $ db $ do
-          EdgeCaseKeys {..} <- edgeCases
-
-          ---- {}        ?. "" == False
-          ---- ""        ?. "" == True
-          ---- {"":9001} ?. "" == True
-
-          vals <- selectList [TestValueJson ?. ""] []
-          [strNullK,objEmptyK] `matchKeys` vals
-
-        it "matches lists containing string value when queried with raw string value" $ db $ do
-          EdgeCaseKeys {..} <- edgeCases
-
-          -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] ?. "b" == True
-          vals <- selectList [TestValueJson ?. "b"] []
-          [arrFilledK,arrList4K,objFullK] `matchKeys` vals
-
-        it "matches lists, objects, and raw values correctly when queried with string" $ db $ do
-          EdgeCaseKeys {..} <- edgeCases
-
-          -- [["a"]]                   ?. "a" == False
-          -- "a"                       ?. "a" == True
-          -- ["a","b","c","d"]         ?. "a" == True
-          -- {"a":1,"b":2,"c":3,"d":4} ?. "a" == True
-
-          vals <- selectList [TestValueJson ?. "a"] []
-          [strAK,arrList4K,objFullK] `matchKeys` vals
-
-        it "matches string list but not real list when queried with \"[]\"" $ db $ do
-          EdgeCaseKeys {..} <- edgeCases
-
-          -- "[]" ?. "[]" == True
-          -- []   ?. "[]" == False
-
-          vals <- selectList [TestValueJson ?. "[]"] []
-          [strArrK] `matchKeys` vals
-
-        it "does not match null when queried with string null" $ db $ do
-          void $ edgeCases
-
-          -- null ?. "null" == False
-
-          vals <- selectList [TestValueJson ?. "null"] []
-          [] `matchKeys` vals
-
-        it "does not match bool whe nqueried with string bool" $ db $ do
-          void $ edgeCases
-
-          -- true ?. "true" == False
-
-          vals <- selectList [TestValueJson ?. "true"] []
-          [] `matchKeys` vals
+        it "does not match bool whe nqueried with string bool" $
+            -- true ?. "true" == False
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson ?. "true"] []
+            [] `matchKeys` vals
 
 
       describe "?|. queries" $ do
+        it "matches raw vals, lists, objects, and nested objects" $
+            -- "a"                                              ?|. ["a","b","c"] == True
+            -- [["a"],1]                                        ?|. ["a","b","c"] == False
+            -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] ?|. ["a","b","c"] == True
+            -- ["a","b","c","d"]                                ?|. ["a","b","c"] == True
+            -- {"a":1,"b":2,"c":3,"d":4}                        ?|. ["a","b","c"] == True
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson ?|. ["a","b","c"]] []
+            [strAK,arrFilledK,objDeepK,arrList4K,objFullK] `matchKeys` vals
 
-        it "matches raw vals, lists, objects, and nested objects" $ db $ do
-          EdgeCaseKeys {..} <- edgeCases
+        it "matches str object but not object when queried with \"{}\"" $
+            -- "{}"  ?|. ["{}"] == True
+            -- {}    ?|. ["{}"] == False
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson ?|. ["{}"]] []
+            [strObjK] `matchKeys` vals
 
-          -- "a"                                              ?|. ["a","b","c"] == True
-          -- [["a"],1]                                        ?|. ["a","b","c"] == False
-          -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] ?|. ["a","b","c"] == True
-          -- ["a","b","c","d"]                                ?|. ["a","b","c"] == True
-          -- {"a":1,"b":2,"c":3,"d":4}                        ?|. ["a","b","c"] == True
+        it "doesn't match superstrings when queried with substring" $
+            -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] ?|. ["test"] == False
+            -- "testing"                                        ?|. ["test"] == False
+            -- {"test":null,"test1":"no"}                       ?|. ["test"] == True
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson ?|. ["test"]] []
+            [objTestK] `matchKeys` vals
 
-          vals <- selectList [TestValueJson ?|. ["a","b","c"]] []
-          [strAK,arrFilledK,objDeepK,arrList4K,objFullK] `matchKeys` vals
+        it "doesn't match nested keys" $
+            -- {"c":24.986,"foo":{"deep1":true"}} ?|. ["deep1"] == False
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson ?|. ["deep1"]] []
+            [] `matchKeys` vals
 
-        it "matches str object but not object when queried with \"{}\"" $ db $ do
-          void $ edgeCases
+        it "doesn't match anything when queried with empty list" $
+            -- ANYTHING ?|. [] == False
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson ?|. []] []
+            [] `matchKeys` vals
 
-          -- "{}"  ?|. ["{}"] == True
-          -- {}    ?|. ["{}"] == False
+        it "doesn't match raw, non-string, values when queried with strings" $
+            -- true ?|. ["true","null","1"] == False
+            -- null ?|. ["true","null","1"] == False
+            -- 1    ?|. ["true","null","1"] == False
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson ?|. ["true","null","1"]] []
+            [] `matchKeys` vals
 
-          vals <- selectList [TestValueJson ?|. ["{}"]] []
-          [strObjK] `matchKeys` vals
-
-        it "doesn't match superstrings when queried with substring" $ db $ do
-          void $ edgeCases
-
-          -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] ?|. ["test"] == False
-          -- "testing"                                        ?|. ["test"] == False
-          -- {"test":null,"test1":"no"}                       ?|. ["test"] == True
-          --
-          vals <- selectList [TestValueJson ?|. ["test"]] []
-          [objTestK] `matchKeys` vals
-
-        it "doesn't match nested keys" $ db $ do
-          void $ edgeCases
-          -- {"c":24.986,"foo":{"deep1":true"}} ?|. ["deep1"] == False
-
-          vals <- selectList [TestValueJson ?|. ["deep1"]] []
-          [] `matchKeys` vals
-
-        it "doesn't match anything when queried with empty list" $ db $ do
-          void $ edgeCases
-
-          -- ANYTHING ?|. [] == False
-          vals <- selectList [TestValueJson ?|. []] []
-          [] `matchKeys` vals
-
-        it "doesn't match raw, non-string, values when queried with strings" $ db $ do
-          void $ edgeCases
-
-          -- true ?|. ["true","null","1"] == False
-          -- null ?|. ["true","null","1"] == False
-          -- 1    ?|. ["true","null","1"] == False
-
-          vals <- selectList [TestValueJson ?|. ["true","null","1"]] []
-          [] `matchKeys` vals
-
-        it "matches string array when queried with \"[]\"" $ db $ do
-          void $ edgeCases
-
-          -- []   ?|. ["[]"] == False
-          -- "[]" ?|. ["[]"] == True
-
-          vals <- selectList [TestValueJson ?|. ["[]"]] []
-          [strArrK] `matchKeys` vals
+        it "matches string array when queried with \"[]\"" $
+            -- []   ?|. ["[]"] == False
+            -- "[]" ?|. ["[]"] == True
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson ?|. ["[]"]] []
+            [strArrK] `matchKeys` vals
 
       describe "?&. queries" $ do
+        it "matches anything when queried with an empty list" $
+            -- ANYTHING ?&. [] == True
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson ?&. []] []
+            flip matchKeys vals [ nullK
+                                , boolTK, boolFK
+                                , num0K, num1K, numBigK, numFloatK
+                                , numSmallK, numFloat2K, numBigFloatK
+                                , strNullK, strObjK, strArrK, strAK
+                                , strTestK, str2K, strFloatK
+                                , arrNullK, arrListK, arrList2K
+                                , arrFilledK, arrList3K, arrList4K
+                                , objNullK, objTestK, objDeepK
+                                , objEmptyK, objFullK
+                                ]
 
-        it "matches anything when queried with an empty list" $ db $ do
-          EdgeCaseKeys {..} <- edgeCases
+        it "matches raw values, lists, and objects when queried with string" $
+            -- "a"                       ?&. ["a"] == True
+            -- [["a"],1]                 ?&. ["a"] == False
+            -- ["a","b","c","d"]         ?&. ["a"] == True
+            -- {"a":1,"b":2,"c":3,"d":4} ?&. ["a"] == True
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson ?&. ["a"]] []
+            [strAK,arrList4K,objFullK] `matchKeys` vals
 
-          -- ANYTHING ?&. [] == True
-          vals <- selectList [TestValueJson ?&. []] []
-          flip matchKeys vals [ nullK
+        it "matches raw values, lists, and objects when queried with multiple string" $
+            -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] ?&. ["b","c"] == False
+            -- {"c":24.986,"foo":{"deep1":true"}}               ?&. ["b","c"] == False
+            -- ["a","b","c","d"]                                ?&. ["b","c"] == True
+            -- {"a":1,"b":2,"c":3,"d":4}                        ?&. ["b","c"] == True
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson ?&. ["b","c"]] []
+            [arrList4K,objFullK] `matchKeys` vals
 
-                              , boolTK, boolFK
+        it "matches object string when queried with \"{}\"" $
+            -- {}   ?&. ["{}"] == False
+            -- "{}" ?&. ["{}"] == True
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson ?&. ["{}"]] []
+            [strObjK] `matchKeys` vals
 
-                              , num0K, num1K, numBigK, numFloatK
-                              , numSmallK, numFloat2K, numBigFloatK
+        it "doesn't match superstrings when queried with substring" $
+            -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] ?&. ["test"] == False
+            -- "testing"                                        ?&. ["test"] == False
+            -- {"test":null,"test1":"no"}                       ?&. ["test"] == True
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson ?&. ["test"]] []
+            [objTestK] `matchKeys` vals
 
-                              , strNullK, strObjK, strArrK, strAK
-                              , strTestK, str2K, strFloatK
+        it "doesn't match nested keys" $
+            -- {"c":24.986,"foo":{"deep1":true"}} ?&. ["deep1"] == False
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson ?&. ["deep1"]] []
+            [] `matchKeys` vals
 
-                              , arrNullK, arrListK, arrList2K
-                              , arrFilledK, arrList3K, arrList4K
+        it "doesn't match anything when there is a partial match" $
+            -- "a"                       ?&. ["a","e"] == False
+            -- ["a","b","c","d"]         ?&. ["a","e"] == False
+            -- {"a":1,"b":2,"c":3,"d":4} ?&. ["a","e"] == False
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson ?&. ["a","e"]] []
+            [] `matchKeys` vals
 
-                              , objNullK, objTestK, objDeepK
-                              , objEmptyK, objFullK
-                              ]
+        it "matches string array when queried with \"[]\"" $
+            -- []   ?&. ["[]"] == False
+            -- "[]" ?&. ["[]"] == True
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson ?&. ["[]"]] []
+            [strArrK] `matchKeys` vals
 
-        it "matches raw values, lists, and objects when queried with string" $ db $ do
-          EdgeCaseKeys {..} <- edgeCases
+        it "doesn't match null when queried with string null" $
+            -- THIS WILL FAIL IF THE IMPLEMENTATION USES
+            -- @ '{null}' @
+            -- INSTEAD OF
+            -- @ ARRAY['null'] @
+            -- null ?&. ["null"] == False
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson ?&. ["null"]] []
+            [] `matchKeys` vals
 
-          -- "a"                       ?&. ["a"] == True
-          -- [["a"],1]                 ?&. ["a"] == False
-          -- ["a","b","c","d"]         ?&. ["a"] == True
-          -- {"a":1,"b":2,"c":3,"d":4} ?&. ["a"] == True
-
-          vals <- selectList [TestValueJson ?&. ["a"]] []
-          [strAK,arrList4K,objFullK] `matchKeys` vals
-
-        it "matches raw values, lists, and objects when queried with multiple string" $ db $ do
-          EdgeCaseKeys {..} <- edgeCases
-
-          -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] ?&. ["b","c"] == False
-          -- {"c":24.986,"foo":{"deep1":true"}}               ?&. ["b","c"] == False
-          -- ["a","b","c","d"]                                ?&. ["b","c"] == True
-          -- {"a":1,"b":2,"c":3,"d":4}                        ?&. ["b","c"] == True
-
-          vals <- selectList [TestValueJson ?&. ["b","c"]] []
-          [arrList4K,objFullK] `matchKeys` vals
-
-        it "matches object string when queried with \"{}\"" $ db $ do
-          void $ edgeCases
-
-          -- {}   ?&. ["{}"] == False
-          -- "{}" ?&. ["{}"] == True
-
-          vals <- selectList [TestValueJson ?&. ["{}"]] []
-          [strObjK] `matchKeys` vals
-
-        it "doesn't match superstrings when queried with substring" $ db $ do
-          void $ edgeCases
-
-          -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] ?&. ["test"] == False
-          -- "testing"                                        ?&. ["test"] == False
-          -- {"test":null,"test1":"no"}                       ?&. ["test"] == True
-
-          vals <- selectList [TestValueJson ?&. ["test"]] []
-          [objTestK] `matchKeys` vals
-
-        it "doesn't match nested keys" $ db $ do
-          void $ edgeCases
-
-          -- {"c":24.986,"foo":{"deep1":true"}} ?&. ["deep1"] == False
-          vals <- selectList [TestValueJson ?&. ["deep1"]] []
-          [] `matchKeys` vals
-
-        it "doesn't match anything when there is a partial match" $ db $ do
-          void $ edgeCases
-
-          -- "a"                       ?&. ["a","e"] == False
-          -- ["a","b","c","d"]         ?&. ["a","e"] == False
-          -- {"a":1,"b":2,"c":3,"d":4} ?&. ["a","e"] == False
-          vals <- selectList [TestValueJson ?&. ["a","e"]] []
-          [] `matchKeys` vals
-
-        it "matches string array when queried with \"[]\"" $ db $ do
-          void $ edgeCases
-
-          -- []   ?&. ["[]"] == False
-          -- "[]" ?&. ["[]"] == True
-          vals <- selectList [TestValueJson ?&. ["[]"]] []
-          [strArrK] `matchKeys` vals
-
-        it "doesn't match null when queried with string null" $ db $ do
-          void $ edgeCases
-
-          -- THIS WILL FAIL IF THE IMPLEMENTATION USES
-          -- @ '{null}' @
-          -- INSTEAD OF
-          -- @ ARRAY['null'] @
-          -- null ?&. ["null"] == False
-          vals <- selectList [TestValueJson ?&. ["null"]] []
-          [] `matchKeys` vals
-
-        it "doesn't match number when queried with str of that number" $ db $ do
-          void $ edgeCases
+        it "doesn't match number when queried with str of that number" $
+            -- [["a"],1] ?&. ["1"] == False
+            -- "1"       ?&. ["1"] == True
+          \TestKeys {..} -> db $ do
           str1 <- insert' $ toJSON $ String "1"
-
-          -- [["a"],1] ?&. ["1"] == False
-          -- "1"       ?&. ["1"] == True
-
           vals <- selectList [TestValueJson ?&. ["1"]] []
           [str1] `matchKeys` vals
 
-        it "doesn't match empty objs or list when queried with empty string" $ db $ do
-          EdgeCaseKeys {..} <- edgeCases
-
-          -- {}        ?&. [""] == False
-          -- []        ?&. [""] == False
-          -- ""        ?&. [""] == True
-          -- {"":9001} ?&. [""] == True
-
-          vals <- selectList [TestValueJson ?&. [""]] []
-          [strNullK,objEmptyK] `matchKeys` vals
+        it "doesn't match empty objs or list when queried with empty string" $
+            -- {}        ?&. [""] == False
+            -- []        ?&. [""] == False
+            -- ""        ?&. [""] == True
+            -- {"":9001} ?&. [""] == True
+          \TestKeys {..} -> db $ do
+            vals <- selectList [TestValueJson ?&. [""]] []
+            [strNullK,objEmptyK] `matchKeys` vals

--- a/persistent-postgresql/test/JSONTest.hs
+++ b/persistent-postgresql/test/JSONTest.hs
@@ -294,47 +294,56 @@ specs =
           [] `matchKeys` vals
 
       describe "@>. number queries" $ do
-        return ()
-          ---- 1 @> 1 == True
-          --selectList [TestValueJson @>. toJSON (1 :: Int)] []
-          --  >>= matchKeys "28" [num1K]
 
-          ---- 0 @> 0.0 == True
-          ---- 0.0 @> 0.0 == True
-          --selectList [TestValueJson @>. toJSON (0.0 :: Double)] []
-          --  >>= matchKeys "29" [num0K,numFloatK]
+        it "matches identical numbers" $ db $ do
+          -- 1 @> 1 == True
+          vals <- selectList [TestValueJson @>. toJSON (1 :: Int)] []
+          [num1K] `matchKeys` vals
 
-          ---- 1234567890 @> 123456789 == False
-          --selectList [TestValueJson @>. toJSON (123456789 :: Int)] []
-          --  >>= matchKeys "30" []
+        it "matches numbers when queried with float" $ db $ do
+          -- 0 @> 0.0 == True
+          -- 0.0 @> 0.0 == True
+          vals <- selectList [TestValueJson @>. toJSON (0.0 :: Double)] []
+          [num0K,numFloatK] `matchKeys` vals
 
-          ---- 1234567890 @> 234567890 == False
-          --selectList [TestValueJson @>. toJSON (234567890 :: Int)] []
-          --  >>= matchKeys "31" []
+        it "does not match numbers when queried with a substring of that number" $ db $ do
+          -- 1234567890 @> 123456789 == False
+          vals <- selectList [TestValueJson @>. toJSON (123456789 :: Int)] []
+          [] `matchKeys` vals
 
-          ---- 1 @> "1" == False
-          --selectList [TestValueJson @>. String "1"] []
-          --  >>= matchKeys "32" []
+        it "does not match number when queried with different number" $ db $ do
+          -- 1234567890 @> 234567890 == False
+          vals <- selectList [TestValueJson @>. toJSON (234567890 :: Int)] []
+          [] `matchKeys` vals
 
-          ---- 1234567890 @> [1,2,3,4,5,6,7,8,9,0] == False
-          --selectList [TestValueJson @>. toJSON ([1,2,3,4,5,6,7,8,9,0] :: [Int])] []
-          --  >>= matchKeys "33" []
+        it "does not match number when queried with string of that number" $ db $ do
+          -- 1 @> "1" == False
+          vals <- selectList [TestValueJson @>. String "1"] []
+          [] `matchKeys` vals
+
+        it "does not match number when queried with list of digits" $ db $ do
+          -- 1234567890 @> [1,2,3,4,5,6,7,8,9,0] == False
+          vals <- selectList [TestValueJson @>. toJSON ([1,2,3,4,5,6,7,8,9,0] :: [Int])] []
+          [] `matchKeys` vals
 
       describe "@>. boolean queries" $ do
-        return ()
-          ---- true @> true == True
-          ---- false @> true == False
-          --selectList [TestValueJson @>. toJSON True] []
-          --  >>= matchKeys "34" [boolTK]
 
-          ---- false @> false == True
-          ---- true @> false == False
-          --selectList [TestValueJson @>. Bool False] []
-          --  >>= matchKeys "35" [boolFK]
+        it "matches identical booleans (True)" $ db $ do
+          -- true @> true == True
+          -- false @> true == False
+          vals <- selectList [TestValueJson @>. toJSON True] []
+          [boolTK] `matchKeys` vals
 
-          ---- true @> "true" == False
-          --selectList [TestValueJson @>. String "true"] []
-          --  >>= matchKeys "36" []
+        it "matches identical booleans (False)" $ db $ do
+          -- false @> false == True
+          -- true @> false == False
+          vals <- selectList [TestValueJson @>. Bool False] []
+          [boolFK] `matchKeys` vals
+
+        it "does not match boolean with string of boolean" $ db $ do
+          -- true @> "true" == False
+          vals <- selectList [TestValueJson @>. String "true"] []
+          [] `matchKeys` vals
 
       describe "@>. null queries" $ do
         return ()

--- a/persistent-postgresql/test/JSONTest.hs
+++ b/persistent-postgresql/test/JSONTest.hs
@@ -9,11 +9,13 @@
 {-# LANGUAGE UndecidableInstances #-} -- FIXME
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module JSONTest where
 
 import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.IO.Unlift (MonadUnliftIO)
 import Data.Aeson
 import qualified Data.Vector as V (fromList)
 import Test.HUnit (assertBool)
@@ -23,6 +25,7 @@ import Database.Persist
 import Database.Persist.Postgresql.JSON
 
 import PgInit
+
 
 share [mkPersist persistSettings,  mkMigrate "jsonTestMigrate"] [persistLowerCase|
   TestValue
@@ -40,431 +43,514 @@ insert' :: (MonadIO m, PersistStoreWrite backend, BaseBackend backend ~ SqlBacke
         => Value -> ReaderT backend m (Key TestValue)
 insert' = insert . TestValue
 
-(=@=) :: MonadIO m => String -> Bool -> m ()
-s =@= b = liftIO $ assertBool s b
 
 matchKeys :: (Show record, Show (Key record), MonadIO m, Eq (Key record))
-          => String -> [Key record] -> [Entity record] -> m ()
-matchKeys s ys xs = do
-    msg1 =@= (xLen == yLen)
-    forM_ ys $ \y -> msg2 y =@= (y `elem` ks)
+          => [Key record] -> [Entity record] -> m ()
+matchKeys ys xs = do
+    msg1 `assertBoolIO` (xLen == yLen)
+    forM_ ys $ \y -> msg2 y `assertBoolIO` (y `elem` ks)
   where ks = entityKey <$> xs
         xLen = length xs
         yLen = length ys
         msg1 = mconcat
-            [ s, "\nexpected: ", show yLen
+            [ "\nexpected: ", show yLen
             , "\n but got: ", show xLen
-            , "\n[xs: ", show xs
-            , ", ys: ", show ys, "]"
+            , "\n[xs: ", show xs, "]"
+            , "\n[ys: ", show ys, "]"
             ]
         msg2 y = mconcat
-            [ s, ": "
-            , "key \"", show y
+            [ "key \"", show y
             , "\" not in result:\n  ", show ks
             ]
 
-specs :: Spec
-specs = describe "postgresql's JSON operators behave" $ do
-
-  it "migrate, clean table, insert values and check queries" $ asIO $ runConn $ do
-      runMigrationSilent jsonTestMigrate
-      cleanDB
-
-      liftIO $ putStrLn "\n- - - - -  Inserting JSON values  - - - - -\n"
-
-      nullK <- insert' Null
-
-      boolTK <- insert' $ Bool True
-      boolFK <- insert' $ toJSON False
-
-      num0K <- insert' $ Number 0
-      num1K <- insert' $ Number 1
-      numBigK <- insert' $ toJSON (1234567890 :: Int)
-      numFloatK <- insert' $ Number 0.0
-      numSmallK <- insert' $ Number 0.0000000000000000123
-      numFloat2K <- insert' $ Number 1.5
-      -- numBigFloatK will turn into 9876543210.123457 because JSON
-      numBigFloatK <- insert' $ toJSON (9876543210.123456789 :: Double)
-
-      strNullK <- insert' $ String ""
-      strObjK <- insert' $ String "{}"
-      strArrK <- insert' $ String "[]"
-      strAK <- insert' $ String "a"
-      strTestK <- insert' $ toJSON ("testing" :: Text)
-      str2K <- insert' $ String "2"
-      strFloatK <- insert' $ String "0.45876"
-
-      arrNullK <- insert' $ Array $ V.fromList []
-      arrListK <- insert' $ toJSON ([emptyArr,emptyArr,toJSON [emptyArr,emptyArr]])
-      arrList2K <- insert' $ toJSON [emptyArr,toJSON [Number 3,Bool False],toJSON [emptyArr,toJSON [Object mempty]]]
-      arrFilledK <- insert' $ toJSON [Null, Number 4, String "b", Object mempty, emptyArr, object [ "test" .= [Null], "test2" .= String "yes"]]
-
-      objNullK <- insert' $ Object mempty
-      objTestK <- insert' $ object ["test" .= Null, "test1" .= String "no"]
-      objDeepK <- insert' $ object ["c" .= Number 24.986, "foo" .= object ["deep1" .= Bool True]]
-
-----------------------------------------------------------------------------------------
-
-      liftIO $ putStrLn "\n- - - - -  Starting @> tests  - - - - -\n"
-
-      -- An empty Object matches any object
-      selectList [TestValueJson @>. Object mempty] []
-        >>= matchKeys "1" [objNullK,objTestK,objDeepK]
-
-      -- {"test":null,"test1":"no"} @> {"test":null} == True
-      selectList [TestValueJson @>. object ["test" .= Null]] []
-        >>= matchKeys "2" [objTestK]
-
-      -- {"c":24.986,"foo":{"deep1":true"}} @> {"foo":{}} == True
-      selectList [TestValueJson @>. object ["foo" .= object []]] []
-        >>= matchKeys "3" [objDeepK]
-
-      -- {"c":24.986,"foo":{"deep1":true"}} @> {"foo":"nope"} == False
-      selectList [TestValueJson @>. object ["foo" .= String "nope"]] []
-        >>= matchKeys "4" []
-
-      -- {"c":24.986,"foo":{"deep1":true"}} @> {"foo":{"deep1":true}} == True
-      selectList [TestValueJson @>. (object ["foo" .= object ["deep1" .= True]])] []
-        >>= matchKeys "5" [objDeepK]
-
-      -- {"c":24.986,"foo":{"deep1":true"}} @> {"deep1":true} == False
-      selectList [TestValueJson @>. object ["deep1" .= True]] []
-        >>= matchKeys "6" []
-
-      -- An empty Array matches any array
-      selectList [TestValueJson @>. emptyArr] []
-        >>= matchKeys "7" [arrNullK,arrListK,arrList2K,arrFilledK]
-
-      -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @> [4] == True
-      selectList [TestValueJson @>. toJSON [4 :: Int]] []
-        >>= matchKeys "8" [arrFilledK]
-
-      -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @> [null,"b"] == True
-      selectList [TestValueJson @>. toJSON [Null, String "b"]] []
-        >>= matchKeys "9" [arrFilledK]
-
-      -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @> [null,"d"] == False
-      selectList [TestValueJson @>. toJSON [emptyArr, String "d"]] []
-        >>= matchKeys "10" []
-
-      -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @> [[],"b",{"test":[null],"test2":"yes"},4,null,{}] == True
-      selectList [TestValueJson @>. toJSON [emptyArr, String "b", object [ "test" .= [Null], "test2" .= String "yes"], Number 4, Null, Object mempty]] []
-        >>= matchKeys "11" [arrFilledK]
-
-      -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @> [null,4,"b",{},[],{"test":[null],"test2":"yes"},false] == False
-      selectList [TestValueJson @>. toJSON [Null, Number 4, String "b", Object mempty, emptyArr, object [ "test" .= [Null], "test2" .= String "yes"], Bool False]] []
-        >>= matchKeys "12" []
-
-      -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @> [{}] == True
-      selectList [TestValueJson @>. toJSON [Object mempty]] []
-        >>= matchKeys "13" [arrFilledK]
-
-      -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @> [{"test":[]}] == True
-      selectList [TestValueJson @>. toJSON [object ["test" .= emptyArr]]] []
-        >>= matchKeys "14" [arrFilledK]
-
-      -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @> [{"test1":[null]}]  == False
-      selectList [TestValueJson @>. toJSON [object ["test1" .= [Null]]]] []
-        >>= matchKeys "15" []
-
-      -- [[],[],[[],[]]]                                  @> [[]] == True
-      -- [[],[3,false],[[],[{}]]]                         @> [[]] == True
-      -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @> [[]] == True
-      selectList [TestValueJson @>. toJSON [emptyArr]] []
-        >>= matchKeys "16" [arrListK,arrList2K,arrFilledK]
-
-      -- [[],[3,false],[[],[{}]]] @> [[3]] == True
-      selectList [TestValueJson @>. toJSON [[3 :: Int]]] []
-        >>= matchKeys "17" [arrList2K]
-
-      -- [[],[3,false],[[],[{}]]] @> [[true,3]] == False
-      selectList [TestValueJson @>. toJSON [[Bool True, Number 3]]] []
-        >>= matchKeys "18" []
-
-      -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @> 4 == True
-      selectList [TestValueJson @>. Number 4] []
-        >>= matchKeys "19" [arrFilledK]
-
-      -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @> 4 == True
-      selectList [TestValueJson @>. Number 99] []
-        >>= matchKeys "20" []
-
-      -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @> "b" == True
-      selectList [TestValueJson @>. String "b"] []
-        >>= matchKeys "21" [arrFilledK]
-
-      -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @> "{}" == False
-      selectList [TestValueJson @>. String "{}"] []
-        >>= matchKeys "22" [strObjK]
-
-      -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @> {"test":[null],"test2":"yes"} == False
-      selectList [TestValueJson @>. object [ "test" .= [Null], "test2" .= String "yes"]] []
-        >>= matchKeys "23" []
-
-      -- "testing" @> "testing" == True
-      selectList [TestValueJson @>. String "testing"] []
-        >>= matchKeys "24" [strTestK]
-
-      -- "testing" @> "Testing" == False
-      selectList [TestValueJson @>. String "Testing"] []
-        >>= matchKeys "25" []
-
-      -- "testing" @> "test" == False
-      selectList [TestValueJson @>. String "test"] []
-        >>= matchKeys "26" []
-
-      -- "testing" @> {"testing":1} == False
-      selectList [TestValueJson @>. object ["testing" .= Number 1]] []
-        >>= matchKeys "27" []
-
-      -- 1 @> 1 == True
-      selectList [TestValueJson @>. toJSON (1 :: Int)] []
-        >>= matchKeys "28" [num1K]
-
-      -- 0 @> 0.0 == True
-      -- 0.0 @> 0.0 == True
-      selectList [TestValueJson @>. toJSON (0.0 :: Double)] []
-        >>= matchKeys "29" [num0K,numFloatK]
-
-      -- 1234567890 @> 123456789 == False
-      selectList [TestValueJson @>. toJSON (123456789 :: Int)] []
-        >>= matchKeys "30" []
-
-      -- 1234567890 @> 234567890 == False
-      selectList [TestValueJson @>. toJSON (234567890 :: Int)] []
-        >>= matchKeys "31" []
-
-      -- 1 @> "1" == False
-      selectList [TestValueJson @>. String "1"] []
-        >>= matchKeys "32" []
-
-      -- 1234567890 @> [1,2,3,4,5,6,7,8,9,0] == False
-      selectList [TestValueJson @>. toJSON ([1,2,3,4,5,6,7,8,9,0] :: [Int])] []
-        >>= matchKeys "33" []
-
-      -- true @> true == True
-      -- false @> true == False
-      selectList [TestValueJson @>. toJSON True] []
-        >>= matchKeys "34" [boolTK]
-
-      -- false @> false == True
-      -- true @> false == False
-      selectList [TestValueJson @>. Bool False] []
-        >>= matchKeys "35" [boolFK]
-
-      -- true @> "true" == False
-      selectList [TestValueJson @>. String "true"] []
-        >>= matchKeys "36" []
-
-      -- null @> null == True
-      selectList [TestValueJson @>. Null] []
-        >>= matchKeys "37" [nullK,arrFilledK]
-
-      -- null @> "null" == False
-      selectList [TestValueJson @>. String "null"] []
-        >>= matchKeys "38" []
-
-----------------------------------------------------------------------------------------
-
-      liftIO $ putStrLn "\n- - - - -  Starting <@ tests  - - - - -\n"
-
-      -- {}                         <@ {"test":null,"test1":"no","blabla":[]} == True
-      -- {"test":null,"test1":"no"} <@ {"test":null,"test1":"no","blabla":[]} == True
-      selectList [TestValueJson <@. object ["test" .= Null, "test1" .= String "no", "blabla" .= emptyArr]] []
-        >>= matchKeys "39" [objNullK,objTestK]
-
-      -- []                                               <@ [null,4,"b",{},[],{"test":[null],"test2":"yes"},false] == True
-      -- null                                             <@ [null,4,"b",{},[],{"test":[null],"test2":"yes"},false] == True
-      -- false                                            <@ [null,4,"b",{},[],{"test":[null],"test2":"yes"},false] == True
-      -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] <@ [null,4,"b",{},[],{"test":[null],"test2":"yes"},false] == True
-      selectList [TestValueJson <@. toJSON [Null, Number 4, String "b", Object mempty, emptyArr, object [ "test" .= [Null], "test2" .= String "yes"], Bool False]] []
-        >>= matchKeys "40" [arrNullK,arrFilledK,boolFK,nullK]
-
-      -- "a" <@ "a" == True
-      selectList [TestValueJson <@. String "a"] []
-        >>= matchKeys "41" [strAK]
-
-
-      -- 9876543210.123457 <@ 9876543210.123457 == False
-      selectList [TestValueJson <@. Number 9876543210.123457] []
-        >>= matchKeys "42" [numBigFloatK]
-
-      -- 9876543210.123457 <@ 9876543210.123456789 == False
-      selectList [TestValueJson <@. Number 9876543210.123456789] []
-        >>= matchKeys "43" []
-
-      -- null <@ null == True
-      selectList [TestValueJson <@. Null] []
-        >>= matchKeys "44" [nullK]
-
-----------------------------------------------------------------------------------------
-
-      liftIO $ putStrLn "\n- - - - -  Starting ? tests  - - - - -\n"
-
-      arrList3K <- insert' $ toJSON [toJSON [String "a"], Number 1]
-      arrList4K <- insert' $ toJSON [String "a", String "b", String "c", String "d"]
-      objEmptyK <- insert' $ object ["" .= Number 9001]
-      objFullK  <- insert' $ object ["a" .= Number 1, "b" .= Number 2, "c" .= Number 3, "d" .= Number 4]
-
-      -- {"test":null,"test1":"no"}                       ? "test" == True
-      -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] ? "test" == False
-      selectList [TestValueJson ?. "test"] []
-        >>= matchKeys "45" [objTestK]
-
-      -- {"c":24.986,"foo":{"deep1":true"}} ? "deep1" == False
-      selectList [TestValueJson ?. "deep1"] []
-        >>= matchKeys "46" []
-
-      -- "{}" ? "{}" == True
-      -- {}   ? "{}" == False
-      selectList [TestValueJson ?. "{}"] []
-        >>= matchKeys "47" [strObjK]
-
-      -- {}        ? "" == False
-      -- ""        ? "" == True
-      -- {"":9001} ? "" == True
-      selectList [TestValueJson ?. ""] []
-        >>= matchKeys "48" [strNullK,objEmptyK]
-
-      -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] ? "b" == True
-      selectList [TestValueJson ?. "b"] []
-        >>= matchKeys "49" [arrFilledK,arrList4K,objFullK]
-
-      -- [["a"]]                   ? "a" == False
-      -- "a"                       ? "a" == True
-      -- ["a","b","c","d"]         ? "a" == True
-      -- {"a":1,"b":2,"c":3,"d":4} ? "a" == True
-      selectList [TestValueJson ?. "a"] []
-        >>= matchKeys "50" [strAK,arrList4K,objFullK]
-
-      -- "[]" ? "[]" == True
-      -- []   ? "[]" == False
-      selectList [TestValueJson ?. "[]"] []
-        >>= matchKeys "51" [strArrK]
-
-      -- null ? "null" == False
-      selectList [TestValueJson ?. "null"] []
-        >>= matchKeys "52" []
-
-      -- true ? "true" == False
-      selectList [TestValueJson ?. "true"] []
-        >>= matchKeys "53" []
-
-----------------------------------------------------------------------------------------
-
-      liftIO $ putStrLn "\n- - - - -  Starting ?| tests  - - - - -\n"
-
-      -- "a"                                              ?| ["a","b","c"] == True
-      -- [["a"],1]                                        ?| ["a","b","c"] == False
-      -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] ?| ["a","b","c"] == True
-      -- ["a","b","c","d"]                                ?| ["a","b","c"] == True
-      -- {"a":1,"b":2,"c":3,"d":4}                        ?| ["a","b","c"] == True
-      selectList [TestValueJson ?|. ["a","b","c"]] []
-        >>= matchKeys "54" [strAK,arrFilledK,objDeepK,arrList4K,objFullK]
-
-      -- "{}"  ?| ["{}"] == True
-      -- {}    ?| ["{}"] == False
-      selectList [TestValueJson ?|. ["{}"]] []
-        >>= matchKeys "55" [strObjK]
-
-      -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] ?| ["test"] == False
-      -- "testing"                                        ?| ["test"] == False
-      -- {"test":null,"test1":"no"}                       ?| ["test"] == True
-      selectList [TestValueJson ?|. ["test"]] []
-        >>= matchKeys "56" [objTestK]
-
-      -- {"c":24.986,"foo":{"deep1":true"}} ?| ["deep1"] == False
-      selectList [TestValueJson ?|. ["deep1"]] []
-        >>= matchKeys "57" []
-
-      -- ANYTHING ?| [] == False
-      selectList [TestValueJson ?|. []] []
-        >>= matchKeys "58" []
-
-      -- true ?| ["true","null","1"] == False
-      -- null ?| ["true","null","1"] == False
-      -- 1    ?| ["true","null","1"] == False
-      selectList [TestValueJson ?|. ["true","null","1"]] []
-        >>= matchKeys "59" []
-
-      -- []   ?| ["[]"] == False
-      -- "[]" ?| ["[]"] == True
-      selectList [TestValueJson ?|. ["[]"]] []
-        >>= matchKeys "60" [strArrK]
-
-----------------------------------------------------------------------------------------
-
-      liftIO $ putStrLn "\n- - - - -  Starting ?& tests  - - - - -\n"
-
-      -- ANYTHING ?& [] == True
-      selectList [TestValueJson ?&. []] []
-        >>= matchKeys "61" [ nullK
-                           , boolTK, boolFK
-                           , num0K, num1K, numBigK, numFloatK, numSmallK, numFloat2K, numBigFloatK
-                           , strNullK, strObjK, strArrK, strAK, strTestK, str2K, strFloatK
-                           , arrNullK, arrListK, arrList2K, arrFilledK
-                           , objNullK, objTestK, objDeepK
-
-                           , arrList3K, arrList4K
-                           , objEmptyK, objFullK
-                           ]
-
-      -- "a"                       ?& ["a"] == True
-      -- [["a"],1]                 ?& ["a"] == False
-      -- ["a","b","c","d"]         ?& ["a"] == True
-      -- {"a":1,"b":2,"c":3,"d":4} ?& ["a"] == True
-      selectList [TestValueJson ?&. ["a"]] []
-        >>= matchKeys "62" [strAK,arrList4K,objFullK]
-
-      -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] ?& ["b","c"] == False
-      -- {"c":24.986,"foo":{"deep1":true"}}               ?& ["b","c"] == False
-      -- ["a","b","c","d"]                                ?& ["b","c"] == True
-      -- {"a":1,"b":2,"c":3,"d":4}                        ?& ["b","c"] == True
-      selectList [TestValueJson ?&. ["b","c"]] []
-        >>= matchKeys "63" [arrList4K,objFullK]
-
-      -- {}   ?& ["{}"] == False
-      -- "{}" ?& ["{}"] == True
-      selectList [TestValueJson ?&. ["{}"]] []
-        >>= matchKeys "64" [strObjK]
-
-      -- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] ?& ["test"] == False
-      -- "testing"                                        ?& ["test"] == False
-      -- {"test":null,"test1":"no"}                       ?& ["test"] == True
-      selectList [TestValueJson ?&. ["test"]] []
-        >>= matchKeys "65" [objTestK]
-
-      -- {"c":24.986,"foo":{"deep1":true"}} ?& ["deep1"] == False
-      selectList [TestValueJson ?&. ["deep1"]] []
-        >>= matchKeys "66" []
-
-      -- "a"                       ?& ["a","e"] == False
-      -- ["a","b","c","d"]         ?& ["a","e"] == False
-      -- {"a":1,"b":2,"c":3,"d":4} ?& ["a","e"] == False
-      selectList [TestValueJson ?&. ["a","e"]] []
-        >>= matchKeys "67" []
-
-      -- []   ?& ["[]"] == False
-      -- "[]" ?& ["[]"] == True
-      selectList [TestValueJson ?&. ["[]"]] []
-        >>= matchKeys "68" [strArrK]
-
-      -- THIS WILL FAIL IF THE IMPLEMENTATION USES
-      -- @ '{null}' @
-      -- INSTEAD OF
-      -- @ ARRAY['null'] @
-      -- null ?& ["null"] == False
-      selectList [TestValueJson ?&. ["null"]] []
-        >>= matchKeys "69" []
-
-      -- [["a"],1] ?& ["1"] == False
-      -- "1"       ?& ["1"] == True
-      selectList [TestValueJson ?&. ["1"]] []
-        >>= matchKeys "70" []
-
-      -- {}        ?& [""] == False
-      -- []        ?& [""] == False
-      -- ""        ?& [""] == True
-      -- {"":9001} ?& [""] == True
-      selectList [TestValueJson ?&. [""]] []
-        >>= matchKeys "71" [strNullK,objEmptyK]
+migrateJSON :: IO ()
+migrateJSON = asIO $ runConn $ do
+    void $ runMigrationSilent jsonTestMigrate
+
+preHook :: IO ()
+preHook = asIO $ runConn $ do
+  return ()
+
+cleanUp :: IO ()
+cleanUp = asIO $ runConn $ do
+  cleanDB
+
+shouldBeIO :: (Show a, Eq a, MonadIO m) => a -> a -> m ()
+shouldBeIO x y = liftIO $ shouldBe x y
+
+assertBoolIO :: MonadIO m => String -> Bool -> m ()
+assertBoolIO s b = liftIO $ assertBool s b
+
+data TestDBKeys record =
+  TestDBKeys { nulls   :: [Key record]
+             , bools   :: [Key record]
+             , numbers :: [Key record]
+             , strings :: [Key record]
+             , arrays  :: [Key record]
+             , objects :: [Key record] }
+
+-- $> :t asIO
+
+specs :: (MonadUnliftIO m, MonadFail m, MonadIO m) => RunDb SqlBackend m -> Spec
+specs runDb =
+    describe "tests for @>. operator"
+    $ beforeAll migrateJSON
+    $ before preHook
+    $ afterAll_ cleanUp $ do
+
+      keys <- runIO $ runConn_ $ do
+          nullK <- insert' Null
+          let nulls = [nullK]
+
+          boolTK <- insert' $ Bool True
+          boolFK <- insert' $ toJSON False
+          let bools = [boolTK, boolFK]
+
+          num0K <- insert' $ Number 0
+          num1K <- insert' $ Number 1
+          numBigK <- insert' $ toJSON (1234567890 :: Int)
+          numFloatK <- insert' $ Number 0.0
+          numSmallK <- insert' $ Number 0.0000000000000000123
+          numFloat2K <- insert' $ Number 1.5
+          -- numBigFloatK will turn into 9876543210.123457 because JSON
+          numBigFloatK <- insert' $ toJSON (9876543210.123456789 :: Double)
+          let numbers = [ num0K, num1K, numBigK, numFloatK
+                        , numSmallK, numFloat2K, numBigFloatK ]
+
+          strNullK <- insert' $ String ""
+          strObjK <- insert' $ String "{}"
+          strArrK <- insert' $ String "[]"
+          strAK <- insert' $ String "a"
+          strTestK <- insert' $ toJSON ("testing" :: Text)
+          str2K <- insert' $ String "2"
+          strFloatK <- insert' $ String "0.45876"
+          let strings = [ strNullK, strObjK, strArrK, strAK
+                        , strTestK, str2K, strFloatK ]
+
+          arrNullK <- insert' $ Array $ V.fromList []
+          arrListK <- insert' $ toJSON ([emptyArr,emptyArr,toJSON [emptyArr,emptyArr]])
+          arrList2K <- insert' $ toJSON [emptyArr,toJSON [Number 3,Bool False],toJSON [emptyArr,toJSON [Object mempty]]]
+          arrFilledK <- insert' $ toJSON [Null, Number 4, String "b", Object mempty, emptyArr, object [ "test" .= [Null], "test2" .= String "yes"]]
+          let arrays = [ arrNullK, arrListK, arrList2K, arrFilledK ]
+
+          objNullK <- insert' $ Object mempty
+          objTestK <- insert' $ object ["test" .= Null, "test1" .= String "no"]
+          objDeepK <- insert' $ object ["c" .= Number 24.986, "foo" .= object ["deep1" .= Bool True]]
+          let objects = [ objNullK, objTestK, objDeepK ]
+          return TestDBKeys{..}
+
+      it "matches an empty Object with any object" $ runDb $ do
+          vals <- selectList [TestValueJson @>. Object mempty] []
+          matchKeys (objects keys) vals
+
+      it "{test: null, test1: no} @>. {test: null} == True" $ runDb $ do
+          cleanDB
+          objTestK <- insert' $ object ["test" .= Null, "test1" .= String "no"]
+
+          vals <- selectList [TestValueJson @>. object ["test" .= Null]] []
+          matchKeys [objTestK] vals
+
+      xit "migrate, clean table, insert values and check queries" $ asIO $ runConn $ do
+
+          -- void $ runMigrationSilent jsonTestMigrate
+          -- cleanDB
+
+          -- liftIO $ putStrLn "\n- - - - -  Inserting JSON values  - - - - -\n"
+
+          -- nullK <- insert' Null
+
+          -- boolTK <- insert' $ Bool True
+          -- boolFK <- insert' $ toJSON False
+
+          -- num0K <- insert' $ Number 0
+          -- num1K <- insert' $ Number 1
+          -- numBigK <- insert' $ toJSON (1234567890 :: Int)
+          -- numFloatK <- insert' $ Number 0.0
+          -- numSmallK <- insert' $ Number 0.0000000000000000123
+          -- numFloat2K <- insert' $ Number 1.5
+          -- -- numBigFloatK will turn into 9876543210.123457 because JSON
+          -- numBigFloatK <- insert' $ toJSON (9876543210.123456789 :: Double)
+
+          -- strNullK <- insert' $ String ""
+          -- strObjK <- insert' $ String "{}"
+          -- strArrK <- insert' $ String "[]"
+          -- strAK <- insert' $ String "a"
+          -- strTestK <- insert' $ toJSON ("testing" :: Text)
+          -- str2K <- insert' $ String "2"
+          -- strFloatK <- insert' $ String "0.45876"
+
+          -- arrNullK <- insert' $ Array $ V.fromList []
+          -- arrListK <- insert' $ toJSON ([emptyArr,emptyArr,toJSON [emptyArr,emptyArr]])
+          -- arrList2K <- insert' $ toJSON [emptyArr,toJSON [Number 3,Bool False],toJSON [emptyArr,toJSON [Object mempty]]]
+          -- arrFilledK <- insert' $ toJSON [Null, Number 4, String "b", Object mempty, emptyArr, object [ "test" .= [Null], "test2" .= String "yes"]]
+
+          -- objNullK <- insert' $ Object mempty
+          -- objTestK <- insert' $ object ["test" .= Null, "test1" .= String "no"]
+          -- objDeepK <- insert' $ object ["c" .= Number 24.986, "foo" .= object ["deep1" .= Bool True]]
+
+          return ()
+    ----------------------------------------------------------------------------------------
+
+          --liftIO $ putStrLn "\n- - - - -  Starting @> tests  - - - - -\n"
+
+          ---- An empty Object matches any object
+          --selectList [TestValueJson @>. Object mempty] []
+          --  >>= matchKeys "1" [objNullK,objTestK,objDeepK]
+
+          ---- {"test":null,"test1":"no"} @> {"test":null} == True
+          --selectList [TestValueJson @>. object ["test" .= Null]] []
+          --  >>= matchKeys "2" [objTestK]
+
+          ---- {"c":24.986,"foo":{"deep1":true"}} @> {"foo":{}} == True
+          --selectList [TestValueJson @>. object ["foo" .= object []]] []
+          --  >>= matchKeys "3" [objDeepK]
+
+          ---- {"c":24.986,"foo":{"deep1":true"}} @> {"foo":"nope"} == False
+          --selectList [TestValueJson @>. object ["foo" .= String "nope"]] []
+          --  >>= matchKeys "4" []
+
+          ---- {"c":24.986,"foo":{"deep1":true"}} @> {"foo":{"deep1":true}} == True
+          --selectList [TestValueJson @>. (object ["foo" .= object ["deep1" .= True]])] []
+          --  >>= matchKeys "5" [objDeepK]
+
+          ---- {"c":24.986,"foo":{"deep1":true"}} @> {"deep1":true} == False
+          --selectList [TestValueJson @>. object ["deep1" .= True]] []
+          --  >>= matchKeys "6" []
+
+          ---- An empty Array matches any array
+          --selectList [TestValueJson @>. emptyArr] []
+          --  >>= matchKeys "7" [arrNullK,arrListK,arrList2K,arrFilledK]
+
+          ---- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @> [4] == True
+          --selectList [TestValueJson @>. toJSON [4 :: Int]] []
+          --  >>= matchKeys "8" [arrFilledK]
+
+          ---- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @> [null,"b"] == True
+          --selectList [TestValueJson @>. toJSON [Null, String "b"]] []
+          --  >>= matchKeys "9" [arrFilledK]
+
+          ---- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @> [null,"d"] == False
+          --selectList [TestValueJson @>. toJSON [emptyArr, String "d"]] []
+          --  >>= matchKeys "10" []
+
+          ---- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @> [[],"b",{"test":[null],"test2":"yes"},4,null,{}] == True
+          --selectList [TestValueJson @>. toJSON [emptyArr, String "b", object [ "test" .= [Null], "test2" .= String "yes"], Number 4, Null, Object mempty]] []
+          --  >>= matchKeys "11" [arrFilledK]
+
+          ---- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @> [null,4,"b",{},[],{"test":[null],"test2":"yes"},false] == False
+          --selectList [TestValueJson @>. toJSON [Null, Number 4, String "b", Object mempty, emptyArr, object [ "test" .= [Null], "test2" .= String "yes"], Bool False]] []
+          --  >>= matchKeys "12" []
+
+          ---- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @> [{}] == True
+          --selectList [TestValueJson @>. toJSON [Object mempty]] []
+          --  >>= matchKeys "13" [arrFilledK]
+
+          ---- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @> [{"test":[]}] == True
+          --selectList [TestValueJson @>. toJSON [object ["test" .= emptyArr]]] []
+          --  >>= matchKeys "14" [arrFilledK]
+
+          ---- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @> [{"test1":[null]}]  == False
+          --selectList [TestValueJson @>. toJSON [object ["test1" .= [Null]]]] []
+          --  >>= matchKeys "15" []
+
+          ---- [[],[],[[],[]]]                                  @> [[]] == True
+          ---- [[],[3,false],[[],[{}]]]                         @> [[]] == True
+          ---- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @> [[]] == True
+          --selectList [TestValueJson @>. toJSON [emptyArr]] []
+          --  >>= matchKeys "16" [arrListK,arrList2K,arrFilledK]
+
+          ---- [[],[3,false],[[],[{}]]] @> [[3]] == True
+          --selectList [TestValueJson @>. toJSON [[3 :: Int]]] []
+          --  >>= matchKeys "17" [arrList2K]
+
+          ---- [[],[3,false],[[],[{}]]] @> [[true,3]] == False
+          --selectList [TestValueJson @>. toJSON [[Bool True, Number 3]]] []
+          --  >>= matchKeys "18" []
+
+          ---- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @> 4 == True
+          --selectList [TestValueJson @>. Number 4] []
+          --  >>= matchKeys "19" [arrFilledK]
+
+          ---- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @> 4 == True
+          --selectList [TestValueJson @>. Number 99] []
+          --  >>= matchKeys "20" []
+
+          ---- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @> "b" == True
+          --selectList [TestValueJson @>. String "b"] []
+          --  >>= matchKeys "21" [arrFilledK]
+
+          ---- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @> "{}" == False
+          --selectList [TestValueJson @>. String "{}"] []
+          --  >>= matchKeys "22" [strObjK]
+
+          ---- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] @> {"test":[null],"test2":"yes"} == False
+          --selectList [TestValueJson @>. object [ "test" .= [Null], "test2" .= String "yes"]] []
+          --  >>= matchKeys "23" []
+
+          ---- "testing" @> "testing" == True
+          --selectList [TestValueJson @>. String "testing"] []
+          --  >>= matchKeys "24" [strTestK]
+
+          ---- "testing" @> "Testing" == False
+          --selectList [TestValueJson @>. String "Testing"] []
+          --  >>= matchKeys "25" []
+
+          ---- "testing" @> "test" == False
+          --selectList [TestValueJson @>. String "test"] []
+          --  >>= matchKeys "26" []
+
+          ---- "testing" @> {"testing":1} == False
+          --selectList [TestValueJson @>. object ["testing" .= Number 1]] []
+          --  >>= matchKeys "27" []
+
+          ---- 1 @> 1 == True
+          --selectList [TestValueJson @>. toJSON (1 :: Int)] []
+          --  >>= matchKeys "28" [num1K]
+
+          ---- 0 @> 0.0 == True
+          ---- 0.0 @> 0.0 == True
+          --selectList [TestValueJson @>. toJSON (0.0 :: Double)] []
+          --  >>= matchKeys "29" [num0K,numFloatK]
+
+          ---- 1234567890 @> 123456789 == False
+          --selectList [TestValueJson @>. toJSON (123456789 :: Int)] []
+          --  >>= matchKeys "30" []
+
+          ---- 1234567890 @> 234567890 == False
+          --selectList [TestValueJson @>. toJSON (234567890 :: Int)] []
+          --  >>= matchKeys "31" []
+
+          ---- 1 @> "1" == False
+          --selectList [TestValueJson @>. String "1"] []
+          --  >>= matchKeys "32" []
+
+          ---- 1234567890 @> [1,2,3,4,5,6,7,8,9,0] == False
+          --selectList [TestValueJson @>. toJSON ([1,2,3,4,5,6,7,8,9,0] :: [Int])] []
+          --  >>= matchKeys "33" []
+
+          ---- true @> true == True
+          ---- false @> true == False
+          --selectList [TestValueJson @>. toJSON True] []
+          --  >>= matchKeys "34" [boolTK]
+
+          ---- false @> false == True
+          ---- true @> false == False
+          --selectList [TestValueJson @>. Bool False] []
+          --  >>= matchKeys "35" [boolFK]
+
+          ---- true @> "true" == False
+          --selectList [TestValueJson @>. String "true"] []
+          --  >>= matchKeys "36" []
+
+          ---- null @> null == True
+          --selectList [TestValueJson @>. Null] []
+          --  >>= matchKeys "37" [nullK,arrFilledK]
+
+          ---- null @> "null" == False
+          --selectList [TestValueJson @>. String "null"] []
+          --  >>= matchKeys "38" []
+
+    ------------------------------------------------------------------------------------------
+
+          --liftIO $ putStrLn "\n- - - - -  Starting <@ tests  - - - - -\n"
+
+          ---- {}                         <@ {"test":null,"test1":"no","blabla":[]} == True
+          ---- {"test":null,"test1":"no"} <@ {"test":null,"test1":"no","blabla":[]} == True
+          --selectList [TestValueJson <@. object ["test" .= Null, "test1" .= String "no", "blabla" .= emptyArr]] []
+          --  >>= matchKeys "39" [objNullK,objTestK]
+
+          ---- []                                               <@ [null,4,"b",{},[],{"test":[null],"test2":"yes"},false] == True
+          ---- null                                             <@ [null,4,"b",{},[],{"test":[null],"test2":"yes"},false] == True
+          ---- false                                            <@ [null,4,"b",{},[],{"test":[null],"test2":"yes"},false] == True
+          ---- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] <@ [null,4,"b",{},[],{"test":[null],"test2":"yes"},false] == True
+          --selectList [TestValueJson <@. toJSON [Null, Number 4, String "b", Object mempty, emptyArr, object [ "test" .= [Null], "test2" .= String "yes"], Bool False]] []
+          --  >>= matchKeys "40" [arrNullK,arrFilledK,boolFK,nullK]
+
+          ---- "a" <@ "a" == True
+          --selectList [TestValueJson <@. String "a"] []
+          --  >>= matchKeys "41" [strAK]
+
+
+          ---- 9876543210.123457 <@ 9876543210.123457 == False
+          --selectList [TestValueJson <@. Number 9876543210.123457] []
+          --  >>= matchKeys "42" [numBigFloatK]
+
+          ---- 9876543210.123457 <@ 9876543210.123456789 == False
+          --selectList [TestValueJson <@. Number 9876543210.123456789] []
+          --  >>= matchKeys "43" []
+
+          ---- null <@ null == True
+          --selectList [TestValueJson <@. Null] []
+          --  >>= matchKeys "44" [nullK]
+
+    ------------------------------------------------------------------------------------------
+
+          --liftIO $ putStrLn "\n- - - - -  Starting ? tests  - - - - -\n"
+
+          --arrList3K <- insert' $ toJSON [toJSON [String "a"], Number 1]
+          --arrList4K <- insert' $ toJSON [String "a", String "b", String "c", String "d"]
+          --objEmptyK <- insert' $ object ["" .= Number 9001]
+          --objFullK  <- insert' $ object ["a" .= Number 1, "b" .= Number 2, "c" .= Number 3, "d" .= Number 4]
+
+          ---- {"test":null,"test1":"no"}                       ? "test" == True
+          ---- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] ? "test" == False
+          --selectList [TestValueJson ?. "test"] []
+          --  >>= matchKeys "45" [objTestK]
+
+          ---- {"c":24.986,"foo":{"deep1":true"}} ? "deep1" == False
+          --selectList [TestValueJson ?. "deep1"] []
+          --  >>= matchKeys "46" []
+
+          ---- "{}" ? "{}" == True
+          ---- {}   ? "{}" == False
+          --selectList [TestValueJson ?. "{}"] []
+          --  >>= matchKeys "47" [strObjK]
+
+          ---- {}        ? "" == False
+          ---- ""        ? "" == True
+          ---- {"":9001} ? "" == True
+          --selectList [TestValueJson ?. ""] []
+          --  >>= matchKeys "48" [strNullK,objEmptyK]
+
+          ---- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] ? "b" == True
+          --selectList [TestValueJson ?. "b"] []
+          --  >>= matchKeys "49" [arrFilledK,arrList4K,objFullK]
+
+          ---- [["a"]]                   ? "a" == False
+          ---- "a"                       ? "a" == True
+          ---- ["a","b","c","d"]         ? "a" == True
+          ---- {"a":1,"b":2,"c":3,"d":4} ? "a" == True
+          --selectList [TestValueJson ?. "a"] []
+          --  >>= matchKeys "50" [strAK,arrList4K,objFullK]
+
+          ---- "[]" ? "[]" == True
+          ---- []   ? "[]" == False
+          --selectList [TestValueJson ?. "[]"] []
+          --  >>= matchKeys "51" [strArrK]
+
+          ---- null ? "null" == False
+          --selectList [TestValueJson ?. "null"] []
+          --  >>= matchKeys "52" []
+
+          ---- true ? "true" == False
+          --selectList [TestValueJson ?. "true"] []
+          --  >>= matchKeys "53" []
+
+    ------------------------------------------------------------------------------------------
+
+          --liftIO $ putStrLn "\n- - - - -  Starting ?| tests  - - - - -\n"
+
+          ---- "a"                                              ?| ["a","b","c"] == True
+          ---- [["a"],1]                                        ?| ["a","b","c"] == False
+          ---- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] ?| ["a","b","c"] == True
+          ---- ["a","b","c","d"]                                ?| ["a","b","c"] == True
+          ---- {"a":1,"b":2,"c":3,"d":4}                        ?| ["a","b","c"] == True
+          --selectList [TestValueJson ?|. ["a","b","c"]] []
+          --  >>= matchKeys "54" [strAK,arrFilledK,objDeepK,arrList4K,objFullK]
+
+          ---- "{}"  ?| ["{}"] == True
+          ---- {}    ?| ["{}"] == False
+          --selectList [TestValueJson ?|. ["{}"]] []
+          --  >>= matchKeys "55" [strObjK]
+
+          ---- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] ?| ["test"] == False
+          ---- "testing"                                        ?| ["test"] == False
+          ---- {"test":null,"test1":"no"}                       ?| ["test"] == True
+          --selectList [TestValueJson ?|. ["test"]] []
+          --  >>= matchKeys "56" [objTestK]
+
+          ---- {"c":24.986,"foo":{"deep1":true"}} ?| ["deep1"] == False
+          --selectList [TestValueJson ?|. ["deep1"]] []
+          --  >>= matchKeys "57" []
+
+          ---- ANYTHING ?| [] == False
+          --selectList [TestValueJson ?|. []] []
+          --  >>= matchKeys "58" []
+
+          ---- true ?| ["true","null","1"] == False
+          ---- null ?| ["true","null","1"] == False
+          ---- 1    ?| ["true","null","1"] == False
+          --selectList [TestValueJson ?|. ["true","null","1"]] []
+          --  >>= matchKeys "59" []
+
+          ---- []   ?| ["[]"] == False
+          ---- "[]" ?| ["[]"] == True
+          --selectList [TestValueJson ?|. ["[]"]] []
+          --  >>= matchKeys "60" [strArrK]
+
+    ------------------------------------------------------------------------------------------
+
+          --liftIO $ putStrLn "\n- - - - -  Starting ?& tests  - - - - -\n"
+
+          ---- ANYTHING ?& [] == True
+          --selectList [TestValueJson ?&. []] []
+          --  >>= matchKeys "61" [ nullK
+          --                     , boolTK, boolFK
+          --                     , num0K, num1K, numBigK, numFloatK, numSmallK, numFloat2K, numBigFloatK
+          --                     , strNullK, strObjK, strArrK, strAK, strTestK, str2K, strFloatK
+          --                     , arrNullK, arrListK, arrList2K, arrFilledK
+          --                     , objNullK, objTestK, objDeepK
+
+          --                     , arrList3K, arrList4K
+          --                     , objEmptyK, objFullK
+          --                     ]
+
+          ---- "a"                       ?& ["a"] == True
+          ---- [["a"],1]                 ?& ["a"] == False
+          ---- ["a","b","c","d"]         ?& ["a"] == True
+          ---- {"a":1,"b":2,"c":3,"d":4} ?& ["a"] == True
+          --selectList [TestValueJson ?&. ["a"]] []
+          --  >>= matchKeys "62" [strAK,arrList4K,objFullK]
+
+          ---- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] ?& ["b","c"] == False
+          ---- {"c":24.986,"foo":{"deep1":true"}}               ?& ["b","c"] == False
+          ---- ["a","b","c","d"]                                ?& ["b","c"] == True
+          ---- {"a":1,"b":2,"c":3,"d":4}                        ?& ["b","c"] == True
+          --selectList [TestValueJson ?&. ["b","c"]] []
+          --  >>= matchKeys "63" [arrList4K,objFullK]
+
+          ---- {}   ?& ["{}"] == False
+          ---- "{}" ?& ["{}"] == True
+          --selectList [TestValueJson ?&. ["{}"]] []
+          --  >>= matchKeys "64" [strObjK]
+
+          ---- [null,4,"b",{},[],{"test":[null],"test2":"yes"}] ?& ["test"] == False
+          ---- "testing"                                        ?& ["test"] == False
+          ---- {"test":null,"test1":"no"}                       ?& ["test"] == True
+          --selectList [TestValueJson ?&. ["test"]] []
+          --  >>= matchKeys "65" [objTestK]
+
+          ---- {"c":24.986,"foo":{"deep1":true"}} ?& ["deep1"] == False
+          --selectList [TestValueJson ?&. ["deep1"]] []
+          --  >>= matchKeys "66" []
+
+          ---- "a"                       ?& ["a","e"] == False
+          ---- ["a","b","c","d"]         ?& ["a","e"] == False
+          ---- {"a":1,"b":2,"c":3,"d":4} ?& ["a","e"] == False
+          --selectList [TestValueJson ?&. ["a","e"]] []
+          --  >>= matchKeys "67" []
+
+          ---- []   ?& ["[]"] == False
+          ---- "[]" ?& ["[]"] == True
+          --selectList [TestValueJson ?&. ["[]"]] []
+          --  >>= matchKeys "68" [strArrK]
+
+          ---- THIS WILL FAIL IF THE IMPLEMENTATION USES
+          ---- @ '{null}' @
+          ---- INSTEAD OF
+          ---- @ ARRAY['null'] @
+          ---- null ?& ["null"] == False
+          --selectList [TestValueJson ?&. ["null"]] []
+          --  >>= matchKeys "69" []
+
+          ---- [["a"],1] ?& ["1"] == False
+          ---- "1"       ?& ["1"] == True
+          --selectList [TestValueJson ?&. ["1"]] []
+          --  >>= matchKeys "70" []
+
+          ---- {}        ?& [""] == False
+          ---- []        ?& [""] == False
+          ---- ""        ?& [""] == True
+          ---- {"":9001} ?& [""] == True
+          --selectList [TestValueJson ?&. [""]] []
+          --  >>= matchKeys "71" [strNullK,objEmptyK]

--- a/persistent-postgresql/test/PgInit.hs
+++ b/persistent-postgresql/test/PgInit.hs
@@ -4,11 +4,11 @@
 module PgInit (
   runConn
   , runConn_
+  , runConnAssert
 
   , MonadIO
   , persistSettings
   , MkPersistSettings (..)
-  , db
   , BackendKey(..)
   , GenerateKey(..)
 
@@ -100,8 +100,8 @@ runConn_ f = do
         host <- fromMaybe "localhost" <$> liftIO dockerPg
         withPostgresqlPool ("host=" <> host <> " port=5432 user=postgres dbname=test") 1 $ runSqlPool f
 
-db :: SqlPersistT (LoggingT (ResourceT IO)) () -> Assertion
-db actions = do
+runConnAssert :: SqlPersistT (LoggingT (ResourceT IO)) () -> Assertion
+runConnAssert actions = do
   runResourceT $ runConn $ actions >> transactionUndo
 
 instance Arbitrary Value where

--- a/persistent-postgresql/test/PgInit.hs
+++ b/persistent-postgresql/test/PgInit.hs
@@ -86,17 +86,7 @@ persistSettings :: MkPersistSettings
 persistSettings = sqlSettings { mpsGeneric = True }
 
 runConn :: MonadUnliftIO m => SqlPersistT (LoggingT m) t -> m ()
-runConn f = do
-  travis <- liftIO isTravis
-  let debugPrint = not travis && _debugOn
-  let printDebug = if debugPrint then print . fromLogStr else void . return
-  flip runLoggingT (\_ _ _ s -> printDebug s) $ do
-    _ <- if travis
-      then withPostgresqlPool "host=localhost port=5432 user=postgres dbname=persistent" 1 $ runSqlPool f
-      else do
-        host <- fromMaybe "localhost" <$> liftIO dockerPg
-        withPostgresqlPool ("host=" <> host <> " port=5432 user=postgres dbname=test") 1 $ runSqlPool f
-    return ()
+runConn f = runConn_ f >>= const (return ())
 
 runConn_ :: MonadUnliftIO m => SqlPersistT (LoggingT m) t -> m t
 runConn_ f = do

--- a/persistent-postgresql/test/PgIntervalTest.hs
+++ b/persistent-postgresql/test/PgIntervalTest.hs
@@ -15,7 +15,6 @@
 module PgIntervalTest where
 
 import PgInit
-import Control.Monad.IO.Unlift
 import Data.Time.Clock (NominalDiffTime)
 import Database.Persist.Postgresql (PgInterval(..))
 import Test.Hspec.QuickCheck
@@ -33,9 +32,9 @@ PgIntervalDb
 truncate' :: NominalDiffTime -> NominalDiffTime
 truncate' x = (fromIntegral (round (x * 10^6))) / 10^6
 
-specs :: (MonadUnliftIO m, MonadFail m) => RunDb SqlBackend m -> Spec
-specs runDb = describe "Postgres Interval Property tests" $
-    prop "Round trips" $ \time -> runDb $ do
+specs :: Spec
+specs = describe "Postgres Interval Property tests" $
+    prop "Round trips" $ \time -> runConnAssert $ do
       let eg = PgIntervalDb $ PgInterval (truncate' time)
       rid <- insert eg
       r <- getJust rid

--- a/persistent-postgresql/test/main.hs
+++ b/persistent-postgresql/test/main.hs
@@ -129,8 +129,8 @@ main = do
     PersistentTest.cleanDB
 
   hspec $ do
-    RenameTest.specsWith db
-    DataTypeTest.specsWith db
+    RenameTest.specsWith runConnAssert
+    DataTypeTest.specsWith runConnAssert
         (Just (runMigrationSilent dataTypeMigrate))
         [ TestFn "text" dataTypeTableText
         , TestFn "textMaxLen" dataTypeTableTextMaxLen
@@ -149,44 +149,44 @@ main = do
         [ ("pico", dataTypeTablePico) ]
         dataTypeTableDouble
     HtmlTest.specsWith
-        db
+        runConnAssert
         (Just (runMigrationSilent HtmlTest.htmlMigrate))
-    EmbedTest.specsWith db
-    EmbedOrderTest.specsWith db
-    LargeNumberTest.specsWith db
-    ForeignKey.specsWith db
-    UniqueTest.specsWith db
-    MaxLenTest.specsWith db
-    Recursive.specsWith db
-    SumTypeTest.specsWith db (Just (runMigrationSilent SumTypeTest.sumTypeMigrate))
-    MigrationOnlyTest.specsWith db
+    EmbedTest.specsWith runConnAssert
+    EmbedOrderTest.specsWith runConnAssert
+    LargeNumberTest.specsWith runConnAssert
+    ForeignKey.specsWith runConnAssert
+    UniqueTest.specsWith runConnAssert
+    MaxLenTest.specsWith runConnAssert
+    Recursive.specsWith runConnAssert
+    SumTypeTest.specsWith runConnAssert (Just (runMigrationSilent SumTypeTest.sumTypeMigrate))
+    MigrationOnlyTest.specsWith runConnAssert
         (Just
             $ runMigrationSilent MigrationOnlyTest.migrateAll1
             >> runMigrationSilent MigrationOnlyTest.migrateAll2
         )
-    PersistentTest.specsWith db
-    ReadWriteTest.specsWith db
-    PersistentTest.filterOrSpecs db
-    RawSqlTest.specsWith db
+    PersistentTest.specsWith runConnAssert
+    ReadWriteTest.specsWith runConnAssert
+    PersistentTest.filterOrSpecs runConnAssert
+    RawSqlTest.specsWith runConnAssert
     UpsertTest.specsWith
-        db
+        runConnAssert
         UpsertTest.Don'tUpdateNull
         UpsertTest.UpsertPreserveOldKey
 
-    MpsNoPrefixTest.specsWith db
-    MpsCustomPrefixTest.specsWith db
-    EmptyEntityTest.specsWith db (Just (runMigrationSilent EmptyEntityTest.migration))
-    CompositeTest.specsWith db
-    TreeTest.specsWith db
-    PersistUniqueTest.specsWith db
-    PrimaryTest.specsWith db
-    CustomPersistFieldTest.specsWith db
-    CustomPrimaryKeyReferenceTest.specsWith db
-    MigrationColumnLengthTest.specsWith db
+    MpsNoPrefixTest.specsWith runConnAssert
+    MpsCustomPrefixTest.specsWith runConnAssert
+    EmptyEntityTest.specsWith runConnAssert (Just (runMigrationSilent EmptyEntityTest.migration))
+    CompositeTest.specsWith runConnAssert
+    TreeTest.specsWith runConnAssert
+    PersistUniqueTest.specsWith runConnAssert
+    PrimaryTest.specsWith runConnAssert
+    CustomPersistFieldTest.specsWith runConnAssert
+    CustomPrimaryKeyReferenceTest.specsWith runConnAssert
+    MigrationColumnLengthTest.specsWith runConnAssert
     EquivalentTypeTestPostgres.specs
-    TransactionLevelTest.specsWith db
+    TransactionLevelTest.specsWith runConnAssert
+    LongIdentifierTest.specsWith runConnAssert
     JSONTest.specs
-    CustomConstraintTest.specs db
-    LongIdentifierTest.specsWith db
-    PgIntervalTest.specs db
-    ArrayAggTest.specs db
+    CustomConstraintTest.specs
+    PgIntervalTest.specs
+    ArrayAggTest.specs

--- a/persistent-postgresql/test/main.hs
+++ b/persistent-postgresql/test/main.hs
@@ -20,8 +20,7 @@ import qualified Data.Text as T
 import Data.Time
 import Test.QuickCheck
 
--- FIXME: should probably be used?
--- import qualified ArrayAggTest
+import qualified ArrayAggTest
 import qualified CompositeTest
 import qualified ForeignKey
 import qualified CustomPersistFieldTest
@@ -130,65 +129,64 @@ main = do
     PersistentTest.cleanDB
 
   hspec $ do
-    RenameTest.specsWith db
-    DataTypeTest.specsWith db
-        (Just (runMigrationSilent dataTypeMigrate))
-        [ TestFn "text" dataTypeTableText
-        , TestFn "textMaxLen" dataTypeTableTextMaxLen
-        , TestFn "bytes" dataTypeTableBytes
-        , TestFn "bytesTextTuple" dataTypeTableBytesTextTuple
-        , TestFn "bytesMaxLen" dataTypeTableBytesMaxLen
-        , TestFn "int" dataTypeTableInt
-        , TestFn "intList" dataTypeTableIntList
-        , TestFn "intMap" dataTypeTableIntMap
-        , TestFn "bool" dataTypeTableBool
-        , TestFn "day" dataTypeTableDay
-        , TestFn "time" (DataTypeTest.roundTime . dataTypeTableTime)
-        , TestFn "utc" (DataTypeTest.roundUTCTime . dataTypeTableUtc)
-        , TestFn "jsonb" dataTypeTableJsonb
-        ]
-        [ ("pico", dataTypeTablePico) ]
-        dataTypeTableDouble
-    HtmlTest.specsWith
-        db
-        (Just (runMigrationSilent HtmlTest.htmlMigrate))
-    EmbedTest.specsWith db
-    EmbedOrderTest.specsWith db
-    LargeNumberTest.specsWith db
-    ForeignKey.specsWith db
-    UniqueTest.specsWith db
-    MaxLenTest.specsWith db
-    Recursive.specsWith db
-    SumTypeTest.specsWith db (Just (runMigrationSilent SumTypeTest.sumTypeMigrate))
-    MigrationOnlyTest.specsWith db
-        (Just
-            $ runMigrationSilent MigrationOnlyTest.migrateAll1
-            >> runMigrationSilent MigrationOnlyTest.migrateAll2
-        )
-    PersistentTest.specsWith db
-    ReadWriteTest.specsWith db
-    PersistentTest.filterOrSpecs db
-    RawSqlTest.specsWith db
-    UpsertTest.specsWith
-        db
-        UpsertTest.Don'tUpdateNull
-        UpsertTest.UpsertPreserveOldKey
+    -- RenameTest.specsWith db
+    -- DataTypeTest.specsWith db
+    --     (Just (runMigrationSilent dataTypeMigrate))
+    --     [ TestFn "text" dataTypeTableText
+    --     , TestFn "textMaxLen" dataTypeTableTextMaxLen
+    --     , TestFn "bytes" dataTypeTableBytes
+    --     , TestFn "bytesTextTuple" dataTypeTableBytesTextTuple
+    --     , TestFn "bytesMaxLen" dataTypeTableBytesMaxLen
+    --     , TestFn "int" dataTypeTableInt
+    --     , TestFn "intList" dataTypeTableIntList
+    --     , TestFn "intMap" dataTypeTableIntMap
+    --     , TestFn "bool" dataTypeTableBool
+    --     , TestFn "day" dataTypeTableDay
+    --     , TestFn "time" (DataTypeTest.roundTime . dataTypeTableTime)
+    --     , TestFn "utc" (DataTypeTest.roundUTCTime . dataTypeTableUtc)
+    --     , TestFn "jsonb" dataTypeTableJsonb
+    --     ]
+    --     [ ("pico", dataTypeTablePico) ]
+    --     dataTypeTableDouble
+    -- HtmlTest.specsWith
+    --     db
+    --     (Just (runMigrationSilent HtmlTest.htmlMigrate))
+    -- EmbedTest.specsWith db
+    -- EmbedOrderTest.specsWith db
+    -- LargeNumberTest.specsWith db
+    -- ForeignKey.specsWith db
+    -- UniqueTest.specsWith db
+    -- MaxLenTest.specsWith db
+    -- Recursive.specsWith db
+    -- SumTypeTest.specsWith db (Just (runMigrationSilent SumTypeTest.sumTypeMigrate))
+    -- MigrationOnlyTest.specsWith db
+    --     (Just
+    --         $ runMigrationSilent MigrationOnlyTest.migrateAll1
+    --         >> runMigrationSilent MigrationOnlyTest.migrateAll2
+    --     )
+    -- PersistentTest.specsWith db
+    -- ReadWriteTest.specsWith db
+    -- PersistentTest.filterOrSpecs db
+    -- RawSqlTest.specsWith db
+    -- UpsertTest.specsWith
+    --     db
+    --     UpsertTest.Don'tUpdateNull
+    --     UpsertTest.UpsertPreserveOldKey
 
-    MpsNoPrefixTest.specsWith db
-    MpsCustomPrefixTest.specsWith db
-    EmptyEntityTest.specsWith db (Just (runMigrationSilent EmptyEntityTest.migration))
-    CompositeTest.specsWith db
-    TreeTest.specsWith db
-    PersistUniqueTest.specsWith db
-    PrimaryTest.specsWith db
-    CustomPersistFieldTest.specsWith db
-    CustomPrimaryKeyReferenceTest.specsWith db
-    MigrationColumnLengthTest.specsWith db
-    EquivalentTypeTestPostgres.specs
-    TransactionLevelTest.specsWith db
-    JSONTest.specs
-    CustomConstraintTest.specs db
-    LongIdentifierTest.specsWith db
-    PgIntervalTest.specs db
-    -- FIXME: not used, probably should?
+    -- MpsNoPrefixTest.specsWith db
+    -- MpsCustomPrefixTest.specsWith db
+    -- EmptyEntityTest.specsWith db (Just (runMigrationSilent EmptyEntityTest.migration))
+    -- CompositeTest.specsWith db
+    -- TreeTest.specsWith db
+    -- PersistUniqueTest.specsWith db
+    -- PrimaryTest.specsWith db
+    -- CustomPersistFieldTest.specsWith db
+    -- CustomPrimaryKeyReferenceTest.specsWith db
+    -- MigrationColumnLengthTest.specsWith db
+    -- EquivalentTypeTestPostgres.specs
+    -- TransactionLevelTest.specsWith db
+    JSONTest.specs db
+    -- CustomConstraintTest.specs db
+    -- LongIdentifierTest.specsWith db
+    -- PgIntervalTest.specs db
     -- ArrayAggTest.specs db

--- a/persistent-postgresql/test/main.hs
+++ b/persistent-postgresql/test/main.hs
@@ -185,7 +185,7 @@ main = do
     -- MigrationColumnLengthTest.specsWith db
     -- EquivalentTypeTestPostgres.specs
     -- TransactionLevelTest.specsWith db
-    JSONTest.specs db
+    JSONTest.specs
     -- CustomConstraintTest.specs db
     -- LongIdentifierTest.specsWith db
     -- PgIntervalTest.specs db

--- a/persistent-postgresql/test/main.hs
+++ b/persistent-postgresql/test/main.hs
@@ -129,64 +129,64 @@ main = do
     PersistentTest.cleanDB
 
   hspec $ do
-    -- RenameTest.specsWith db
-    -- DataTypeTest.specsWith db
-    --     (Just (runMigrationSilent dataTypeMigrate))
-    --     [ TestFn "text" dataTypeTableText
-    --     , TestFn "textMaxLen" dataTypeTableTextMaxLen
-    --     , TestFn "bytes" dataTypeTableBytes
-    --     , TestFn "bytesTextTuple" dataTypeTableBytesTextTuple
-    --     , TestFn "bytesMaxLen" dataTypeTableBytesMaxLen
-    --     , TestFn "int" dataTypeTableInt
-    --     , TestFn "intList" dataTypeTableIntList
-    --     , TestFn "intMap" dataTypeTableIntMap
-    --     , TestFn "bool" dataTypeTableBool
-    --     , TestFn "day" dataTypeTableDay
-    --     , TestFn "time" (DataTypeTest.roundTime . dataTypeTableTime)
-    --     , TestFn "utc" (DataTypeTest.roundUTCTime . dataTypeTableUtc)
-    --     , TestFn "jsonb" dataTypeTableJsonb
-    --     ]
-    --     [ ("pico", dataTypeTablePico) ]
-    --     dataTypeTableDouble
-    -- HtmlTest.specsWith
-    --     db
-    --     (Just (runMigrationSilent HtmlTest.htmlMigrate))
-    -- EmbedTest.specsWith db
-    -- EmbedOrderTest.specsWith db
-    -- LargeNumberTest.specsWith db
-    -- ForeignKey.specsWith db
-    -- UniqueTest.specsWith db
-    -- MaxLenTest.specsWith db
-    -- Recursive.specsWith db
-    -- SumTypeTest.specsWith db (Just (runMigrationSilent SumTypeTest.sumTypeMigrate))
-    -- MigrationOnlyTest.specsWith db
-    --     (Just
-    --         $ runMigrationSilent MigrationOnlyTest.migrateAll1
-    --         >> runMigrationSilent MigrationOnlyTest.migrateAll2
-    --     )
-    -- PersistentTest.specsWith db
-    -- ReadWriteTest.specsWith db
-    -- PersistentTest.filterOrSpecs db
-    -- RawSqlTest.specsWith db
-    -- UpsertTest.specsWith
-    --     db
-    --     UpsertTest.Don'tUpdateNull
-    --     UpsertTest.UpsertPreserveOldKey
+    RenameTest.specsWith db
+    DataTypeTest.specsWith db
+        (Just (runMigrationSilent dataTypeMigrate))
+        [ TestFn "text" dataTypeTableText
+        , TestFn "textMaxLen" dataTypeTableTextMaxLen
+        , TestFn "bytes" dataTypeTableBytes
+        , TestFn "bytesTextTuple" dataTypeTableBytesTextTuple
+        , TestFn "bytesMaxLen" dataTypeTableBytesMaxLen
+        , TestFn "int" dataTypeTableInt
+        , TestFn "intList" dataTypeTableIntList
+        , TestFn "intMap" dataTypeTableIntMap
+        , TestFn "bool" dataTypeTableBool
+        , TestFn "day" dataTypeTableDay
+        , TestFn "time" (DataTypeTest.roundTime . dataTypeTableTime)
+        , TestFn "utc" (DataTypeTest.roundUTCTime . dataTypeTableUtc)
+        , TestFn "jsonb" dataTypeTableJsonb
+        ]
+        [ ("pico", dataTypeTablePico) ]
+        dataTypeTableDouble
+    HtmlTest.specsWith
+        db
+        (Just (runMigrationSilent HtmlTest.htmlMigrate))
+    EmbedTest.specsWith db
+    EmbedOrderTest.specsWith db
+    LargeNumberTest.specsWith db
+    ForeignKey.specsWith db
+    UniqueTest.specsWith db
+    MaxLenTest.specsWith db
+    Recursive.specsWith db
+    SumTypeTest.specsWith db (Just (runMigrationSilent SumTypeTest.sumTypeMigrate))
+    MigrationOnlyTest.specsWith db
+        (Just
+            $ runMigrationSilent MigrationOnlyTest.migrateAll1
+            >> runMigrationSilent MigrationOnlyTest.migrateAll2
+        )
+    PersistentTest.specsWith db
+    ReadWriteTest.specsWith db
+    PersistentTest.filterOrSpecs db
+    RawSqlTest.specsWith db
+    UpsertTest.specsWith
+        db
+        UpsertTest.Don'tUpdateNull
+        UpsertTest.UpsertPreserveOldKey
 
-    -- MpsNoPrefixTest.specsWith db
-    -- MpsCustomPrefixTest.specsWith db
-    -- EmptyEntityTest.specsWith db (Just (runMigrationSilent EmptyEntityTest.migration))
-    -- CompositeTest.specsWith db
-    -- TreeTest.specsWith db
-    -- PersistUniqueTest.specsWith db
-    -- PrimaryTest.specsWith db
-    -- CustomPersistFieldTest.specsWith db
-    -- CustomPrimaryKeyReferenceTest.specsWith db
-    -- MigrationColumnLengthTest.specsWith db
-    -- EquivalentTypeTestPostgres.specs
-    -- TransactionLevelTest.specsWith db
+    MpsNoPrefixTest.specsWith db
+    MpsCustomPrefixTest.specsWith db
+    EmptyEntityTest.specsWith db (Just (runMigrationSilent EmptyEntityTest.migration))
+    CompositeTest.specsWith db
+    TreeTest.specsWith db
+    PersistUniqueTest.specsWith db
+    PrimaryTest.specsWith db
+    CustomPersistFieldTest.specsWith db
+    CustomPrimaryKeyReferenceTest.specsWith db
+    MigrationColumnLengthTest.specsWith db
+    EquivalentTypeTestPostgres.specs
+    TransactionLevelTest.specsWith db
     JSONTest.specs
-    -- CustomConstraintTest.specs db
-    -- LongIdentifierTest.specsWith db
-    -- PgIntervalTest.specs db
-    -- ArrayAggTest.specs db
+    CustomConstraintTest.specs db
+    LongIdentifierTest.specsWith db
+    PgIntervalTest.specs db
+    ArrayAggTest.specs db


### PR DESCRIPTION
I wasn't sure how to put all of the db entry keys into scope. I made some ad hoc data structures to do so, but if anyone has any suggestions on how to do this better I would be open to them!

> Note: I used `runIO` instead of `before` or `beforeAll` because I wanted to have access to the db entry keys. Additionally, I didn't insert the `edgeCases` when constructing the spec tree because they mess up some of the earlier tests. I had to insert the `edgeCases` in each `it` block afterwards, so I would still have access to the keys and they wouldn't pollute the db state.

Before submitting your PR, check that you've:

- ~~Bumped the version number~~
- ~~Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)~~
- ~~Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock~~

After submitting your PR:

- ~~Update the Changelog.md file with a link to your PR~~
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->