### PR TITLE
Add cabal flag and CPP option to use Loc from monad-logger.

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -20,6 +20,8 @@
 * Fix a bug where unsafe migration error messages were being shown using `Show` prior to printing, resulting in less helpful output. [#1080](https://github.com/yesodweb/persistent/pull/1080)
 * [#1087](https://github.com/yesodweb/persistent/pull/1087)
   * `RawSql` now has tuple instances up to GHC's max tuple size (62)
+* [#1076](https://github.com/yesodweb/persistent/pull/1076)
+  * `Loc` is now imported from `monad-logger` as opposed to `template-haskell`. Removes `template-haskell` as an explicit dependency.
 
 ## 2.10.5.2
 

--- a/persistent/Database/Persist/Sql/Types/Internal.hs
+++ b/persistent/Database/Persist/Sql/Types/Internal.hs
@@ -23,15 +23,9 @@ module Database.Persist.Sql.Types.Internal
     , IsSqlBackend
     ) where
 
-#ifdef MONAD_LOGGER_TH
-import Language.Haskell.TH.Syntax (Loc)
-import Control.Monad.Logger (LogSource, LogLevel)
-#else
-import Control.Monad.Logger (LogSource, LogLevel, Loc)
-#endif
-
 import Data.List.NonEmpty (NonEmpty(..))
 import Control.Monad.IO.Class (MonadIO (..))
+import Control.Monad.Logger (LogSource, LogLevel, Loc)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Reader (ReaderT, runReaderT, ask)
 import Data.Acquire (Acquire)

--- a/persistent/Database/Persist/Sql/Types/Internal.hs
+++ b/persistent/Database/Persist/Sql/Types/Internal.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE CPP #-}
 module Database.Persist.Sql.Types.Internal
     ( HasPersistBackend (..)
     , IsPersistBackend (..)

--- a/persistent/Database/Persist/Sql/Types/Internal.hs
+++ b/persistent/Database/Persist/Sql/Types/Internal.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE CPP #-}
 module Database.Persist.Sql.Types.Internal
     ( HasPersistBackend (..)
     , IsPersistBackend (..)
@@ -22,9 +23,15 @@ module Database.Persist.Sql.Types.Internal
     , IsSqlBackend
     ) where
 
+#ifdef MONAD_LOGGER_TH
+import Language.Haskell.TH.Syntax (Loc)
+import Control.Monad.Logger (LogSource, LogLevel)
+#else
+import Control.Monad.Logger (LogSource, LogLevel, Loc)
+#endif
+
 import Data.List.NonEmpty (NonEmpty(..))
 import Control.Monad.IO.Class (MonadIO (..))
-import Control.Monad.Logger (LogSource, LogLevel)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Reader (ReaderT, runReaderT, ask)
 import Data.Acquire (Acquire)
@@ -36,7 +43,6 @@ import Data.Monoid ((<>))
 import Data.String (IsString)
 import Data.Text (Text)
 import Data.Typeable (Typeable)
-import Language.Haskell.TH.Syntax (Loc)
 import System.Log.FastLogger (LogStr)
 
 import Database.Persist.Class

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -18,9 +18,20 @@ flag nooverlap
     default: False
     description: test out our assumption that OverlappingInstances is just for String
 
+flag monad-logger-th
+    default:
+      True
+    manual:
+      True
+    description:
+      Enable usage of monad-logger template haskell
+
 library
     if flag(nooverlap)
         cpp-options: -DNO_OVERLAP
+
+    if flag(monad-logger-th)
+        cpp-options: -DMONAD_LOGGER_TH
 
     build-depends:   base                     >= 4.9       && < 5
                    , aeson                    >= 1.0

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:            persistent
-version:         2.11.0.0
+version:         2.11.1.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:            persistent
-version:         2.11.1.0
+version:         2.11.0.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -18,20 +18,9 @@ flag nooverlap
     default: False
     description: test out our assumption that OverlappingInstances is just for String
 
-flag monad-logger-th
-    default:
-      True
-    manual:
-      True
-    description:
-      Enable usage of monad-logger template haskell
-
 library
     if flag(nooverlap)
         cpp-options: -DNO_OVERLAP
-
-    if flag(monad-logger-th)
-        cpp-options: -DMONAD_LOGGER_TH
 
     build-depends:   base                     >= 4.9       && < 5
                    , aeson                    >= 1.0
@@ -50,7 +39,6 @@ library
                    , resourcet                >= 1.1.10
                    , scientific
                    , silently
-                   , template-haskell
                    , text                     >= 1.2
                    , time                     >= 1.6
                    , transformers             >= 0.5


### PR DESCRIPTION
If template haskell is disabled in monad-logger, this needs to
be propagated to persistent. Otherwise, type errors ensue. 

```
Database/Persist/Sql/Raw.hs:43:18: error:
    • Couldn't match type ‘Control.Monad.Logger.Loc’
                     with ‘Language.Haskell.TH.Syntax.Loc’
      NB: ‘Language.Haskell.TH.Syntax.Loc’
            is defined in ‘Language.Haskell.TH.Syntax’
                in package ‘template-haskell-2.14.0.0’
          ‘Control.Monad.Logger.Loc’
            is defined in ‘Control.Monad.Logger’
                in package ‘monad-logger-0.3.30’
      Expected type: Control.Monad.Logger.Loc
                     -> Control.Monad.Logger.LogSource
                     -> Control.Monad.Logger.LogLevel
                     -> fast-logger-2.4.15:System.Log.FastLogger.LogStr.LogStr
                     -> IO ()
        Actual type: LogFunc
    • In the second argument of ‘runLoggingT’, namely
        ‘(connLogFunc conn)’
      In a stmt of a 'do' block:
        runLoggingT
          (logDebugNS (pack "SQL") $ T.append sql $ pack $ "; " ++ show vals)
          (connLogFunc conn)
      In the expression:
        do runLoggingT
             (logDebugNS (pack "SQL") $ T.append sql $ pack $ "; " ++ show vals)
             (connLogFunc conn)
           getStmtConn conn sql
   |
43 |                 (connLogFunc conn)
   |                  ^^^^^^^^^^^^^^^^

Database/Persist/Sql/Raw.hs:65:10: error:
    • Couldn't match type ‘Control.Monad.Logger.Loc’
                     with ‘Language.Haskell.TH.Syntax.Loc’
      NB: ‘Language.Haskell.TH.Syntax.Loc’
            is defined in ‘Language.Haskell.TH.Syntax’
                in package ‘template-haskell-2.14.0.0’
          ‘Control.Monad.Logger.Loc’
            is defined in ‘Control.Monad.Logger’
                in package ‘monad-logger-0.3.30’
      Expected type: Control.Monad.Logger.Loc
                     -> Control.Monad.Logger.LogSource
                     -> Control.Monad.Logger.LogLevel
                     -> fast-logger-2.4.15:System.Log.FastLogger.LogStr.LogStr
                     -> IO ()
        Actual type: LogFunc
    • In the second argument of ‘runLoggingT’, namely
        ‘(connLogFunc conn)’
      In a stmt of a 'do' block:
        runLoggingT
          (logDebugNS (pack "SQL") $ T.append sql $ pack $ "; " ++ show vals)
          (connLogFunc conn)
      In the expression:
        do conn <- projectBackend `liftM` ask
           runLoggingT
             (logDebugNS (pack "SQL") $ T.append sql $ pack $ "; " ++ show vals)
             (connLogFunc conn)
           stmt <- getStmt sql
           res <- liftIO $ stmtExecute stmt vals
           ....
   |
65 |         (connLogFunc conn)
   |          ^^^^^^^^^^^^^^^^
```

*Note*: this change will not affect any code by default, only when the flag is disabled.


Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->