### PR TITLE
Fix display of exception error messages, #1079

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,9 +1,5 @@
 # Changelog for persistent
 
-## 2.11.1.0
-
-* Fix a bug where unsafe migration error messages were being shown using `Show` prior to printing, resulting in less helpful output. [#1080](https://github.com/yesodweb/persistent/pull/1080)
-
 ## 2.11.0.0
 
 * Introduces a breaking change to the internal function `mkColumns`, which can now be passed a record of functions to override its default behavior. [#996](https://github.com/yesodweb/persistent/pull/996)
@@ -21,6 +17,7 @@
     record` from a `record` if it was defined with `Primary`.
 * [#1036](https://github.com/yesodweb/persistent/pull/1036):
   * The method `entityIdFromJSON` that is used to parse entities now correctly works for entities that define a custom `Primary` key.
+* Fix a bug where unsafe migration error messages were being shown using `Show` prior to printing, resulting in less helpful output. [#1080](https://github.com/yesodweb/persistent/pull/1080)
 
 ## 2.10.5.2
 

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for persistent
 
+## 2.11.1.0
+
+* Fix a bug where unsafe migration error messages were being shown using `Show` prior to printing, resulting in less helpful output. [#1080](https://github.com/yesodweb/persistent/pull/1080)
+
 ## 2.11.0.0
 
 * Introduces a breaking change to the internal function `mkColumns`, which can now be passed a record of functions to override its default behavior. [#996](https://github.com/yesodweb/persistent/pull/996)

--- a/persistent/Database/Persist/Sql/Types.hs
+++ b/persistent/Database/Persist/Sql/Types.hs
@@ -7,13 +7,13 @@ module Database.Persist.Sql.Types
     , OverflowNatural(..)
     ) where
 
-import Control.Exception (Exception)
+import Control.Exception (Exception(..))
 import Control.Monad.Logger (NoLoggingT)
 import Control.Monad.Trans.Reader (ReaderT (..))
 import Control.Monad.Trans.Resource (ResourceT)
 import Control.Monad.Trans.Writer (WriterT)
 import Data.Pool (Pool)
-import Data.Text (Text)
+import Data.Text (Text, unpack)
 import Data.Typeable (Typeable)
 
 import Database.Persist.Types
@@ -114,3 +114,30 @@ type ConnectionPool = Pool SqlBackend
 -- processing).
 newtype Single a = Single {unSingle :: a}
     deriving (Eq, Ord, Show, Read)
+
+-- | An exception indicating that Persistent refused to run some unsafe
+-- migrations. Contains a list of pairs where the Bool tracks whether the
+-- migration was unsafe (True means unsafe), and the Sql is the sql statement
+-- for the migration.
+--
+-- @since 2.11.1.0
+newtype PersistUnsafeMigrationException
+  = PersistUnsafeMigrationException [(Bool, Sql)]
+  deriving Typeable
+
+-- | This 'Show' instance renders an error message suitable for printing to the
+-- console. This is a little dodgy, but since GHC uses Show instances when
+-- displaying uncaught exceptions, we have little choice.
+instance Show PersistUnsafeMigrationException where
+  show (PersistUnsafeMigrationException mig) =
+    concat
+      [ "\n\nDatabase migration: manual intervention required.\n"
+      , "The unsafe actions are prefixed by '***' below:\n\n"
+      , unlines $ map displayMigration mig
+      ]
+    where
+      displayMigration :: (Bool, Sql) -> String
+      displayMigration (True,  s) = "*** " ++ unpack s ++ ";"
+      displayMigration (False, s) = "    " ++ unpack s ++ ";"
+
+instance Exception PersistUnsafeMigrationException

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:            persistent
-version:         2.11.0.0
+version:         2.11.1.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:            persistent
-version:         2.11.1.0
+version:         2.11.0.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
Fixes #1079. Running the test script from that issue now prints

    Migrating: ALTER TABLE "person" ALTER COLUMN "age" TYPE INT8
    [Debug#SQL] ALTER TABLE "person" ALTER COLUMN "age" TYPE INT8; []
    persistent-repro-exe:

    Database migration: manual intervention required.
    The unsafe actions are prefixed by '***' below:

    *** ALTER TABLE "person" DROP COLUMN "age";

This is arguably a breaking change, since if people were catching this exception in their code before, they'll need to change their uses of `catch` to catch this type. If #969 was previously released without a breaking-level version bump and nobody complained, though, this is probably okay to release without a breaking-level version bump too?

Before submitting your PR, check that you've:

- [x] Bumped the version number
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->