### PR TITLE
Configurable idle timeout

### DIFF
--- a/persistent-postgresql/ChangeLog.md
+++ b/persistent-postgresql/ChangeLog.md
@@ -12,6 +12,11 @@
   * Renamed `db` to `runConnAssert` in `test/PgInit.hs` for clarity
   * Ran `test/ArrayAggTest.hs` (which was previously written but not being run)
 * Remove unnecessary deriving of Typeable [#1114](https://github.com/yesodweb/persistent/pull/1114)
+* Add support for configuring the number of stripes and idle timeout for connection pools [#1098](https://github.com/yesodweb/persistent/pull/1098)
+	* `PostgresConf` has two new fields to configure these values.
+		* Its `FromJSON` instance will default stripes to 1 and idle timeout to 600 seconds
+		* If you're constructing a `PostgresConf` manually, this is a breaking change
+	* Add `createPostgresqlPoolWithConf` and `withPostgresqlPoolWithConf`, which take a `PostgresConf` for the new configuration.
 
 ## 2.10.1.2
 

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -107,7 +107,7 @@ instance Show PostgresServerVersionError where
       "Unexpected PostgreSQL server version, got " <> uniqueMsg
 instance Exception PostgresServerVersionError
 
--- | Create a PostgreSQL connection pool and run the given action.  The pool is
+-- | Create a PostgreSQL connection pool and run the given action. The pool is
 -- properly released after the action finishes using it.  Note that you should
 -- not use the given 'ConnectionPool' outside the action since it may already
 -- have been released.

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -11,9 +11,11 @@ module Database.Persist.Postgresql
     , withPostgresqlPoolWithVersion
     , withPostgresqlConn
     , withPostgresqlConnWithVersion
+    , withPostgresqlPoolWithConf
     , createPostgresqlPool
     , createPostgresqlPoolModified
     , createPostgresqlPoolModifiedWithVersion
+    , createPostgresqlPoolWithConf
     , module Database.Persist.Sql
     , ConnectionString
     , PostgresConf (..)
@@ -24,6 +26,8 @@ module Database.Persist.Postgresql
     , fieldName
     , mockMigration
     , migrateEnableExtension
+    , PostgresConfHooks(..)
+    , defaultPostgresConfHooks
     ) where
 
 import qualified Debug.Trace as Debug
@@ -51,6 +55,7 @@ import qualified Blaze.ByteString.Builder.Char8 as BBB
 import Data.Acquire (Acquire, mkAcquire, with)
 import Data.Aeson
 import Data.Aeson.Types (modifyFailure)
+import qualified Data.Attoparsec.Text as AT
 import qualified Data.Attoparsec.ByteString.Char8 as P
 import Data.Bits ((.&.))
 import Data.ByteString (ByteString)
@@ -136,7 +141,25 @@ withPostgresqlPoolWithVersion :: (MonadUnliftIO m, MonadLogger m)
                               -- ^ Action to be executed that uses the
                               -- connection pool.
                               -> m a
-withPostgresqlPoolWithVersion getVer ci = withSqlPool $ open' (const $ return ()) getVer ci
+withPostgresqlPoolWithVersion getVerDouble ci = do
+  let getVer = oldGetVersionToNew getVerDouble
+  withSqlPool $ open' (const $ return ()) getVer ci
+
+-- | Same as 'withPostgresqlPool', but can be configured with 'PostgresConf' and 'PostgresConfHooks'.
+--
+-- @since 2.11.0.0
+withPostgresqlPoolWithConf :: (MonadUnliftIO m, MonadLogger m)
+                           => PostgresConf -- ^ Configuration for connecting to Postgres
+                           -> PostgresConfHooks -- ^ Record of callback functions
+                           -> (Pool SqlBackend -> m a)
+                           -- ^ Action to be executed that uses the
+                           -- connection pool.
+                           -> m a
+withPostgresqlPoolWithConf conf hooks = do
+  let getVer = pgConfHooksGetServerVersion hooks
+      modConn = pgConfHooksAfterCreate hooks
+  let logFuncToBackend = open' modConn getVer (pgConnStr conf)
+  withSqlPoolWithConfig logFuncToBackend (postgresConfToConnectionPoolConfig conf)
 
 -- | Create a PostgreSQL connection pool.  Note that it's your
 -- responsibility to properly close the connection pool when
@@ -179,8 +202,30 @@ createPostgresqlPoolModifiedWithVersion
     -> ConnectionString -- ^ Connection string to the database.
     -> Int -- ^ Number of connections to be kept open in the pool.
     -> m (Pool SqlBackend)
-createPostgresqlPoolModifiedWithVersion getVer modConn ci =
+createPostgresqlPoolModifiedWithVersion getVerDouble modConn ci = do
+  let getVer = oldGetVersionToNew getVerDouble
   createSqlPool $ open' modConn getVer ci
+
+-- | Same as 'createPostgresqlPool', but can be configured with 'PostgresConf' and 'PostgresConfHooks'.
+--
+-- @since 2.11.0.0
+createPostgresqlPoolWithConf
+    :: (MonadUnliftIO m, MonadLogger m)
+    => PostgresConf -- ^ Configuration for connecting to Postgres
+    -> PostgresConfHooks -- ^ Record of callback functions
+    -> m (Pool SqlBackend)
+createPostgresqlPoolWithConf conf hooks = do
+  let getVer = pgConfHooksGetServerVersion hooks
+      modConn = pgConfHooksAfterCreate hooks
+  createSqlPoolWithConfig (open' modConn getVer (pgConnStr conf)) (postgresConfToConnectionPoolConfig conf)
+
+postgresConfToConnectionPoolConfig :: PostgresConf -> ConnectionPoolConfig
+postgresConfToConnectionPoolConfig conf =
+  ConnectionPoolConfig
+    { connectionPoolConfigStripes = pgPoolStripes conf
+    , connectionPoolConfigIdleTimeout = fromInteger $ pgPoolIdleTimeout conf
+    , connectionPoolConfigSize = pgPoolSize conf
+    }
 
 -- | Same as 'withPostgresqlPool', but instead of opening a pool
 -- of connections, only one connection is opened.
@@ -199,11 +244,13 @@ withPostgresqlConnWithVersion :: (MonadUnliftIO m, MonadLogger m)
                               -> ConnectionString
                               -> (SqlBackend -> m a)
                               -> m a
-withPostgresqlConnWithVersion getVer = withSqlConn . open' (const $ return ()) getVer
+withPostgresqlConnWithVersion getVerDouble = do
+  let getVer = oldGetVersionToNew getVerDouble
+  withSqlConn . open' (const $ return ()) getVer
 
 open'
     :: (PG.Connection -> IO ())
-    -> (PG.Connection -> IO (Maybe Double))
+    -> (PG.Connection -> IO (NonEmpty Word))
     -> ConnectionString -> LogFunc -> IO SqlBackend
 open' modConn getVer cstr logFunc = do
     conn <- PG.connectPostgreSQL cstr
@@ -225,15 +272,46 @@ getServerVersion conn = do
     Right (a,_) -> return $ Just a
     Left err -> throwIO $ PostgresServerVersionError err
 
+getServerVersionNonEmpty :: PG.Connection -> IO (NonEmpty Word)
+getServerVersionNonEmpty conn = do
+  [PG.Only version] <- PG.query_ conn "show server_version";
+  case AT.parseOnly parseVersion (T.pack version) of
+    Left err -> throwIO $ PostgresServerVersionError $ "Failed to parse Postgres version. Got: " <> version <> ". Error: " <> err
+    Right versionComponents -> case NEL.nonEmpty versionComponents of
+      Nothing -> throwIO $ PostgresServerVersionError $ "Empty Postgres version string. Got: " <> version
+      Just neVersion -> pure neVersion
+
+  where
+    -- Partially copied from the `versions` package
+    parseVersion = AT.decimal `AT.sepBy` AT.char '.' <* AT.endOfInput
+
 -- | Choose upsert sql generation function based on postgresql version.
 -- PostgreSQL version >= 9.5 supports native upsert feature,
 -- so depending upon that we have to choose how the sql query is generated.
 -- upsertFunction :: Double -> Maybe (EntityDef -> Text -> Text)
-upsertFunction :: a -> Double -> Maybe a
-upsertFunction f version = if (version >= 9.5)
+upsertFunction :: a -> NonEmpty Word -> Maybe a
+upsertFunction f version = if (version >= postgres9dot5)
                          then Just f
                          else Nothing
+  where
 
+postgres9dot5 :: NonEmpty Word
+postgres9dot5 = 9 NEL.:| [5]
+
+-- | If the user doesn't supply a Postgres version, we assume this version.
+--
+-- This is currently below any version-specific features Persistent uses.
+minimumPostgresVersion :: NonEmpty Word
+minimumPostgresVersion = 9 NEL.:| [4]
+
+oldGetVersionToNew :: (PG.Connection -> IO (Maybe Double)) -> (PG.Connection -> IO (NonEmpty Word))
+oldGetVersionToNew oldFn = \conn -> do
+  mDouble <- oldFn conn
+  case mDouble of
+    Nothing -> pure minimumPostgresVersion
+    Just double -> do
+      let (major, minor) = properFraction double
+      pure $ major NEL.:| [floor minor]
 
 -- | Generate a 'SqlBackend' from a 'PG.Connection'.
 openSimpleConn :: LogFunc -> PG.Connection -> IO SqlBackend
@@ -244,14 +322,14 @@ openSimpleConn = openSimpleConnWithVersion getServerVersion
 --
 -- @since 2.9.1
 openSimpleConnWithVersion :: (PG.Connection -> IO (Maybe Double)) -> LogFunc -> PG.Connection -> IO SqlBackend
-openSimpleConnWithVersion getVer logFunc conn = do
+openSimpleConnWithVersion getVerDouble logFunc conn = do
     smap <- newIORef $ Map.empty
-    serverVersion <- getVer conn
+    serverVersion <- oldGetVersionToNew getVerDouble conn
     return $ createBackend logFunc serverVersion smap conn
 
 -- | Create the backend given a logging function, server version, mutable statement cell,
 -- and connection.
-createBackend :: LogFunc -> Maybe Double
+createBackend :: LogFunc -> NonEmpty Word
               -> IORef (Map.Map Text Statement) -> PG.Connection -> SqlBackend
 createBackend logFunc serverVersion smap conn = do
     SqlBackend
@@ -259,8 +337,8 @@ createBackend logFunc serverVersion smap conn = do
         , connStmtMap    = smap
         , connInsertSql  = insertSql'
         , connInsertManySql = Just insertManySql'
-        , connUpsertSql  = serverVersion >>= upsertFunction upsertSql'
-        , connPutManySql = serverVersion >>= upsertFunction putManySql
+        , connUpsertSql  = upsertFunction upsertSql' serverVersion
+        , connPutManySql = upsertFunction putManySql serverVersion
         , connClose      = PG.close conn
         , connMigrateSql = migrate'
         , connBegin      = \_ mIsolation -> case mIsolation of
@@ -278,7 +356,7 @@ createBackend logFunc serverVersion smap conn = do
         , connLimitOffset = decorateSQLWithLimitOffset "LIMIT ALL"
         , connLogFunc = logFunc
         , connMaxParams = Nothing
-        , connRepsertManySql = serverVersion >>= upsertFunction repsertManySql
+        , connRepsertManySql = upsertFunction repsertManySql serverVersion
         }
 
 prepare' :: PG.Connection -> Text -> IO Statement
@@ -1299,6 +1377,20 @@ escape (DBName s) =
 data PostgresConf = PostgresConf
     { pgConnStr  :: ConnectionString
       -- ^ The connection string.
+    
+    -- TODO: Currently stripes, idle timeout, and pool size are all separate fields
+    -- When Persistent next does a large breaking release (3.0?), we should consider making these just a single ConnectionPoolConfig value
+    -- 
+    -- Currently there the idle timeout is an Integer, rather than resource-pool's NominalDiffTime type.
+    -- This is because the time package only recently added the Read instance for NominalDiffTime.
+    -- Future TODO: Consider removing the Read instance, and/or making the idle timeout a NominalDiffTime.
+
+    , pgPoolStripes :: Int
+    -- ^ How many stripes to divide the pool into. See "Data.Pool" for details.
+    -- @since 2.11.0.0
+    , pgPoolIdleTimeout :: Integer -- Ideally this would be a NominalDiffTime, but that type lacks a Read instance https://github.com/haskell/time/issues/130
+    -- ^ How long connections can remain idle before being disposed of, in seconds.
+    -- @since 2.11.0.0
     , pgPoolSize :: Int
       -- ^ How many connections should be held in the connection pool.
     } deriving (Show, Read, Data)
@@ -1306,12 +1398,15 @@ data PostgresConf = PostgresConf
 instance FromJSON PostgresConf where
     parseJSON v = modifyFailure ("Persistent: error loading PostgreSQL conf: " ++) $
       flip (withObject "PostgresConf") v $ \o -> do
+        let defaultPoolConfig = defaultConnectionPoolConfig
         database <- o .: "database"
         host     <- o .: "host"
         port     <- o .:? "port" .!= 5432
         user     <- o .: "user"
         password <- o .: "password"
-        pool     <- o .: "poolsize"
+        poolSize <- o .:? "poolsize" .!= (connectionPoolConfigSize defaultPoolConfig)
+        poolStripes <- o .:? "stripes" .!= (connectionPoolConfigStripes defaultPoolConfig)
+        poolIdleTimeout <- o .:? "idleTimeout" .!= (floor $ connectionPoolConfigIdleTimeout defaultPoolConfig)
         let ci = PG.ConnectInfo
                    { PG.connectHost     = host
                    , PG.connectPort     = port
@@ -1320,11 +1415,11 @@ instance FromJSON PostgresConf where
                    , PG.connectDatabase = database
                    }
             cstr = PG.postgreSQLConnectionString ci
-        return $ PostgresConf cstr pool
+        return $ PostgresConf cstr poolStripes poolIdleTimeout poolSize
 instance PersistConfig PostgresConf where
     type PersistConfigBackend PostgresConf = SqlPersistT
     type PersistConfigPool PostgresConf = ConnectionPool
-    createPoolConfig (PostgresConf cs size) = runNoLoggingT $ createPostgresqlPool cs size -- FIXME
+    createPoolConfig conf = runNoLoggingT $ createPostgresqlPoolWithConf conf defaultPostgresConfHooks
     runPool _ = runSqlPool
     loadConfig = parseJSON
 
@@ -1355,6 +1450,38 @@ instance PersistConfig PostgresConf where
         addUser     = maybeAddParam "user"     "PGUSER"
         addPass     = maybeAddParam "password" "PGPASS"
         addDatabase = maybeAddParam "dbname"   "PGDATABASE"
+
+-- | Hooks for configuring the Persistent/its connection to Postgres
+--
+-- @since 2.11.0
+data PostgresConfHooks = PostgresConfHooks
+  { pgConfHooksGetServerVersion :: PG.Connection -> IO (NonEmpty Word) 
+      -- ^ Function to get the version of Postgres
+      --
+      -- The default implementation queries the server with "show server_version".
+      -- Some variants of Postgres, such as Redshift, don't support showing the version.
+      -- It's recommended you return a hardcoded version in those cases.
+      --
+      -- @since 2.11.0
+  , pgConfHooksAfterCreate :: PG.Connection -> IO ()
+      -- ^ Action to perform after a connection is created.
+      --
+      -- Typical uses of this are modifying the connection (e.g. to set the schema) or logging a connection being created.
+      --
+      -- The default implementation does nothing.
+      --
+      -- @since 2.11.0
+  }
+
+-- | Default settings for 'PostgresConfHooks'. See the individual fields of 'PostgresConfHooks' for the default values.
+--
+-- @since 2.11.0
+defaultPostgresConfHooks :: PostgresConfHooks
+defaultPostgresConfHooks = PostgresConfHooks
+  { pgConfHooksGetServerVersion = getServerVersionNonEmpty
+  , pgConfHooksAfterCreate = const $ pure ()
+  }
+
 
 refName :: DBName -> DBName -> DBName
 refName (DBName table) (DBName column) =

--- a/persistent-postgresql/test/PgInit.hs
+++ b/persistent-postgresql/test/PgInit.hs
@@ -106,7 +106,7 @@ runConnInternal connType f = do
       poolSize = 1
   connString <- if travis
     then do
-      pure "host=localhost port=5432 user=postgres dbname=persistent"
+      pure "host=localhost port=5432 user=perstest password=perstest dbname=persistent"
     else do
       host <- fromMaybe "localhost" <$> liftIO dockerPg
       pure ("host=" <> host <> " port=5432 user=postgres dbname=test")

--- a/persistent-postgresql/test/PgInit.hs
+++ b/persistent-postgresql/test/PgInit.hs
@@ -106,14 +106,13 @@ runConnInternal connType f = do
       poolSize = 1
   connString <- if travis
     then do
-      logInfoN "Running in CI"
       pure "host=localhost port=5432 user=postgres dbname=persistent"
     else do
-      logInfoN "CI not detected"
       host <- fromMaybe "localhost" <$> liftIO dockerPg
       pure ("host=" <> host <> " port=5432 user=postgres dbname=test")
 
   flip runLoggingT (\_ _ _ s -> printDebug s) $ do
+    logInfoN (if travis then "Running in CI" else "CI not detected")
     case connType of
       RunConnBasic -> withPostgresqlPool connString poolSize $ runSqlPool f
       RunConnConf -> do

--- a/persistent-postgresql/test/PgInit.hs
+++ b/persistent-postgresql/test/PgInit.hs
@@ -5,6 +5,7 @@ module PgInit (
   runConn
   , runConn_
   , runConnAssert
+  , runConnAssertUseConf
 
   , MonadIO
   , persistSettings
@@ -89,23 +90,50 @@ runConn :: MonadUnliftIO m => SqlPersistT (LoggingT m) t -> m ()
 runConn f = runConn_ f >>= const (return ())
 
 runConn_ :: MonadUnliftIO m => SqlPersistT (LoggingT m) t -> m t
-runConn_ f = do
+runConn_ f = runConnInternal RunConnBasic f
+
+-- | Data type to switch between pool creation functions, to ease testing both.
+data RunConnType =
+    RunConnBasic -- ^ Use 'withPostgresqlPool'
+  | RunConnConf -- ^ Use 'withPostgresqlPoolWithConf'
+  deriving (Show, Eq)
+
+runConnInternal :: MonadUnliftIO m => RunConnType -> SqlPersistT (LoggingT m) t -> m t
+runConnInternal connType f = do
   travis <- liftIO isTravis
   let debugPrint = not travis && _debugOn
-  let printDebug = if debugPrint then print . fromLogStr else void . return
+      printDebug = if debugPrint then print . fromLogStr else void . return
+      poolSize = 1
+  connString <- if travis
+    then do
+      logInfoN "Running in CI"
+      pure "host=localhost port=5432 user=postgres dbname=persistent"
+    else do
+      logInfoN "CI not detected"
+      host <- fromMaybe "localhost" <$> liftIO dockerPg
+      pure ("host=" <> host <> " port=5432 user=postgres dbname=test")
+
   flip runLoggingT (\_ _ _ s -> printDebug s) $ do
-    if travis
-      then do
-          logInfoN "Running in CI"
-          withPostgresqlPool "host=localhost port=5432 user=perstest password=perstest dbname=persistent" 1 $ runSqlPool f
-      else do
-          logInfoN "CI not detected"
-          host <- fromMaybe "localhost" <$> liftIO dockerPg
-          withPostgresqlPool ("host=" <> host <> " port=5432 user=postgres dbname=test") 1 $ runSqlPool f
+    case connType of
+      RunConnBasic -> withPostgresqlPool connString poolSize $ runSqlPool f
+      RunConnConf -> do
+        let conf = PostgresConf
+              { pgConnStr = connString
+              , pgPoolStripes = 1
+              , pgPoolIdleTimeout = 60
+              , pgPoolSize = poolSize
+              }
+            hooks = defaultPostgresConfHooks
+        withPostgresqlPoolWithConf conf hooks (runSqlPool f)
 
 runConnAssert :: SqlPersistT (LoggingT (ResourceT IO)) () -> Assertion
 runConnAssert actions = do
   runResourceT $ runConn $ actions >> transactionUndo
+
+-- | Like runConnAssert, but uses the "conf" flavor of functions to test that code path.
+runConnAssertUseConf :: SqlPersistT (LoggingT (ResourceT IO)) () -> Assertion
+runConnAssertUseConf actions = do
+  runResourceT $ runConnInternal RunConnConf (actions >> transactionUndo)
 
 instance Arbitrary Value where
   arbitrary = frequency [ (1, pure Null)

--- a/persistent-postgresql/test/main.hs
+++ b/persistent-postgresql/test/main.hs
@@ -190,7 +190,7 @@ main = do
     MigrationColumnLengthTest.specsWith runConnAssert
     EquivalentTypeTestPostgres.specs
     TransactionLevelTest.specsWith runConnAssert
-    LongIdentifierTest.specsWith runConnAssert
+    LongIdentifierTest.specsWith runConnAssertUseConf -- Have at least one test use the conf variant of connecting to Postgres, to improve test coverage.
     JSONTest.specs
     CustomConstraintTest.specs
     PgIntervalTest.specs

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -46,6 +46,13 @@
     constraints on an entity update without having to update it.
 * [#1142](https://github.com/yesodweb/persistent/pull/1142)
     * Deprecate `hasCompositeKey` in favor of `hasCustomPrimaryKey` and `hasCompositePrimaryKey` functions.
+* [#1098](https://github.com/yesodweb/persistent/pull/1098)
+  * Add support for configuring the number of stripes and idle timeout for connection pools 
+    * For functions that do not specify an idle timeout, the default has been bumped to 600 seconds.
+      * This change is based off the experience of two production codebases. See [#775](https://github.com/yesodweb/persistent/issues/775)
+    * Add a new type `ConnectionPoolConfig` to configure the number of connections in a pool, their idle timeout, and stripe size.
+    * Add `defaultConnectionPoolConfig` to create a `ConnectionPoolConfig`
+    * Add `createSqlPoolWithConfig` and `withSqlPoolWithConfig`, which take this new data type
 
 ## 2.10.5.2
 

--- a/persistent/Database/Persist/Sql/Types.hs
+++ b/persistent/Database/Persist/Sql/Types.hs
@@ -5,6 +5,8 @@ module Database.Persist.Sql.Types
     , readToUnknown, readToWrite, writeToUnknown
     , SqlBackendCanRead, SqlBackendCanWrite, SqlReadT, SqlWriteT, IsSqlBackend
     , OverflowNatural(..)
+    , ConnectionPoolConfig(..)
+    , defaultConnectionPoolConfig
     ) where
 
 import Control.Exception (Exception(..))
@@ -17,6 +19,7 @@ import Data.Text (Text, unpack)
 
 import Database.Persist.Types
 import Database.Persist.Sql.Types.Internal
+import Data.Time (NominalDiffTime)
 
 data Column = Column
     { cName      :: !DBName
@@ -54,6 +57,23 @@ type CautiousMigration = [(Bool, Sql)]
 type Migration = WriterT [Text] (WriterT CautiousMigration (ReaderT SqlBackend IO)) ()
 
 type ConnectionPool = Pool SqlBackend
+
+-- | Values to configure a pool of database connections. See "Data.Pool" for details.
+--
+-- @since 2.11.0.0
+data ConnectionPoolConfig = ConnectionPoolConfig
+    { connectionPoolConfigStripes :: Int -- ^ How many stripes to divide the pool into. See "Data.Pool" for details. Default: 1.
+    , connectionPoolConfigIdleTimeout :: NominalDiffTime -- ^ How long connections can remain idle before being disposed of, in seconds. Default: 600
+    , connectionPoolConfigSize :: Int -- ^ How many connections should be held in the connection pool. Default: 10
+    }
+    deriving (Show)
+
+-- TODO: Bad defaults for SQLite maybe?
+-- | Initializes a ConnectionPoolConfig with default values. See the documentation of 'ConnectionPoolConfig' for each field's default value.
+--
+-- @since 2.11.0.0
+defaultConnectionPoolConfig :: ConnectionPoolConfig
+defaultConnectionPoolConfig = ConnectionPoolConfig 1 600 10
 
 -- $rawSql
 --


### PR DESCRIPTION
This PR ~is a draft~ shows what it might look like to have a configurable idle timeout and stripe size for Persistent's SQL backends. This would resolve the issues brought up in #775.

~This PR is just a draft~. It's untested and needs a few small additions, but most things are in place. (Edit: added a test)


Before submitting your PR, check that you've:

- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
