### PR TITLE
Add UUID instances for PersistField

### DIFF
--- a/persistent/Database/Persist/Sql/Class.hs
+++ b/persistent/Database/Persist/Sql/Class.hs
@@ -33,6 +33,7 @@ import Data.Word
 import Numeric.Natural (Natural)
 import Text.Blaze.Html (Html)
 import GHC.TypeLits
+import Data.UUID.Types
 
 import Database.Persist
 import Database.Persist.Sql.Types
@@ -1241,6 +1242,9 @@ instance (HasResolution a) => PersistFieldSql (Fixed a) where
 
 instance PersistFieldSql Rational where
     sqlType _ = SqlNumeric 32 20   --  need to make this field big enough to handle Rational to Mumber string conversion for ODBC
+
+instance PersistFieldSql UUID where
+  sqlType _ = SqlOther "uuid"
 
 
 -- | This type uses the 'SqlInt64' version, which will exhibit overflow and

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -47,6 +47,7 @@ library
                    , unliftio
                    , unordered-containers
                    , vector
+                   , uuid-types
 
     default-extensions: FlexibleContexts
                       , MultiParamTypeClasses


### PR DESCRIPTION
Issue: https://github.com/yesodweb/persistent/issues/579

As discussed this only works for postgres. This suggested PR has no support for MySQL.  
An alternative could be creating a newtype as suggested by @parsonsmatt 
I'm not sure what's best. But at least now we have something to point at.

Before submitting your PR, check that you've:

- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
