### PR TITLE
persistent-template: Use the stock strategy when deriving Show/Read f…

### DIFF
--- a/persistent-template/ChangeLog.md
+++ b/persistent-template/ChangeLog.md
@@ -1,6 +1,6 @@
 ## Unreleased changes
 
-* Always use the "stock" strategy when deriving Show/Read for keys
+* Always use the "stock" strategy when deriving Show/Read for keys [#1106](https://github.com/yesodweb/persistent/pull/1106)
 	* This fixes a regression from 2.8.0, which started using the `newtype` strategy when deriving `Show`/`Read` for keys
 	* In practice, this means that from 2.8.0–2.8.3.1, for the following schema:
 

--- a/persistent-template/ChangeLog.md
+++ b/persistent-template/ChangeLog.md
@@ -1,5 +1,7 @@
 ## Unreleased changes
 
+## 2.9
+
 * Always use the "stock" strategy when deriving Show/Read for keys [#1106](https://github.com/yesodweb/persistent/pull/1106)
 	* This fixes a regression from 2.8.0, which started using the `newtype` strategy when deriving `Show`/`Read` for keys
 	* In practice, this means that from 2.8.0–2.8.3.1, for the following schema:

--- a/persistent-template/ChangeLog.md
+++ b/persistent-template/ChangeLog.md
@@ -1,5 +1,28 @@
 ## Unreleased changes
 
+* Always use the "stock" strategy when deriving Show/Read for keys
+	* This fixes a regression from 2.8.0, which started using the `newtype` strategy when deriving `Show`/`Read` for keys
+	* In practice, this means that from 2.8.0–2.8.3.1, for the following schema:
+
+	```
+	Person
+		name Text
+	CustomPrimary
+		anInt Int
+		Primary anInt
+		name Text
+	```
+
+	`PersonKey 1` would show as `"SqlBackendKey {unSqlBackendKey = 1}"`
+	and `CustomPrimaryKey 1` would show as `"1"`
+
+	This was generally poor for debugging and logging, since all tables keys would print the same. For Persistent < 2.8.0 and > 2.8.3.1, they instead will show as:
+
+	`"PersonKey {unPersonKey = SqlBackendKey {unSqlBackendKey = 1}}"`
+	and `"CustomPrimaryKey {unCustomPrimaryKey = 1}"`
+
+	This could be a breaking change if you have used `Show` on a key, wrote that string into some persistent storage like a database, and are trying to `Read` it back again later.
+
 ## 2.8.3.1
 
 * Allow aeson 1.5. [#1085](https://github.com/yesodweb/persistent/pull/1085)

--- a/persistent-template/persistent-template.cabal
+++ b/persistent-template/persistent-template.cabal
@@ -1,5 +1,5 @@
 name:            persistent-template
-version:         2.8.3.1
+version:         2.9
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/persistent-template/test/main.hs
+++ b/persistent-template/test/main.hs
@@ -71,6 +71,9 @@ Laddress json
     city Text
     zip Int Maybe
     deriving Show Eq
+CustomPrimaryKey
+    anInt Int
+    Primary anInt
 |]
 
 arbitraryT :: Gen Text
@@ -110,6 +113,14 @@ main = hspec $ do
         (person1 ^. lpersonAddress) `shouldBe` address1
         (person1 ^. (lpersonAddress . laddressCity)) `shouldBe` city1
         (person1 & ((lpersonAddress . laddressCity) .~ city2)) `shouldBe` person2
+    describe "Derived Show/Read instances" $ do
+        -- This tests confirms https://github.com/yesodweb/persistent/issues/1104 remains fixed
+        it "includes the name of the newtype when showing/reading a Key, i.e. uses the stock strategy when deriving Show/Read" $ do
+            show (PersonKey 0) `shouldBe` "PersonKey {unPersonKey = SqlBackendKey {unSqlBackendKey = 0}}"
+            read (show (PersonKey 0)) `shouldBe` PersonKey 0
+
+            show (CustomPrimaryKeyKey 0) `shouldBe` "CustomPrimaryKeyKey {unCustomPrimaryKeyKey = 0}"
+            read (show (CustomPrimaryKeyKey 0)) `shouldBe` CustomPrimaryKeyKey 0
 
 (&) :: a -> (a -> b) -> b
 x & f = f x


### PR DESCRIPTION
…or keys

This closes https://github.com/yesodweb/persistent/issues/1104

If people are amenable to this PR, thoughts on the version for it? This could be a breaking change, as described in the Changelog (idk how people feel about that though—if changing the content of a Show/Read instance is considered to be a breaking change)

Before submitting your PR, check that you've:

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html) (n/a)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock (n/a)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
