### PR TITLE
persistent-qq: Add interpolation support for multirow VALUES syntax

### DIFF
--- a/persistent-qq/ChangeLog.md
+++ b/persistent-qq/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for persistent-qq
 
+## 2.9.2
+
+* Add interpolation support for multirow VALUES syntax (`*{rows}`) [#1111](https://github.com/yesodweb/persistent/pull/1111)
+
 ## 2.9.1.1
 
 * Compatibility with latest persistent-template for test suite [#1002](https://github.com/yesodweb/persistent/pull/1002/files)

--- a/persistent-qq/persistent-qq.cabal
+++ b/persistent-qq/persistent-qq.cabal
@@ -7,7 +7,7 @@ cabal-version: 1.12
 -- hash: bef2b585278826bc60fe813d4918833dc06cec43f2a8e4567190448ccfdee163
 
 name:           persistent-qq
-version:        2.9.1.1
+version:        2.9.2
 synopsis:       Provides a quasi-quoter for raw SQL for persistent
 description:    Please see README and API docs at <http://www.stackage.org/package/persistent>.
 category:       Database, Yesod


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
