### PR TITLE
Remove deriving of Typeable.

### DIFF
--- a/persistent-mongoDB/ChangeLog.md
+++ b/persistent-mongoDB/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for persistent-mongoDB
 
+## 2.10.0.1
+
+* Remove unnecessary deriving of Typeable [#1114](https://github.com/yesodweb/persistent/pull/1114)
+
 ## 2.10.0.0
 
 * Fix `ninList` filter operator [#1058](https://github.com/yesodweb/persistent/pull/1058)

--- a/persistent-mongoDB/persistent-mongoDB.cabal
+++ b/persistent-mongoDB/persistent-mongoDB.cabal
@@ -1,5 +1,5 @@
 name:            persistent-mongoDB
-version:         2.10.0.0
+version:         2.10.0.1
 license:         MIT
 license-file:    LICENSE
 author:          Greg Weber <greg@gregweber.info>

--- a/persistent-mongoDB/test/EmbedTestMongo.hs
+++ b/persistent-mongoDB/test/EmbedTestMongo.hs
@@ -20,7 +20,6 @@ import Data.List.NonEmpty hiding (insert, length)
 import qualified Data.Map as M
 import qualified Data.Set as S
 import qualified Data.Text as T
-import Data.Typeable (Typeable)
 import Database.MongoDB (genObjectId)
 import Database.MongoDB (Value(String))
 import System.Process (readProcess)
@@ -29,7 +28,7 @@ import EntityEmbedTestMongo
 import Database.Persist.MongoDB
 
 data TestException = TestException
-    deriving (Show, Typeable, Eq)
+    deriving (Show, Eq)
 instance Exception TestException
 
 instance PersistFieldSql a => PersistFieldSql (NonEmpty a) where

--- a/persistent-postgresql/ChangeLog.md
+++ b/persistent-postgresql/ChangeLog.md
@@ -12,6 +12,8 @@
   * Renamed `db` to `runConnAssert` in `test/PgInit.hs` for clarity
   * Ran `test/ArrayAggTest.hs` (which was previously written but not being run)
 
+* Remove unnecessary deriving of Typeable [#1114](https://github.com/yesodweb/persistent/pull/1114)
+
 ## 2.10.1.2
 
 * Fix issue with multiple foreign keys on single column. [#1010](https://github.com/yesodweb/persistent/pull/1010)

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -77,7 +77,6 @@ import qualified Data.Text.Encoding as T
 import qualified Data.Text.IO as T
 import Data.Text.Read (rational)
 import Data.Time (utc, NominalDiffTime, localTimeToUTC)
-import Data.Typeable (Typeable)
 import System.Environment (getEnvironment)
 
 import Database.Persist.Sql
@@ -93,7 +92,7 @@ type ConnectionString = ByteString
 
 -- | PostgresServerVersionError exception. This is thrown when persistent
 -- is unable to find the version of the postgreSQL server.
-data PostgresServerVersionError = PostgresServerVersionError String deriving Data.Typeable.Typeable
+data PostgresServerVersionError = PostgresServerVersionError String
 
 instance Show PostgresServerVersionError where
     show (PostgresServerVersionError uniqueMsg) =
@@ -542,7 +541,7 @@ instance PersistFieldSql PgInterval where
   sqlType _ = SqlOther "interval"
 
 newtype Unknown = Unknown { unUnknown :: ByteString }
-  deriving (Eq, Show, Read, Ord, Typeable)
+  deriving (Eq, Show, Read, Ord)
 
 instance PGFF.FromField Unknown where
     fromField f mdata =
@@ -1263,7 +1262,7 @@ data PostgresConf = PostgresConf
       -- ^ The connection string.
     , pgPoolSize :: Int
       -- ^ How many connections should be held in the connection pool.
-    } deriving (Show, Read, Data, Typeable)
+    } deriving (Show, Read, Data)
 
 instance FromJSON PostgresConf where
     parseJSON v = modifyFailure ("Persistent: error loading PostgreSQL conf: " ++) $

--- a/persistent-redis/ChangeLog.md
+++ b/persistent-redis/ChangeLog.md
@@ -1,3 +1,7 @@
+# 2.5.2.5
+
+* Remove unnecessary deriving of Typeable [#1114](https://github.com/yesodweb/persistent/pull/1114)
+
 # 2.5.2.4
 
 * Compatibility with latest persistent-template for test suite [#1002](https://github.com/yesodweb/persistent/pull/1002/files)

--- a/persistent-redis/Database/Persist/Redis/Exception.hs
+++ b/persistent-redis/Database/Persist/Redis/Exception.hs
@@ -1,17 +1,14 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 module Database.Persist.Redis.Exception
     ( RedisException (..)
     ) where
 
 import Control.Exception (Exception)
-import Data.Typeable (Typeable)
 
 data RedisException = NotSupportedOperation String
                     | ParserError String
                     | NotSupportedValueType String
                     | IncorrectUpdate String
                     | IncorrectBehavior
-    deriving Typeable
 
 instance Show RedisException where
     show (NotSupportedOperation key) = "The operation is not supported: " ++ key

--- a/persistent-redis/persistent-redis.cabal
+++ b/persistent-redis/persistent-redis.cabal
@@ -1,5 +1,5 @@
 name:            persistent-redis
-version:         2.5.2.4
+version:         2.5.2.5
 license:         BSD3
 license-file:    LICENSE
 author:          Pavel Ryzhov <paul@paulrz.cz>

--- a/persistent-sqlite/ChangeLog.md
+++ b/persistent-sqlite/ChangeLog.md
@@ -5,6 +5,8 @@
 * [#1060](https://github.com/yesodweb/persistent/pull/1060)
   * The QuasiQuoter now supports `OnDelete` and `OnUpdate` cascade options.
 
+* Remove unnecessary deriving of Typeable [#1114](https://github.com/yesodweb/persistent/pull/1114)
+
 ## 2.10.6.2
 
 * Move template haskell splices to be correct (and GHC 8.10 compatible) [#1034](https://github.com/yesodweb/persistent/pull/1034)

--- a/persistent-sqlite/Database/Sqlite.hs
+++ b/persistent-sqlite/Database/Sqlite.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE OverloadedStrings #-}
 -- | A port of the direct-sqlite package for dealing directly with
@@ -92,7 +91,6 @@ import Data.Text (Text, pack, unpack)
 import Data.Text.Encoding (encodeUtf8, decodeUtf8With)
 import Data.Text.Encoding.Error (lenientDecode)
 import Data.Time (defaultTimeLocale, formatTime, UTCTime)
-import Data.Typeable (Typeable)
 import Database.Sqlite.Internal (Connection(..), Connection'(..), Statement(..))
 import Foreign
 import Foreign.C
@@ -107,7 +105,7 @@ data SqliteException = SqliteException
     , seFunctionName :: !Text
     , seDetails      :: !Text
     }
-    deriving (Typeable)
+
 instance Show SqliteException where
     show (SqliteException error functionName details) = unpack $ Data.Monoid.mconcat
         ["SQLite3 returned "

--- a/persistent-test/ChangeLog.md
+++ b/persistent-test/ChangeLog.md
@@ -1,5 +1,9 @@
 ## Unreleased changes
 
+## 2.0.3.2
+
+* Remove unnecessary deriving of Typeable [#1114](https://github.com/yesodweb/persistent/pull/1114)
+
 ## 2.0.3.1
 
 * Compatibility with latest persistent-template for test suite [#1002](https://github.com/yesodweb/persistent/pull/1002/files)

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -1,5 +1,5 @@
 name:            persistent-test
-version:         2.0.3.1
+version:         2.0.3.2
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/persistent-test/src/EmbedTest.hs
+++ b/persistent-test/src/EmbedTest.hs
@@ -7,14 +7,13 @@ import Control.Exception (Exception, throw)
 import Data.List.NonEmpty hiding (insert, length)
 import qualified Data.Map as M
 import qualified Data.Text as T
-import Data.Typeable (Typeable)
 import qualified Data.Set as S
 
 import EntityEmbedTest
 import Init
 
 data TestException = TestException
-    deriving (Show, Typeable, Eq)
+    deriving (Show, Eq)
 instance Exception TestException
 
 instance PersistFieldSql a => PersistFieldSql (NonEmpty a) where

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -22,6 +22,8 @@
   * `RawSql` now has tuple instances up to GHC's max tuple size (62)
 * [#1076](https://github.com/yesodweb/persistent/pull/1076)
   * `Loc` is now imported from `monad-logger` as opposed to `template-haskell`. Removes `template-haskell` as an explicit dependency.
+* [#1114](https://github.com/yesodweb/persistent/pull/1114)
+  * Remove unnecessary deriving of `Typeable`.
 
 ## 2.10.5.2
 

--- a/persistent/Database/Persist/Class/PersistEntity.hs
+++ b/persistent/Database/Persist/Class/PersistEntity.hs
@@ -35,7 +35,6 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.Text.Lazy as LT
 import qualified Data.Text.Lazy.Builder as TB
-import Data.Typeable (Typeable)
 import GHC.Generics
 
 import Database.Persist.Class.PersistField
@@ -200,7 +199,6 @@ data FilterValue typ where
 data Entity record =
     Entity { entityKey :: Key record
            , entityVal :: record }
-    deriving Typeable
 
 deriving instance (Generic (Key record), Generic record) => Generic (Entity record)
 deriving instance (Eq (Key record), Eq record) => Eq (Entity record)

--- a/persistent/Database/Persist/Sql/Types.hs
+++ b/persistent/Database/Persist/Sql/Types.hs
@@ -14,7 +14,6 @@ import Control.Monad.Trans.Resource (ResourceT)
 import Control.Monad.Trans.Writer (WriterT)
 import Data.Pool (Pool)
 import Data.Text (Text, unpack)
-import Data.Typeable (Typeable)
 
 import Database.Persist.Types
 import Database.Persist.Sql.Types.Internal
@@ -32,7 +31,7 @@ data Column = Column
 
 data PersistentSqlException = StatementAlreadyFinalized Text
                             | Couldn'tGetSQLConnection
-    deriving (Typeable, Show)
+    deriving Show
 instance Exception PersistentSqlException
 
 type SqlPersistT = ReaderT SqlBackend
@@ -123,7 +122,6 @@ newtype Single a = Single {unSingle :: a}
 -- @since 2.11.1.0
 newtype PersistUnsafeMigrationException
   = PersistUnsafeMigrationException [(Bool, Sql)]
-  deriving Typeable
 
 -- | This 'Show' instance renders an error message suitable for printing to the
 -- console. This is a little dodgy, but since GHC uses Show instances when

--- a/persistent/Database/Persist/Sql/Types/Internal.hs
+++ b/persistent/Database/Persist/Sql/Types/Internal.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE RankNTypes #-}
 module Database.Persist.Sql.Types.Internal
     ( HasPersistBackend (..)
@@ -35,7 +34,6 @@ import Data.Map (Map)
 import Data.Monoid ((<>))
 import Data.String (IsString)
 import Data.Text (Text)
-import Data.Typeable (Typeable)
 import System.Log.FastLogger (LogStr)
 
 import Database.Persist.Class
@@ -145,7 +143,6 @@ data SqlBackend = SqlBackend
     --
     -- @since 2.9.0
     }
-    deriving Typeable
 instance HasPersistBackend SqlBackend where
     type BaseBackend SqlBackend = SqlBackend
     persistBackend = id
@@ -155,7 +152,7 @@ instance IsPersistBackend SqlBackend where
 -- | An SQL backend which can only handle read queries
 --
 -- The constructor was exposed in 2.10.0.
-newtype SqlReadBackend = SqlReadBackend { unSqlReadBackend :: SqlBackend } deriving Typeable
+newtype SqlReadBackend = SqlReadBackend { unSqlReadBackend :: SqlBackend } 
 instance HasPersistBackend SqlReadBackend where
     type BaseBackend SqlReadBackend = SqlBackend
     persistBackend = unSqlReadBackend
@@ -165,7 +162,7 @@ instance IsPersistBackend SqlReadBackend where
 -- | An SQL backend which can handle read or write queries
 --
 -- The constructor was exposed in 2.10.0
-newtype SqlWriteBackend = SqlWriteBackend { unSqlWriteBackend :: SqlBackend } deriving Typeable
+newtype SqlWriteBackend = SqlWriteBackend { unSqlWriteBackend :: SqlBackend }
 instance HasPersistBackend SqlWriteBackend where
     type BaseBackend SqlWriteBackend = SqlBackend
     persistBackend = unSqlWriteBackend

--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# OPTIONS_GHC -fno-warn-deprecations #-} -- usage of Error typeclass
 module Database.Persist.Types.Base where
 
@@ -20,7 +19,6 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import Data.Text.Encoding.Error (lenientDecode)
 import Data.Time (Day, TimeOfDay, UTCTime)
-import Data.Typeable (Typeable)
 import qualified Data.Vector as V
 import Data.Word (Word32)
 import Numeric (showHex, readHex)
@@ -357,7 +355,7 @@ data PersistException
   | PersistForeignConstraintUnmet Text
   | PersistMongoDBError Text
   | PersistMongoDBUnsupported Text
-    deriving (Show, Typeable)
+    deriving Show
 
 instance Exception PersistException
 instance Error PersistException where
@@ -405,7 +403,7 @@ data PersistValue = PersistText Text
 -- insert $ Foo (toPoint 44 44)
 -- @
 --
-    deriving (Show, Read, Eq, Typeable, Ord)
+    deriving (Show, Read, Eq, Ord)
 
 
 instance ToHttpApiData PersistValue where
@@ -535,7 +533,7 @@ data SqlType = SqlString
              | SqlDayTime -- ^ Always uses UTC timezone
              | SqlBlob
              | SqlOther T.Text -- ^ a backend-specific name
-    deriving (Show, Read, Eq, Typeable, Ord)
+    deriving (Show, Read, Eq, Ord)
 
 data PersistFilter = Eq | Ne | Gt | Lt | Ge | Le | In | NotIn
                    | BackendSpecificFilter T.Text
@@ -543,13 +541,12 @@ data PersistFilter = Eq | Ne | Gt | Lt | Ge | Le | In | NotIn
 
 data UpdateException = KeyNotFound String
                      | UpsertError String
-    deriving Typeable
 instance Show UpdateException where
     show (KeyNotFound key) = "Key not found during updateGet: " ++ key
     show (UpsertError msg) = "Error during upsert: " ++ msg
 instance Exception UpdateException
 
-data OnlyUniqueException = OnlyUniqueException String deriving Typeable
+data OnlyUniqueException = OnlyUniqueException String
 instance Show OnlyUniqueException where
     show (OnlyUniqueException uniqueMsg) =
       "Expected only one unique key, got " ++ uniqueMsg


### PR DESCRIPTION
Closes #1107.

~I am not sure about the use of `Typeable` in [persistent-template/Database/Persist/TH.hs](https://github.com/yesodweb/persistent/blob/master/persistent-template/Database/Persist/TH.hs). However, even if it is no longer needed, this may be out of scope for this PR.~ After some research I believe this is handled by Template Haskell, as it should be.

I hope I got the versions/changelogs right.

-----------

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)