### PR TITLE
Foreign key improvements

### DIFF
--- a/persistent-postgresql/ChangeLog.md
+++ b/persistent-postgresql/ChangeLog.md
@@ -2,6 +2,10 @@
 
 ## (Unreleased) 2.11.0.0
 
+* Foreign Key improvements [#1121] https://github.com/yesodweb/persistent/pull/1121
+  * It is now supported to refer to a table with an auto generated Primary Kay
+  * It is now supported to refer to non-primary fields, using the keyword `References`
+
 * Implement interval support. [#1053](https://github.com/yesodweb/persistent/pull/1053)
 * [#1060](https://github.com/yesodweb/persistent/pull/1060)
   * The QuasiQuoter now supports `OnDelete` and `OnUpdate` cascade options.

--- a/persistent-sqlite/ChangeLog.md
+++ b/persistent-sqlite/ChangeLog.md
@@ -2,6 +2,11 @@
 
 ## (Unreleased) 2.11.0.0
 
+* Foreign Key improvements [#1121] (https://github.com/yesodweb/persistent/pull/1121)
+  * It is now supported to refer to a table with an auto generated Primary Kay
+  * It is now supported to refer to non-primary fields, using the keyword `References`
+  * It is now supported to have cascade options for simple/single-field Foreign Keys
+
 * [#1060](https://github.com/yesodweb/persistent/pull/1060)
   * The QuasiQuoter now supports `OnDelete` and `OnUpdate` cascade options.
 

--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -581,8 +581,14 @@ sqlColumn noRef (Column name isNull typ def _cn _maxLen ref) = T.concat
     , mayDefault def
     , case ref of
         Nothing -> ""
-        Just cref -> if noRef then "" else " REFERENCES " <> escape (crTableName cref)
+        Just ColumnReference {crTableName=table, crFieldCascade=cascadeOpts} ->
+          if noRef then "" else " REFERENCES " <> escape table
+            <> onDelete cascadeOpts <> onUpdate cascadeOpts
     ]
+  where
+
+    onDelete opts = maybe "" (T.append " ON DELETE " . renderCascadeAction) (fcOnDelete opts)
+    onUpdate opts = maybe "" (T.append " ON UPDATE " . renderCascadeAction) (fcOnUpdate opts)
 
 sqlForeign :: ForeignDef -> Text
 sqlForeign fdef = T.concat $

--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -581,7 +581,7 @@ sqlColumn noRef (Column name isNull typ def _cn _maxLen ref) = T.concat
     , mayDefault def
     , case ref of
         Nothing -> ""
-        Just (table, _) -> if noRef then "" else " REFERENCES " <> escape table
+        Just cref -> if noRef then "" else " REFERENCES " <> escape (crTableName cref)
     ]
 
 sqlForeign :: ForeignDef -> Text

--- a/persistent-template/Database/Persist/TH.hs
+++ b/persistent-template/Database/Persist/TH.hs
@@ -1335,7 +1335,8 @@ mkLenses mps ent = fmap mconcat $ forM (entityFields ent) $ \field -> do
         ]
 
 mkForeignKeysComposite :: MkPersistSettings -> EntityDef -> ForeignDef -> Q [Dec]
-mkForeignKeysComposite mps t ForeignDef {..} = do
+mkForeignKeysComposite mps t ForeignDef {..} =
+    if not foreignToPrimary then return [] else do
     let fieldName f = mkName $ unpack $ recName mps (entityHaskell t) f
     let fname = fieldName foreignConstraintNameHaskell
     let reftableString = unpack $ unHaskellName foreignRefTableHaskell

--- a/persistent-template/Database/Persist/TH.hs
+++ b/persistent-template/Database/Persist/TH.hs
@@ -1104,11 +1104,11 @@ mkEntity entityMap mps t = do
     fpv <- mkFromPersistValues mps t
     utv <- mkUniqueToValues $ entityUniques t
     puk <- mkUniqueKeys t
+    let primaryField = entityId t
+    fields <- mapM (mkField mps t) $ primaryField : entityFields t
     fkc <- mapM (mkForeignKeysComposite mps t) $ entityForeigns t
 
-    let primaryField = entityId t
 
-    fields <- mapM (mkField mps t) $ primaryField : entityFields t
     toFieldNames <- mkToFieldNames $ entityUniques t
 
     (keyTypeDec, keyInstanceDecs) <- mkKeyTypeDec mps t
@@ -1343,8 +1343,12 @@ mkForeignKeysComposite mps t ForeignDef {..} = do
     let tablename = mkName $ unpack $ entityText t
     recordName <- newName "record"
 
-    let fldsE = map (\((foreignName, _),_) -> VarE (fieldName foreignName)
-                  `AppE` VarE recordName) foreignFields
+    let mkFldE ((foreignName, _),ff) = case ff of
+          (HaskellName {unHaskellName = "Id"}, DBName {unDBName = "id"})
+            -> AppE (VarE $ mkName "toBackendKey") $
+               VarE (fieldName foreignName) `AppE` VarE recordName
+          _ -> VarE (fieldName foreignName) `AppE` VarE recordName
+    let fldsE = map mkFldE foreignFields
     let mkKeyE = foldl' AppE (maybeExp foreignNullable $ ConE reftableKeyName) fldsE
     let fn = FunD fname [normalClause [VarP recordName] mkKeyE]
 

--- a/persistent-test/src/ForeignKey.hs
+++ b/persistent-test/src/ForeignKey.hs
@@ -16,6 +16,15 @@ share [mkPersist persistSettings { mpsGeneric = False }, mkMigrate "compositeMig
     Foreign Parent OnDeleteCascade OnUpdateCascade fkparent pname
     deriving Show Eq
 
+  ParentImplicit
+    name String
+
+  ChildImplicit
+    pname String
+    parentId ParentImplicitId noreference
+    Foreign ParentImplicit OnDeleteCascade OnUpdateCascade fkparent parentId
+    deriving Show Eq
+
   ParentComposite
     name String
     lastName String
@@ -50,6 +59,13 @@ specsWith runDb = describe "foreign keys options" $ do
     update kf [ParentName =. "B"]
     cs <- selectList [] []
     fmap (childPname . entityVal) cs @== ["B"]
+  it "delete cascades on implicit Primary key" $ runDb $ do
+    kf <- insert $ ParentImplicit "A"
+    kc <- insert $ ChildImplicit "B" kf
+    delete kf
+    cs <- selectList [] []
+    let expected = [] :: [Entity ChildImplicit]
+    cs @== expected
   it "delete Composite cascades" $ runDb $ do
     kf <- insert $ ParentComposite "A" "B"
     kc <- insert $ ChildComposite "A" "B"

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -2,6 +2,10 @@
 
 ## (Unreleased) 2.11.0.0
 
+* Foreign Key improvements [#1121] https://github.com/yesodweb/persistent/pull/1121
+  * It is now supported to refer to a table with an auto generated Primary Kay
+  * It is now supported to refer to non-primary fields, using the keyword `References`
+  * It is now supported to have cascade options for simple/single-field Foreign Keys
 * Introduces a breaking change to the internal function `mkColumns`, which can now be passed a record of functions to override its default behavior. [#996](https://github.com/yesodweb/persistent/pull/996)
 * Added explicit `forall` notation to make most API functions play nice when using `TypeApplications`. (e.g. instead of `selectList @_ @_ @User [] []`, you can now write `selectList @User [] []`) [#1006](https://github.com/yesodweb/persistent/pull/1006)
 * [#1060](https://github.com/yesodweb/persistent/pull/1060)

--- a/persistent/Database/Persist/Quasi.hs
+++ b/persistent/Database/Persist/Quasi.hs
@@ -609,8 +609,9 @@ fixForeignKeysAll unEnts = map fixForeignKeys unEnts
                    ++ show (map (unHaskellName . fieldHaskell) (fd:fds))
         isNull = (NotNullable /=) . nullable . fieldAttrs
 
+        toForeignFields :: EntityDef -> Text -> FieldDef -> (FieldDef, ((HaskellName, DBName), (HaskellName, DBName)))
         toForeignFields pent fieldText pfd =
-           case chktypes fd haskellField (entityFields pent) pfh of
+           case chktypes fd haskellField pfd of
                Just err -> error err
                Nothing -> (fd, ((haskellField, fieldDB fd), (pfh, pfdb)))
           where
@@ -619,12 +620,9 @@ fixForeignKeysAll unEnts = map fixForeignKeys unEnts
             haskellField = HaskellName fieldText
             (pfh, pfdb) = (fieldHaskell pfd, fieldDB pfd)
 
-            chktypes :: FieldDef -> HaskellName -> [FieldDef] -> HaskellName -> Maybe String
-            chktypes ffld _fkey pflds pkey =
+            chktypes ffld _fkey pfld =
                 if fieldType ffld == fieldType pfld then Nothing
                   else Just $ "fieldType mismatch: " ++ show (fieldType ffld) ++ ", " ++ show (fieldType pfld)
-              where
-                pfld = getFd pflds pkey
 
             entName = entityHaskell ent
             getFd [] t = error $ "foreign key constraint for: " ++ show (unHaskellName entName)

--- a/persistent/Database/Persist/Sql/Internal.hs
+++ b/persistent/Database/Persist/Sql/Internal.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TupleSections #-}
 
 -- | Intended for creating new backends.
 module Database.Persist.Sql.Internal
@@ -87,11 +88,12 @@ mkColumns allDefs t overrides =
 
             , cDefaultConstraintName =  Nothing
             , cMaxLen = maxLen $ fieldAttrs fd
-            , cReference = ref (fieldDB fd) (fieldReference fd) (fieldAttrs fd)
+            , cReference = mkColumnReference fd
             }
 
     tableName :: DBName
     tableName = entityDB t
+
 
     go :: FieldDef -> Column
     go fd =
@@ -102,7 +104,7 @@ mkColumns allDefs t overrides =
             , cDefault = defaultAttribute $ fieldAttrs fd
             , cDefaultConstraintName =  Nothing
             , cMaxLen = maxLen $ fieldAttrs fd
-            , cReference = ref (fieldDB fd) (fieldReference fd) (fieldAttrs fd)
+            , cReference = mkColumnReference fd
             }
 
     maxLen :: [Attr] -> Maybe Integer
@@ -116,6 +118,11 @@ mkColumns allDefs t overrides =
         | otherwise = maxLen as
 
     refNameFn = fromMaybe refName (backendSpecificForeignKeyName overrides)
+
+    mkColumnReference :: FieldDef -> Maybe ColumnReference
+    mkColumnReference fd =
+        fmap (\(tName, cName) -> ColumnReference tName cName (fieldCascadeOpts fd))
+        $ ref (fieldDB fd) (fieldReference fd) (fieldAttrs fd)
 
     ref :: DBName
         -> ReferenceDef

--- a/persistent/Database/Persist/Sql/Types.hs
+++ b/persistent/Database/Persist/Sql/Types.hs
@@ -7,6 +7,8 @@ module Database.Persist.Sql.Types
     , OverflowNatural(..)
     ) where
 
+import Database.Persist.Types.Base (FieldCascade)
+
 import Control.Exception (Exception(..))
 import Control.Monad.Logger (NoLoggingT)
 import Control.Monad.Trans.Reader (ReaderT (..))
@@ -25,7 +27,14 @@ data Column = Column
     , cDefault   :: !(Maybe Text)
     , cDefaultConstraintName   :: !(Maybe DBName)
     , cMaxLen    :: !(Maybe Integer)
-    , cReference :: !(Maybe (DBName, DBName)) -- table name, constraint name
+    , cReference :: !(Maybe ColumnReference)
+    }
+    deriving (Eq, Ord, Show)
+
+data ColumnReference = ColumnReference
+    { crTableName :: DBName
+    , crConstraintName :: DBName
+    , crFieldCascade :: FieldCascade
     }
     deriving (Eq, Ord, Show)
 

--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -209,6 +209,7 @@ data FieldDef = FieldDef
     -- attach comments to a field in the quasiquoter.
     --
     -- @since 2.10.0
+    , fieldCascadeOpts :: !FieldCascade
     }
     deriving (Show, Eq, Read, Ord)
 

--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -210,6 +210,10 @@ data FieldDef = FieldDef
     --
     -- @since 2.10.0
     , fieldCascadeOpts :: !FieldCascade
+    -- ^ The cascade options of this fields. Used when this field refers to
+    -- another field.
+    --
+    -- @since 2.11.0
     }
     deriving (Show, Eq, Read, Ord)
 
@@ -310,6 +314,9 @@ data ForeignDef = ForeignDef
     , foreignAttrs                 :: ![Attr]
     , foreignNullable              :: Bool
     , foreignToPrimary             :: Bool
+    -- ^ Determines if the reference is towards a Primary Key or not.
+    --
+    -- @since 2.11.0
     }
     deriving (Show, Eq, Read, Ord)
 

--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -139,6 +139,14 @@ data EntityDef = EntityDef
     }
     deriving (Show, Eq, Read, Ord)
 
+entitiesPrimary :: EntityDef -> Maybe [FieldDef]
+entitiesPrimary t = case fieldReference primaryField of
+    CompositeRef c -> Just $ (compositeFields c)
+    ForeignRef _ _ -> Just [primaryField]
+    _ -> Nothing
+  where
+    primaryField = entityId t
+
 entityPrimary :: EntityDef -> Maybe CompositeDef
 entityPrimary t = case fieldReference (entityId t) of
     CompositeRef c -> Just c

--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -308,6 +308,7 @@ data ForeignDef = ForeignDef
     , foreignFields                :: ![(ForeignFieldDef, ForeignFieldDef)] -- this entity plus the primary entity
     , foreignAttrs                 :: ![Attr]
     , foreignNullable              :: Bool
+    , foreignToPrimary             :: Bool
     }
     deriving (Show, Eq, Read, Ord)
 


### PR DESCRIPTION
This pr adds some new feautures related to Foreign Keys that are commonly needed:
- allows a reference to a table without an explicit Primary key (fixes #1119 ), 
- allows a reference to non Primary keys, using the keyword `References` (fixes #999, fixes #957 )
- allows simple/field Foreign Keys to have Cascade Options (fixes #1118)

The extended syntax for Foreign Key is like this:
`Foreign <otherTable> [OnDelete...] [OnUpdate...] <fkeyName> list_of_foreign_fields [References list_of_parent_fields]`

It's still a _WIP_ because:
- Some postgres specific implementation is missing (see commit Support Cascade options for SQLite )
- Currently when the `References` keyword is used, there is no check for Unique constraint, so it's the user's responsibility to only refer to unique fields. Should we change this? ie we could only reference Unique keys or change the syntax after `References` to accept a unique key name instead of a list of fields. This can be too restrictive though, since the user may ensure uniqueness through other ways (ie unique indexes) which we can't check. Any opinions?

Before submitting your PR, check that you've:

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
