### PR TITLE
fix PersistDbSpecific escaping in persistent-postgresql

### DIFF
--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -52,6 +52,7 @@ import Data.Aeson.Types (modifyFailure)
 import qualified Data.Attoparsec.ByteString.Char8 as P
 import Data.Bits ((.&.))
 import Data.ByteString (ByteString)
+import qualified Data.ByteString.Builder as BB
 import qualified Data.ByteString.Char8 as B8
 import Data.Char (ord)
 import Data.Conduit
@@ -550,7 +551,7 @@ instance PGFF.FromField Unknown where
         Just dat -> return (Unknown dat)
 
 instance PGTF.ToField Unknown where
-    toField (Unknown a) = PGTF.Escape a
+    toField (Unknown a) = PGTF.Plain $ BB.byteString a
 
 type Getter a = PGFF.FieldParser a
 

--- a/persistent-postgresql/persistent-postgresql.cabal
+++ b/persistent-postgresql/persistent-postgresql.cabal
@@ -52,6 +52,8 @@ test-suite test
                      JSONTest
                      CustomConstraintTest
                      PgIntervalTest
+                     GeographyType
+                     GeographyTest
     ghc-options:     -Wall
 
     build-depends:   base                 >= 4.9 && < 5

--- a/persistent-postgresql/test/GeographyTest.hs
+++ b/persistent-postgresql/test/GeographyTest.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
+
+module GeographyTest (specs) where
+
+import Control.Monad.Trans.Resource (runResourceT)
+import GeographyType
+
+import Database.Persist.TH
+import PgInit
+
+share [mkPersist sqlSettings, mkMigrate "migrateGeographyTest"] [persistLowerCase|
+GeographyTest
+    location Geo
+|]
+
+specs :: Spec
+specs = describe "GeographyTest" $ do
+    it "works" $ asIO $ runResourceT $ runConn $ do
+        -- this test requires PostGIS to be installed
+        extensions :: [Single PersistValue] <- rawSql "SELECT extname FROM pg_extension;" []
+        when ((Single (PersistText "postgis")) `elem` extensions) $ do
+          _ <- rawExecute "DROP TABLE IF EXISTS geography_test;" []
+
+          _ <- runMigrationSilent migrateGeographyTest
+
+          insert_ $ GeographyTest (toPoint 44 44)
+
+          Just (Entity _ GeographyTest{..}) <- selectFirst [] []
+          let (Geo pointByteString) = geographyTestLocation
+          liftIO $ pointByteString @?= "'0101000020E610000000000000000046400000000000004640'"

--- a/persistent-postgresql/test/GeographyType.hs
+++ b/persistent-postgresql/test/GeographyType.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | This type is taken directly from the example given here: https://hackage.haskell.org/package/persistent-2.10.5/docs/Database-Persist-Types.html#t:PersistValue
+module GeographyType where
+
+import PgInit
+import qualified Data.Text as T
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Char8 as B8
+
+data Geo = Geo ByteString deriving (Show, Eq)
+
+instance PersistField Geo where
+  toPersistValue (Geo t) = PersistDbSpecific t
+
+  fromPersistValue (PersistDbSpecific t) = Right $ Geo $ B.concat ["'", t, "'"]
+  fromPersistValue _ = Left "Geo values must be converted from PersistDbSpecific"
+
+instance PersistFieldSql Geo where
+  sqlType _ = SqlOther "GEOGRAPHY(POINT,4326)"
+
+toPoint :: Double -> Double -> Geo
+toPoint lat lon = Geo $ B.concat ["'POINT(", ps $ lon, " ", ps $ lat, ")'"]
+  where ps = B8.pack . show

--- a/persistent-postgresql/test/main.hs
+++ b/persistent-postgresql/test/main.hs
@@ -53,6 +53,7 @@ import qualified UpsertTest
 import qualified CustomConstraintTest
 import qualified LongIdentifierTest
 import qualified PgIntervalTest
+import qualified GeographyTest
 
 type Tuple = (,)
 
@@ -190,3 +191,4 @@ main = do
     CustomConstraintTest.specs
     PgIntervalTest.specs
     ArrayAggTest.specs
+    GeographyTest.specs

--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -394,7 +394,7 @@ data PersistValue = PersistText Text
 --
 -- toPoint :: Double -> Double -> Geo
 -- toPoint lat lon = Geo $ Data.ByteString.concat ["'POINT(", ps $ lon, " ", ps $ lat, ")'"]
---   where ps = Data.Text.pack . show
+--   where ps = Data.ByteString.Char8.pack . show
 -- @
 --
 -- If Foo has a geography field, we can then perform insertions like the following:


### PR DESCRIPTION
Currently, the implementation of `PersistDbSpecific`:
- (in persistent-mysql) ***does not*** escape the given ByteString: https://github.com/yesodweb/persistent/blob/master/persistent-mysql/Database/Persist/MySQL.hs#L239
- (in persistent-sqlite) ***does not*** escape the given ByteString: https://github.com/yesodweb/persistent/blob/master/persistent-sqlite/Database/Sqlite.hs#L470
- (in persistent-postgresql) ***does*** escape the given ByteString (with single quotes): https://github.com/yesodweb/persistent/blob/master/persistent-postgresql/Database/Persist/Postgresql.hs#L553

This inconsistency led me to believe that the persistent-postgresql behavior is a bug. And indeed, looking at Persistent's own documentation:

https://github.com/yesodweb/persistent/blob/7f4abe94941c2ccea0f27d3e7d9036e9d100a79a/persistent/Database/Persist/Types/Base.hs#L381-L405

We can see that `toPoint` escapes the `POINT(44 44)` entry to become `'POINT(44 44)'`, and when inserting, persistent-postgresql will once again escape this to become `''POINT(44 44)''` which will lead to a runtime error. This further indicates that the escaping in persistent-postgresql is a bug.

I wrote a test to show this. It fails with the currently implementation of `instance PGTF.toField Unknown`:

```
GeographyTest
  works FAILED [1]

Failures:

  test/GeographyTest.hs:30:5: 
  1) GeographyTest works
       uncaught exception: SqlError
       SqlError {sqlState = "XX000", sqlExecStatus = FatalError, sqlErrorMsg = "parse error - invalid geometry", sqlErrorDetail = "", sqlErrorHint = "\"'P\" <-- parse error at position 2 within geometry"}

  To rerun use: --match "/GeographyTest/works/"

Randomized with seed 146528878

Finished in 0.0513 seconds
1 example, 1 failure
```

My change to stop escaping `PersistDbSpecific` fixes the test.

This is related to my investigation/implementation in #1122. I chose to make this a standalone PR to more clearly demonstrate the issue.

cc/ @MaxGabriel @friedbrice @parsonsmatt 
