### PR TITLE
Exists query

### DIFF
--- a/persistent-mongoDB/ChangeLog.md
+++ b/persistent-mongoDB/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 2.11.0
 
-* Naive implementation of `exists` function from `PersistQueryRead` type class using `count`. [#1070](https://github.com/yesodweb/persistent/pull/1070/files)
+* Naive implementation of `exists` function from `PersistQueryRead` type class using `count`. [#1131](https://github.com/yesodweb/persistent/pull/1131/files)
 
 ## 2.10.0.1
 

--- a/persistent-mongoDB/ChangeLog.md
+++ b/persistent-mongoDB/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 2.11.0
 
-* Naive implementation of `exists`function from `PersistQueryRead` type class using `count`.
+* Naive implementation of `exists` function from `PersistQueryRead` type class using `count`. [#1070](https://github.com/yesodweb/persistent/pull/1070/files)
 
 ## 2.10.0.1
 

--- a/persistent-mongoDB/ChangeLog.md
+++ b/persistent-mongoDB/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for persistent-mongoDB
 
+## 2.11.0
+
+* Naive implementation of `exists`function from `PersistQueryRead` type class using `count`.
+
 ## 2.10.0.1
 
 * Remove unnecessary deriving of Typeable [#1114](https://github.com/yesodweb/persistent/pull/1114)

--- a/persistent-mongoDB/Database/Persist/MongoDB.hs
+++ b/persistent-mongoDB/Database/Persist/MongoDB.hs
@@ -691,6 +691,10 @@ instance PersistQueryRead DB.MongoContext where
         query = DB.select (filtersToDoc filts) $
                   collectionName $ dummyFromFilts filts
 
+    exists filts = do
+        cnt <- count filts
+        pure (cnt > 0)
+
     -- | uses cursor option NoCursorTimeout
     -- If there is no sorting, it will turn the $snapshot option on
     -- and explicitly closes the cursor when done

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -661,17 +661,17 @@ migrate' allDefs getter entity = fmap (fmap $ map showAlterDb) $ do
     old <- getColumns getter entity newcols'
     case partitionEithers old of
         ([], old'') -> do
-            exists <-
+            exists' <-
                 if null old
                     then doesTableExist getter name
                     else return True
-            return $ Right $ migrationText exists old''
+            return $ Right $ migrationText exists' old''
         (errs, _) -> return $ Left errs
   where
     name = entityDB entity
     (newcols', udefs, fdefs) = postgresMkColumns allDefs entity
-    migrationText exists old''
-        | not exists =
+    migrationText exists' old''
+        | not exists' =
             createText newcols fdefs udspair
         | otherwise =
             let (acs, ats) =
@@ -1401,8 +1401,8 @@ mockMigrate allDefs _ entity = fmap (fmap $ map showAlterDb) $ do
         (errs, _) -> return $ Left errs
   where
     name = entityDB entity
-    migrationText exists old'' =
-        if not exists
+    migrationText exists' old'' =
+        if not exists'
             then createText newcols fdefs udspair
             else let (acs, ats) = getAlters allDefs entity (newcols, udspair) old'
                      acs' = map (AlterColumn name) acs

--- a/persistent-sqlite/ChangeLog.md
+++ b/persistent-sqlite/ChangeLog.md
@@ -4,7 +4,7 @@
 
 * [#1060](https://github.com/yesodweb/persistent/pull/1060)
   * The QuasiQuoter now supports `OnDelete` and `OnUpdate` cascade options.
-* [#1069](https://github.com/yesodweb/persistent/pull/1070)
+* [#1070](https://github.com/yesodweb/persistent/pull/1070)
   * Provide `exists` function as required by `PersistQueryRead` type class.
 
 * Remove unnecessary deriving of Typeable [#1114](https://github.com/yesodweb/persistent/pull/1114)

--- a/persistent-sqlite/ChangeLog.md
+++ b/persistent-sqlite/ChangeLog.md
@@ -4,7 +4,7 @@
 
 * [#1060](https://github.com/yesodweb/persistent/pull/1060)
   * The QuasiQuoter now supports `OnDelete` and `OnUpdate` cascade options.
-* [#1070](https://github.com/yesodweb/persistent/pull/1070)
+* [#1131](https://github.com/yesodweb/persistent/pull/1131)
   * Provide `exists` function as required by `PersistQueryRead` type class.
 
 * Remove unnecessary deriving of Typeable [#1114](https://github.com/yesodweb/persistent/pull/1114)

--- a/persistent-sqlite/ChangeLog.md
+++ b/persistent-sqlite/ChangeLog.md
@@ -4,6 +4,8 @@
 
 * [#1060](https://github.com/yesodweb/persistent/pull/1060)
   * The QuasiQuoter now supports `OnDelete` and `OnUpdate` cascade options.
+* [#1069](https://github.com/yesodweb/persistent/pull/1070)
+  * Provide `exists` function as required by `PersistQueryRead` type class.
 
 * Remove unnecessary deriving of Typeable [#1114](https://github.com/yesodweb/persistent/pull/1114)
 

--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -859,6 +859,7 @@ instance (PersistQueryRead b) => PersistQueryRead (RawSqlite b) where
     selectFirst filts opts = withReaderT _persistentBackend $ selectFirst filts opts
     selectKeysRes filts opts = withReaderT _persistentBackend $ selectKeysRes filts opts
     count = withReaderT _persistentBackend . count
+    exists = withReaderT _persistentBackend . exists
 
 instance (PersistQueryWrite b) => PersistQueryWrite (RawSqlite b) where
     updateWhere filts updates = withReaderT _persistentBackend $ updateWhere filts updates

--- a/persistent-test/src/PersistentTest.hs
+++ b/persistent-test/src/PersistentTest.hs
@@ -139,6 +139,14 @@ specsWith runDb = describe "persistent" $ do
       Just mic29 <- get micK
       personAge mic29 @== 29
 
+      let louis = Person "Louis" 55 $ Just "brown"
+      ex0 <- exists [PersonName ==. "Louis"]
+      ex0 @== False
+      louisK <- insert louis
+      ex1 <- exists [PersonName ==. "Louis"]
+      ex1 @== True
+      delete louisK
+
       let eli = Person "Eliezer" 2 $ Just "blue"
       _ <- insert eli
       pasc <- selectList [] [Asc PersonAge]

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -36,7 +36,7 @@
     ```haskell
     deriving stock instance Show (Unique User)
     ```
-* [#1069](https://github.com/yesodweb/persistent/pull/1070)
+* [#1070](https://github.com/yesodweb/persistent/pull/1070)
   * Add an `exists` function to the `PersistQueryRead` type class.
 
 ## 2.10.5.2

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -36,7 +36,7 @@
     ```haskell
     deriving stock instance Show (Unique User)
     ```
-* [#1070](https://github.com/yesodweb/persistent/pull/1070)
+* [#1131](https://github.com/yesodweb/persistent/pull/1131)
   * Add an `exists` function to the `PersistQueryRead` type class.
 
 ## 2.10.5.2

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -36,6 +36,8 @@
     ```haskell
     deriving stock instance Show (Unique User)
     ```
+* [#1069](https://github.com/yesodweb/persistent/pull/1070)
+  * Add an `exists` function to the `PersistQueryRead` type class.
 
 ## 2.10.5.2
 

--- a/persistent/Database/Persist/Class/PersistQuery.hs
+++ b/persistent/Database/Persist/Class/PersistQuery.hs
@@ -48,6 +48,9 @@ class (PersistCore backend, PersistStoreRead backend) => PersistQueryRead backen
     count :: (MonadIO m, PersistRecordBackend record backend)
           => [Filter record] -> ReaderT backend m Int
 
+    -- | Check if there is at least one record fulfilling the given criterien.
+    --
+    -- @since 2.11
     exists :: (MonadIO m, PersistRecordBackend record backend)
            => [Filter record] -> ReaderT backend m Bool
 

--- a/persistent/Database/Persist/Class/PersistQuery.hs
+++ b/persistent/Database/Persist/Class/PersistQuery.hs
@@ -48,7 +48,7 @@ class (PersistCore backend, PersistStoreRead backend) => PersistQueryRead backen
     count :: (MonadIO m, PersistRecordBackend record backend)
           => [Filter record] -> ReaderT backend m Int
 
-    -- | Check if there is at least one record fulfilling the given criterien.
+    -- | Check if there is at least one record fulfilling the given criterion.
     --
     -- @since 2.11
     exists :: (MonadIO m, PersistRecordBackend record backend)

--- a/persistent/Database/Persist/Class/PersistQuery.hs
+++ b/persistent/Database/Persist/Class/PersistQuery.hs
@@ -48,6 +48,9 @@ class (PersistCore backend, PersistStoreRead backend) => PersistQueryRead backen
     count :: (MonadIO m, PersistRecordBackend record backend)
           => [Filter record] -> ReaderT backend m Int
 
+    exists :: (MonadIO m, PersistRecordBackend record backend)
+           => [Filter record] -> ReaderT backend m Bool
+
 -- | Backends supporting conditional write operations
 class (PersistQueryRead backend, PersistStoreWrite backend) => PersistQueryWrite backend where
     -- | Update individual fields on any record matching the given criterion.

--- a/persistent/Database/Persist/Sql/Orphan/PersistQuery.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistQuery.hs
@@ -69,7 +69,11 @@ instance PersistQueryRead SqlBackend where
         withRawQuery sql (getFiltsValues conn filts) $ do
             mm <- CL.head
             case mm of
-              Just [PersistBool b] -> return b
+              Just [PersistBool b]  -> return b
+              Just [PersistInt64 i] -> return $ i > 0
+              Just [PersistByteString i] -> case readInteger i of -- gb mssql
+                                              Just (ret,"") -> return $ ret > 0
+                                              xs -> error $ "invalid number i["++show i++"] xs[" ++ show xs ++ "]"
               Just xs -> error $ "count:invalid sql  return xs["++show xs++"] sql["++show sql++"]"
               Nothing -> error $ "count:invalid sql returned nothing sql["++show sql++"]"
       where

--- a/persistent/Database/Persist/Sql/Orphan/PersistQuery.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistQuery.hs
@@ -69,14 +69,14 @@ instance PersistQueryRead SqlBackend where
         withRawQuery sql (getFiltsValues conn filts) $ do
             mm <- CL.head
             case mm of
-              Just [PersistBool b]  -> return b
-              Just [PersistInt64 i] -> return $ i > 0
+              Just [PersistBool b]  -> return b -- Postgres
+              Just [PersistInt64 i] -> return $ i > 0 -- MySQL, SQLite
               Just [PersistDouble i] -> return $ (truncate i :: Int64) > 0 -- gb oracle
               Just [PersistByteString i] -> case readInteger i of -- gb mssql
                                               Just (ret,"") -> return $ ret > 0
                                               xs -> error $ "invalid number i["++show i++"] xs[" ++ show xs ++ "]"
-              Just xs -> error $ "count:invalid sql  return xs["++show xs++"] sql["++show sql++"]"
-              Nothing -> error $ "count:invalid sql returned nothing sql["++show sql++"]"
+              Just xs -> error $ "PersistQuery.exists: Expected a boolean, int, double, or bytestring; got: " ++ show xs ++ " for query: " ++ show sql
+              Nothing -> error $ "PersistQuery.exists: Expected a boolean, int, double, or bytestring; got: Nothing for query: " ++ show sql
       where
         t = entityDef $ dummyFromFilts filts
 

--- a/persistent/Database/Persist/Sql/Orphan/PersistQuery.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistQuery.hs
@@ -71,6 +71,7 @@ instance PersistQueryRead SqlBackend where
             case mm of
               Just [PersistBool b]  -> return b
               Just [PersistInt64 i] -> return $ i > 0
+              Just [PersistDouble i] -> return $ (truncate i :: Int64) > 0 -- gb oracle
               Just [PersistByteString i] -> case readInteger i of -- gb mssql
                                               Just (ret,"") -> return $ ret > 0
                                               xs -> error $ "invalid number i["++show i++"] xs[" ++ show xs ++ "]"


### PR DESCRIPTION
**Note**: Since I no longer have access to the previous repository, this replaces PR #1070 . I've applied the suggestions from that PR and I'm updating the changelog files to reflect the new PR number.

This addresses #1069 by adding an `exists` function to the `PersistQueryRead` type class, which already provides the `count` function. The `count` function will be used for a fallback implementation for backends that don't provide a separate existence check.

Before submitting your PR, check that you've:

- [X] Bumped the version number (can we get this into 2.11?)
- [X] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [X] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->