### PR TITLE
RFC: TypeError instance for PersistEntity (Entity rec)

### DIFF
--- a/persistent/Database/Persist/Class/PersistEntity.hs
+++ b/persistent/Database/Persist/Class/PersistEntity.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
@@ -22,6 +23,7 @@ module Database.Persist.Class.PersistEntity
     , toPersistValueEnum, fromPersistValueEnum
     ) where
 
+import GHC.TypeLits (TypeError(..))
 import Data.Aeson (ToJSON (..), withObject, FromJSON (..), fromJSON, object, (.:), (.=), Value (Object))
 import qualified Data.Aeson.Parser as AP
 import Data.Aeson.Types (Parser,Result(Error,Success))
@@ -104,6 +106,24 @@ class ( PersistField (Key record), ToJSON (Key record), FromJSON (Key record)
     -- @since 2.11.0.0
     keyFromRecordM :: Maybe (record -> Key record)
     keyFromRecordM = Nothing
+
+instance (TypeError ('Text "no"), rec ~ ()) => PersistEntity (Entity rec) where
+  type PersistEntityBackend (Entity rec) = Void
+
+  data Key (Entity rec)
+
+  keyToValues = undefined
+  keyFromValues = undefiend
+  persistIdField = undefined
+  entityDef = undefined
+  data EntityField rec a
+  persistFieldDef = undefined
+  toPersistFields = undefined
+  fromPersistValues = undefined
+  data Unique (Entity rec)
+  persistUniqueToFieldNames =undefined
+  fieldLens = undefined
+  keyFromRecordM = undefined
 
 type family BackendSpecificUpdate backend record
 


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->

This PR implements a dummy instance for `PersistEntity` on the `Entity` type that fails with a custom type error.

# Motivation

I've helped a ton of folks debug issues where `persistent`'s "figure it out" machinery infers something like `Key (Entity rec)`, and then nothing works, and the errors are always pretty far from the actual problem.

```haskell
Just (Entity userId user) <- get (clientUserId client)
```

The real error is that `get` doesn't return an `Entity`. But GHC doesn't know that - it's typed like:

```haskell
get :: (PersistEntity rec) => Key rec -> SqlPersistT m (Maybe rec)
```

GHC's unification process results in `rec ~ Entity User`, which gives us:

```haskell
get :: (PersistEntity (Entity User)) => Key (Entity User) -> SqlPersistT m (Maybe (Entity User))
```

Then GHC complains that `clientUserId client` doesn't match type `Key (Entity User)`. If you're not a `persistent` user, you may not know what the problem is there.

Having the type-error instance should mean that type inference hits it and reports the problem. I need to do further testing on this to verify it does what I want, but it *should* work.

# Alternatively,

Anyone got an alternative ideas to make this nicer?

Defining an instance of `PersistEntity (Entity rec)` that delegates to the underlying `rec` would be kinda nasty due to the associated type families. eg: `newtype Key (Entity rec) = EntityKey (Key rec); newtype EntityField (Entity rec) a = EntityFieldRec (EntityField rec a)`.