### PR TITLE
Use explicit ordering in RawSqlTest

### DIFF
--- a/persistent-test/ChangeLog.md
+++ b/persistent-test/ChangeLog.md
@@ -1,5 +1,9 @@
 ## Unreleased changes
 
+## 2.0.3.3
+
+* Fix RawSqlTest, which could fail non-deterministically for Postgres [#1139](https://github.com/yesodweb/persistent/pull/1139)
+
 ## 2.0.3.2
 
 * Remove unnecessary deriving of Typeable [#1114](https://github.com/yesodweb/persistent/pull/1114)

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -1,5 +1,5 @@
 name:            persistent-test
-version:         2.0.3.2
+version:         2.0.3.3
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/persistent-test/src/RawSqlTest.hs
+++ b/persistent-test/src/RawSqlTest.hs
@@ -37,13 +37,15 @@ specsWith runDb = describe "rawSql" $ do
         escape <- getEscape
         person <- getTableName (error "rawSql Person" :: Person)
         name   <- getFieldName PersonName
+        pet <- getTableName (error "rawSql Pet" :: Pet)
+        petName   <- getFieldName PetName
         let query = T.concat [ "SELECT ??, ?? "
                              , "FROM ", person
                              , ", ", escape "Pet"
                              , " WHERE ", person, ".", escape "age", " >= ? "
                              , "AND ", escape "Pet", ".", escape "ownerId", " = "
                                      , person, ".", escape "id"
-                             , " ORDER BY ", person, ".", name
+                             , " ORDER BY ", person, ".", name, ", ", pet, ".", petName
                              ]
         ret <- rawSql query [PersistInt64 20]
         liftIO $ ret @?= [ (Entity p1k p1, Entity a1k a1)


### PR DESCRIPTION
I was non-deterministically getting an error on this test, where the pets were misordered. I'm having trouble reproducing, but I believe the issue is that Postgres' order is non-deterministic if not specified (in my experience, it can be Postgres version dependent). I believe the test as-is is incorrect without specifying the pet order, for Postgres.

[Postgres docs warn:](https://www.postgresql.org/docs/12/queries-order.html)

> After a query has produced an output table (after the select list has been processed) it can optionally be sorted. If sorting is not chosen, the rows will be returned in an unspecified order. The actual order in that case will depend on the scan and join plan types and the order on disk, but it must not be relied on. A particular output ordering can only be guaranteed if the sort step is explicitly chosen.

This commit orders the pets explicitly. This ensures when we get both of Mathias' pets, we get "Rodolfo" first and "Zeno" second, as the assertions require.

Before submitting your PR, check that you've:

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
