### PR TITLE
Add API for checking uniqueness constraints for updates

### DIFF
--- a/persistent-test/src/PersistUniqueTest.hs
+++ b/persistent-test/src/PersistUniqueTest.hs
@@ -31,17 +31,18 @@ specsWith runDb = describe "custom primary key" $ do
     Just (Entity _ insertedFoValue) <- insertUniqueEntity fo
     Nothing <- insertUniqueEntity fo
     fo @== insertedFoValue
-  it "checkUniqueUpdate" $ runDb $ do
+  it "checkUniqueUpdateable" $ runDb $ do
+    let f = 3
     let b = 5
-    let fo = Fo 3 b
+    let fo = Fo f b
     k <- insert fo
     Just _ <- checkUnique fo -- conflicts with itself
 
-    let fo' = Fo 4 b
+    let fo' = Fo (f + 1) b
     Just _ <- checkUnique fo' -- conflicts with fo
     Nothing <- checkUniqueUpdateable $ Entity k fo' -- but fo can be updated to fo'
 
-    let fo'' = Fo 3 (b + 1)
+    let fo'' = Fo (f + 1) (b + 1)
     _ <- insert fo''
     Just (UniqueBar conflict) <- checkUniqueUpdateable $ Entity k fo'' -- fo can't be updated to fo''
     conflict @== b + 1

--- a/persistent-test/src/PersistUniqueTest.hs
+++ b/persistent-test/src/PersistUniqueTest.hs
@@ -31,3 +31,17 @@ specsWith runDb = describe "custom primary key" $ do
     Just (Entity _ insertedFoValue) <- insertUniqueEntity fo
     Nothing <- insertUniqueEntity fo
     fo @== insertedFoValue
+  it "checkUniqueUpdate" $ runDb $ do
+    let b = 5
+    let fo = Fo 3 b
+    k <- insert fo
+    Just _ <- checkUnique fo -- conflicts with itself
+
+    let fo' = Fo 4 b
+    Just _ <- checkUnique fo' -- conflicts with fo
+    Nothing <- checkUniqueUpdateable $ Entity k fo' -- but fo can be updated to fo'
+
+    let fo'' = Fo 3 (b + 1)
+    _ <- insert fo''
+    Just (UniqueBar conflict) <- checkUniqueUpdateable $ Entity k fo'' -- fo can't be updated to fo''
+    conflict @== b + 1

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -38,6 +38,9 @@
     ```
 * [#1117](https://github.com/yesodweb/persistent/issues/1117)
   * Allow parsing UTCTimes from sqlite with the format "%F %T%Q" as well, instead of only "%FT%T%Q".
+* [#1140](https://github.com/yesodweb/persistent/pull/1140)
+  * A new function `checkUniqueUpdateable` allows you to check uniqueness
+    constraints on an entity update without having to update it.
 
 ## 2.10.5.2
 

--- a/persistent/Database/Persist/Class.hs
+++ b/persistent/Database/Persist/Class.hs
@@ -99,6 +99,7 @@ module Database.Persist.Class
     , insertUniqueEntity
     , replaceUnique
     , checkUnique
+    , checkUniqueUpdateable
     , onlyUnique
 
     -- * PersistQuery

--- a/persistent/Database/Persist/Class/PersistUnique.hs
+++ b/persistent/Database/Persist/Class/PersistUnique.hs
@@ -17,6 +17,7 @@ module Database.Persist.Class.PersistUnique
   , insertUniqueEntity
   , replaceUnique
   , checkUnique
+  , checkUniqueUpdateable
   , onlyUnique
   , defaultUpsertBy
   , defaultPutMany
@@ -571,6 +572,47 @@ checkUniqueKeys (x:xs) = do
         Nothing -> checkUniqueKeys xs
         Just _ -> return (Just x)
 
+-- | Check whether there are any conflicts for unique keys with this entity and
+-- existing entities in the database.
+--
+-- Returns 'Nothing' if the entity would stay unique, and could thus safely be updated.
+-- on a conflict returns the conflicting key
+--
+-- This is similar to 'checkUnique', except it's useful for updating - when the
+-- particular entity already exists, it would normally conflict with itself.
+-- This variant ignores those conflicts
+--
+-- === __Example usage__
+--
+-- We use <#schema-persist-unique-1 schema-1> and <#dataset-persist-unique-1 dataset-1> here.
+--
+-- This would be 'Nothing':
+--
+-- > mAlanConst <- checkUnique $ User "Alan" 70
+--
+-- While this would be 'Just' because SPJ already exists:
+--
+-- > mSpjConst <- checkUnique $ User "SPJ" 60
+checkUniqueUpdateable
+    :: forall record backend m. ( MonadIO m
+       , PersistRecordBackend record backend
+       , PersistUniqueRead backend)
+    => Entity record -> ReaderT backend m (Maybe (Unique record))
+checkUniqueUpdateable (Entity key record) = checkUniqueKeysUpdateable key (persistUniqueKeys record)
+
+checkUniqueKeysUpdateable
+    :: forall record backend m. ( MonadIO m
+       , PersistUniqueRead backend
+       , PersistRecordBackend record backend)
+    => Key record -> [Unique record] -> ReaderT backend m (Maybe (Unique record))
+checkUniqueKeysUpdateable _ [] = return Nothing
+checkUniqueKeysUpdateable key (x:xs) = do
+    y <- getBy x
+    case y of
+        Nothing -> checkUniqueKeysUpdateable key xs
+        Just (Entity k _)
+          | key == k -> checkUniqueKeysUpdateable key xs
+        Just _ ->  return (Just x)
 
 -- | The slow but generic 'upsertBy' implementation for any 'PersistUniqueRead'.
 -- * Lookup corresponding entities (if any) 'getBy'.

--- a/persistent/Database/Persist/Class/PersistUnique.hs
+++ b/persistent/Database/Persist/Class/PersistUnique.hs
@@ -593,6 +593,8 @@ checkUniqueKeys (x:xs) = do
 -- While this would be 'Just' because SPJ already exists:
 --
 -- > mSpjConst <- checkUnique $ User "SPJ" 60
+--
+-- @since 2.11.0.0
 checkUniqueUpdateable
     :: forall record backend m. ( MonadIO m
        , PersistRecordBackend record backend


### PR DESCRIPTION
Entities which are already in the DB will conflict with themselves when using `checkUnique`, unless the value of each unique key is changed. This adds an alternative `checkUniqueUpdateable` which ignores conflicts from an entity with itself, so that uniqueness constraints can be checked without an update.

Before submitting your PR, check that you've:

- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
