### PR TITLE
GitHub Actions CI

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -52,6 +52,8 @@ jobs:
            postgresql db: persistent
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.3.0
+      - name: Start Redis
+        uses: supercharge/redis-github-action@1.1.0
       - run: cabal v2-update
       - run: cabal v2-freeze $CONFIG
       - uses: actions/cache@v2

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -43,6 +43,8 @@ jobs:
         with:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: ${{ matrix.cabal }}
+      - name: Check MySQL connection
+        run: mysql -utravis -pesqutest -h127.0.0.1 --port=33306 esqutest -e "SELECT 1;"
       - uses: harmon758/postgresql-action@v1
         with:
            postgresql version: '12'  # See https://hub.docker.com/_/postgres for available versions  
@@ -54,12 +56,6 @@ jobs:
            #     mysql database: 'test' # Optional, default value is "test". The specified database which will be create
            #     mysql user: 'test' # Required if "mysql root password" is empty, default is empty. The superuser for the specified database. Can use secrets, too
            #     mysql password: 'test' # Required if "mysql user" exists. The password for the "mysql user"
-      - name: Create MySQL
-        run: |
-          mysql -uroot -proot -e "CREATE DATABASE test;"
-          mysql -uroot -proot -e "CREATE USER 'test'@'localhost' IDENTIFIED BY 'test';"
-          mysql -uroot -proot -e "GRANT ALL PRIVILEGES ON *.* TO 'test'@'localhost';"
-          mysql -uroot -proot -e "FLUSH PRIVILEGES;"
       - run: cabal v2-update
       - run: cabal v2-freeze $CONFIG
       - uses: actions/cache@v2

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -35,11 +35,11 @@ jobs:
            #     mysql user: 'test' # Required if "mysql root password" is empty, default is empty. The superuser for the specified database. Can use secrets, too
            #     mysql password: 'test' # Required if "mysql user" exists. The password for the "mysql user"
       - name: Create MySQL
-        run:
-          - mysql -uroot -proot -e "CREATE DATABASE test;"
-          - mysql -uroot -proot -e "CREATE USER 'test'@'localhost' IDENTIFIED BY 'test';"
-          - mysql -uroot -proot -e "GRANT ALL PRIVILEGES ON *.* TO 'test'@'localhost';"
-          - mysql -uroot -proot -e "FLUSH PRIVILEGES;"
+        run: |
+          mysql -uroot -proot -e "CREATE DATABASE test;"
+          mysql -uroot -proot -e "CREATE USER 'test'@'localhost' IDENTIFIED BY 'test';"
+          mysql -uroot -proot -e "GRANT ALL PRIVILEGES ON *.* TO 'test'@'localhost';"
+          mysql -uroot -proot -e "FLUSH PRIVILEGES;"
       - run: cabal v2-update
       - run: cabal v2-freeze $CONFIG
       - uses: actions/cache@v2

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -64,7 +64,6 @@ jobs:
             ${{ runner.os }}-${{ matrix.ghc }}-
       - run: cabal v2-build all --disable-optimization --only-dependencies $CONFIG
       - run: cabal v2-build all --disable-optimization $CONFIG
-        # TODO: get this running again. disabled to get a cache on dependencies.
-        # - run: cabal v2-test all --disable-optimization $CONFIG
+      - run: cabal v2-test all --disable-optimization $CONFIG
       - run: cabal v2-haddock all $CONFIG
       - run: cabal v2-sdist all

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -44,7 +44,7 @@ jobs:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: ${{ matrix.cabal }}
       - name: Check MySQL connection
-        run: mysql -utravis -pesqutest -h127.0.0.1 --port=33306 esqutest -e "SELECT 1;"
+        run: mysql -utest -ptest -h127.0.0.1 --port=33306 test -e "SELECT 1;"
       - uses: harmon758/postgresql-action@v1
         with:
            postgresql version: '12'  # See https://hub.docker.com/_/postgres for available versions  

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -48,7 +48,8 @@ jobs:
       - uses: harmon758/postgresql-action@v1
         with:
            postgresql version: '12'  # See https://hub.docker.com/_/postgres for available versions  
-           postgresql user: postgres
+           postgresql user: perstest
+           postgresql password: perstest
            postgresql db: persistent
       - name: Start MongoDB
         uses: supercharge/mongodb-github-action@1.3.0

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,0 +1,50 @@
+name: CI
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types:
+      - opened
+      - synchronize
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        cabal: ["3.2"]
+        ghc: ["8.6.5", "8.8.3", "8.10.1"]
+    env:
+      CONFIG: "--enable-tests --enable-benchmarks"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-haskell@v1.1.2
+        id: setup-haskell-cabal
+        with:
+          ghc-version: ${{ matrix.ghc }}
+          cabal-version: ${{ matrix.cabal }}
+      - uses: harmon758/postgresql-action@v1
+        with:
+           postgresql version: '12'  # See https://hub.docker.com/_/postgres for available versions  
+           postgresql user: postgres
+           postgresql db: test
+      - uses: mirromutth/mysql-action@v1.1
+        with:
+          mysql version: '8.0' # Optional, default value is "latest". The version of the MySQL
+          mysql database: 'test' # Optional, default value is "test". The specified database which will be create
+          mysql user: 'test' # Required if "mysql root password" is empty, default is empty. The superuser for the specified database. Can use secrets, too
+          mysql password: 'test' # Required if "mysql user" exists. The password for the "mysql user"
+      - run: cabal v2-update
+      - run: cabal v2-freeze $CONFIG
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
+            dist-newstyle
+          key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.ghc }}-
+      - run: cabal v2-build all $CONFIG
+      - run: cabal v2-test all $CONFIG
+      - run: cabal v2-haddock all $CONFIG
+      - run: cabal v2-sdist all

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -9,6 +9,26 @@ on:
       - synchronize
 jobs:
   build:
+    services:
+      # mysql-service Label used to access the service container
+      mysql-service:
+        # Docker Hub image (also with version)
+        image: mysql:8.0
+        env:
+          ## Accessing to Github secrets, where you can store your configuration
+          MYSQL_USER: test
+          MYSQL_PASSWORD: test
+          MYSQL_ROOT_PASSWORD: test
+          MYSQL_DATABASE: test
+        ## map the "external" 33306 port with the "internal" 3306
+        ports:
+          - 33306:3306
+        # Set health checks to wait until mysql database has started (it takes some seconds to start)
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -49,13 +49,9 @@ jobs:
         with:
            postgresql version: '12'  # See https://hub.docker.com/_/postgres for available versions  
            postgresql user: postgres
-           postgresql db: test
-           # - uses: mirromutth/mysql-action@v1.1
-           #   with:
-           #     mysql version: '8.0' # Optional, default value is "latest". The version of the MySQL
-           #     mysql database: 'test' # Optional, default value is "test". The specified database which will be create
-           #     mysql user: 'test' # Required if "mysql root password" is empty, default is empty. The superuser for the specified database. Can use secrets, too
-           #     mysql password: 'test' # Required if "mysql user" exists. The password for the "mysql user"
+           postgresql db: persistent
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@1.3.0
       - run: cabal v2-update
       - run: cabal v2-freeze $CONFIG
       - uses: actions/cache@v2

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -28,14 +28,18 @@ jobs:
            postgresql version: '12'  # See https://hub.docker.com/_/postgres for available versions  
            postgresql user: postgres
            postgresql db: test
-      - name: Shutdown Ubuntu MySQL (SUDO)
-        run: sudo service mysql stop
-      - uses: mirromutth/mysql-action@v1.1
-        with:
-          mysql version: '8.0' # Optional, default value is "latest". The version of the MySQL
-          mysql database: 'test' # Optional, default value is "test". The specified database which will be create
-          mysql user: 'test' # Required if "mysql root password" is empty, default is empty. The superuser for the specified database. Can use secrets, too
-          mysql password: 'test' # Required if "mysql user" exists. The password for the "mysql user"
+           # - uses: mirromutth/mysql-action@v1.1
+           #   with:
+           #     mysql version: '8.0' # Optional, default value is "latest". The version of the MySQL
+           #     mysql database: 'test' # Optional, default value is "test". The specified database which will be create
+           #     mysql user: 'test' # Required if "mysql root password" is empty, default is empty. The superuser for the specified database. Can use secrets, too
+           #     mysql password: 'test' # Required if "mysql user" exists. The password for the "mysql user"
+      - name: Create MySQL
+        run:
+          - mysql -uroot -proot -e "CREATE DATABASE test;"
+          - mysql -uroot -proot -e "CREATE USER 'test'@'localhost' IDENTIFIED BY 'test';"
+          - mysql -uroot -proot -e "GRANT ALL PRIVILEGES ON *.* TO 'test'@'localhost';"
+          - mysql -uroot -proot -e "FLUSH PRIVILEGES;"
       - run: cabal v2-update
       - run: cabal v2-freeze $CONFIG
       - uses: actions/cache@v2

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -28,6 +28,8 @@ jobs:
            postgresql version: '12'  # See https://hub.docker.com/_/postgres for available versions  
            postgresql user: postgres
            postgresql db: test
+      - name: Shutdown Ubuntu MySQL (SUDO)
+        run: sudo service mysql stop
       - uses: mirromutth/mysql-action@v1.1
         with:
           mysql version: '8.0' # Optional, default value is "latest". The version of the MySQL

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -35,7 +35,7 @@ jobs:
         cabal: ["3.2"]
         ghc: ["8.6.5", "8.8.3", "8.10.1"]
     env:
-      CONFIG: "--enable-tests --enable-benchmarks"
+      CONFIG: "--enable-tests"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-haskell@v1.1.2
@@ -66,8 +66,8 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.ghc }}-
-      - run: cabal v2-build all --only-dependencies $CONFIG
-      - run: cabal v2-build all $CONFIG
-      - run: cabal v2-test all $CONFIG
+      - run: cabal v2-build all --disable-optimization --only-dependencies $CONFIG
+      - run: cabal v2-build all --disable-optimization $CONFIG
+      - run: cabal v2-test all --disable-optimization $CONFIG
       - run: cabal v2-haddock all $CONFIG
       - run: cabal v2-sdist all

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -64,6 +64,7 @@ jobs:
             ${{ runner.os }}-${{ matrix.ghc }}-
       - run: cabal v2-build all --disable-optimization --only-dependencies $CONFIG
       - run: cabal v2-build all --disable-optimization $CONFIG
-      - run: cabal v2-test all --disable-optimization $CONFIG
+        # TODO: get this running again. disabled to get a cache on dependencies.
+        # - run: cabal v2-test all --disable-optimization $CONFIG
       - run: cabal v2-haddock all $CONFIG
       - run: cabal v2-sdist all

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -66,6 +66,7 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.ghc }}-
+      - run: cabal v2-build all --only-dependencies $CONFIG
       - run: cabal v2-build all $CONFIG
       - run: cabal v2-test all $CONFIG
       - run: cabal v2-haddock all $CONFIG

--- a/cabal.project
+++ b/cabal.project
@@ -8,4 +8,3 @@ packages:
   persistent-postgresql
   persistent-redis
   persistent-qq
-

--- a/persistent-mysql/test/MyInit.hs
+++ b/persistent-mysql/test/MyInit.hs
@@ -115,6 +115,7 @@ runConn f = do
                         , connectUser     = "test"
                         , connectPassword = "test"
                         , connectDatabase = "test"
+                        , connectPort     = 33306
                         } 1 $ runSqlPool f
     return ()
 

--- a/persistent-mysql/test/MyInit.hs
+++ b/persistent-mysql/test/MyInit.hs
@@ -112,9 +112,9 @@ runConn f = do
                         } 1 $ runSqlPool f
       else withMySQLPool baseConnectInfo
                         { connectHost     = "localhost"
-                        , connectUser     = "travis"
-                        , connectPassword = ""
-                        , connectDatabase = "persistent"
+                        , connectUser     = "test"
+                        , connectPassword = "test"
+                        , connectDatabase = "test"
                         } 1 $ runSqlPool f
     return ()
 

--- a/persistent-mysql/test/MyInit.hs
+++ b/persistent-mysql/test/MyInit.hs
@@ -111,7 +111,7 @@ runConn f = do
                         , connectDatabase = "test"
                         } 1 $ runSqlPool f
       else withMySQLPool baseConnectInfo
-                        { connectHost     = "localhost"
+                        { connectHost     = "127.0.0.1"
                         , connectUser     = "test"
                         , connectPassword = "test"
                         , connectDatabase = "test"

--- a/persistent-postgresql/test/PgInit.hs
+++ b/persistent-postgresql/test/PgInit.hs
@@ -95,7 +95,7 @@ runConn_ f = do
   let printDebug = if debugPrint then print . fromLogStr else void . return
   flip runLoggingT (\_ _ _ s -> printDebug s) $ do
     if travis
-      then withPostgresqlPool "host=127.0.0.1 port=5432 user=postgres dbname=persistent" 1 $ runSqlPool f
+      then withPostgresqlPool "host=localhost port=5432 user=postgres dbname=persistent" 1 $ runSqlPool f
       else do
         host <- fromMaybe "localhost" <$> liftIO dockerPg
         withPostgresqlPool ("host=" <> host <> " port=5432 user=postgres dbname=test") 1 $ runSqlPool f

--- a/persistent-postgresql/test/PgInit.hs
+++ b/persistent-postgresql/test/PgInit.hs
@@ -95,7 +95,7 @@ runConn_ f = do
   let printDebug = if debugPrint then print . fromLogStr else void . return
   flip runLoggingT (\_ _ _ s -> printDebug s) $ do
     if travis
-      then withPostgresqlPool "host=localhost port=5432 user=postgres dbname=persistent" 1 $ runSqlPool f
+      then withPostgresqlPool "host=127.0.0.1 port=5432 user=postgres dbname=persistent" 1 $ runSqlPool f
       else do
         host <- fromMaybe "localhost" <$> liftIO dockerPg
         withPostgresqlPool ("host=" <> host <> " port=5432 user=postgres dbname=test") 1 $ runSqlPool f

--- a/persistent-postgresql/test/PgInit.hs
+++ b/persistent-postgresql/test/PgInit.hs
@@ -95,10 +95,13 @@ runConn_ f = do
   let printDebug = if debugPrint then print . fromLogStr else void . return
   flip runLoggingT (\_ _ _ s -> printDebug s) $ do
     if travis
-      then withPostgresqlPool "host=localhost port=5432 user=postgres dbname=persistent" 1 $ runSqlPool f
+      then do
+          logInfoN "Running in CI"
+          withPostgresqlPool "host=localhost port=5432 user=perstest password=perstest dbname=persistent" 1 $ runSqlPool f
       else do
-        host <- fromMaybe "localhost" <$> liftIO dockerPg
-        withPostgresqlPool ("host=" <> host <> " port=5432 user=postgres dbname=test") 1 $ runSqlPool f
+          logInfoN "CI not detected"
+          host <- fromMaybe "localhost" <$> liftIO dockerPg
+          withPostgresqlPool ("host=" <> host <> " port=5432 user=postgres dbname=test") 1 $ runSqlPool f
 
 runConnAssert :: SqlPersistT (LoggingT (ResourceT IO)) () -> Assertion
 runConnAssert actions = do

--- a/persistent-test/src/Init.hs
+++ b/persistent-test/src/Init.hs
@@ -55,7 +55,7 @@ import Control.Monad.Trans.Resource
 import Control.Monad.Trans.Resource.Internal
 
 -- re-exports
-import Control.Applicative (liftA2)
+import Control.Applicative (liftA2, (<|>))
 import Control.Exception (SomeException)
 import Control.Monad (void, replicateM, liftM, when, forM_)
 import Control.Monad.Fail (MonadFail)
@@ -124,7 +124,7 @@ isTravis = isCI
 isCI :: IO Bool
 isCI =  do
     env <- liftIO getEnvironment
-    return $ case lookup "TRAVIS" env || lookup "CI" env of
+    return $ case lookup "TRAVIS" env <|> lookup "CI" env of
         Just "true" -> True
         _ -> False
 

--- a/persistent-test/src/Init.hs
+++ b/persistent-test/src/Init.hs
@@ -119,11 +119,15 @@ assertNotEmpty :: (MonadIO m) => [a] -> m ()
 assertNotEmpty xs = liftIO $ assertBool "" (not (null xs))
 
 isTravis :: IO Bool
-isTravis = do
-  env <- liftIO getEnvironment
-  return $ case lookup "TRAVIS" env of
-    Just "true" -> True
-    _ -> False
+isTravis = isCI
+
+isCI :: IO Bool
+isCI =  do
+    env <- liftIO getEnvironment
+    return $ case lookup "TRAVIS" env || lookup "CI" env of
+        Just "true" -> True
+        _ -> False
+
 
 persistSettings :: MkPersistSettings
 persistSettings = sqlSettings { mpsGeneric = True }


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->

This PR implements GitHub Actions as CI as an alternative to Travis.

Alternatively, migrating from `travis-ci.org` to `travis-ci.com` may fix the slowdown issue. But I already got this setup, and it seems like it'll be even nicer. One potential improvement would be a separate CI job for each of the packages, so maintainers can see exactly which database package failed.

Especially if I can get it setup to use the cache from `persistent{,-template}` in `persistent-{mysql,postgres,sqlite}`...