### PR TITLE
Fix markdown link syntax in persistent changelog

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -2,13 +2,13 @@
 
 ## 2.11.0.1
 
-* Docs/Bugs fixes [#1153] https://github.com/yesodweb/persistent/pull/1153
+* Docs/Bugs fixes [#1153](https://github.com/yesodweb/persistent/pull/1153)
   * Fix documentation on `FieldDef.fieldAttrs`.
   * Postgresql backend: Add a space in cascade clause of generated SQL.
 
 ## 2.11.0.0
 
-* Foreign Key improvements [#1121] https://github.com/yesodweb/persistent/pull/1121
+* Foreign Key improvements [#1121](https://github.com/yesodweb/persistent/pull/1121)
   * It is now supported to refer to a table with an auto generated Primary Kay
   * It is now supported to refer to non-primary fields, using the keyword `References`
   * It is now supported to have cascade options for simple/single-field Foreign Keys


### PR DESCRIPTION
(I think it's fine to merge this w/o a new release or mentioning it anywhere)

Before submitting your PR, check that you've:

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
