### PR TITLE
Update persistent-test version bounds

### DIFF
--- a/persistent-test/ChangeLog.md
+++ b/persistent-test/ChangeLog.md
@@ -1,5 +1,10 @@
 ## Unreleased changes
 
+## 2.0.3.5
+
+* Tighter version bounds on `persistent` and `persistent-template`.
+    * [#1155](https://github.com/yesodweb/persistent/pull/1155)
+
 ## 2.0.3.4
 
 * lots of stuff actually :\ should probably start tracking this more!

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -15,90 +15,92 @@ bug-reports:     https://github.com/yesodweb/persistent/issues
 extra-source-files: ChangeLog.md
 
 library
-    exposed-modules: CompositeTest
-                     CustomPersistField
-                     CustomPersistFieldTest
-                     CustomPrimaryKeyReferenceTest
-                     DataTypeTest
-                     EmbedTest
-                     EmbedOrderTest
-                     EmptyEntityTest
-                     EntityEmbedTest
-                     EquivalentTypeTest
-                     ForeignKey
-                     HtmlTest
-                     Init
-                     LargeNumberTest
-                     MaxLenTest
-                     MigrationColumnLengthTest
-                     MigrationIdempotencyTest
-                     MigrationOnlyTest
-                     MigrationTest
-                     MpsNoPrefixTest
-                     MpsCustomPrefixTest
-                     PersistentTest
-                     PersistentTestModels
-                     PersistentTestModelsImports
-                     GeneratedColumnTestSQL
-                     PersistTestPetType
-                     PersistTestPetCollarType
-                     PersistUniqueTest
-                     PrimaryTest
-                     RawSqlTest
-                     ReadWriteTest
-                     RenameTest
-                     Recursive
-                     SumTypeTest
-                     TransactionLevelTest
-                     TreeTest
-                     UniqueTest
-                     UpsertTest
-                     LongIdentifierTest
+    exposed-modules: 
+        CompositeTest
+        CustomPersistField
+        CustomPersistFieldTest
+        CustomPrimaryKeyReferenceTest
+        DataTypeTest
+        EmbedTest
+        EmbedOrderTest
+        EmptyEntityTest
+        EntityEmbedTest
+        EquivalentTypeTest
+        ForeignKey
+        HtmlTest
+        Init
+        LargeNumberTest
+        MaxLenTest
+        MigrationColumnLengthTest
+        MigrationIdempotencyTest
+        MigrationOnlyTest
+        MigrationTest
+        MpsNoPrefixTest
+        MpsCustomPrefixTest
+        PersistentTest
+        PersistentTestModels
+        PersistentTestModelsImports
+        GeneratedColumnTestSQL
+        PersistTestPetType
+        PersistTestPetCollarType
+        PersistUniqueTest
+        PrimaryTest
+        RawSqlTest
+        ReadWriteTest
+        RenameTest
+        Recursive
+        SumTypeTest
+        TransactionLevelTest
+        TreeTest
+        UniqueTest
+        UpsertTest
+        LongIdentifierTest
 
     hs-source-dirs: src
 
-    build-depends:   base                     >= 4.9       && < 5
-                   , persistent
-                   , persistent-template
-                   , aeson                    >= 1.0
-                   , blaze-html               >= 0.9
-                   , bytestring               >= 0.10
-                   , conduit                  >= 1.2.12
-                   , containers               >= 0.5
-                   , exceptions               >= 0.8
-                   , hspec                    >= 2.4
-                   , hspec-expectations
-                   , HUnit
-                   , monad-control
-                   , monad-logger             >= 0.3.25
-                   , mtl
-                   , path-pieces              >= 0.2
-                   , QuickCheck               >= 2.9
-                   , quickcheck-instances     >= 0.3
-                   , random                   >= 1.1
-                   , resourcet                >= 1.1
-                   , text                     >= 1.2
-                   , time                     >= 1.6
-                   , transformers             >= 0.5
-                   , transformers-base
-                   , unliftio
-                   , unliftio-core
-                   , unordered-containers
+    build-depends: 
+        base                     >= 4.9       && < 5
+      , persistent               >= 2.11      && < 2.12
+      , persistent-template      >= 2.9       && < 2.10
+      , aeson                    >= 1.0
+      , blaze-html               >= 0.9
+      , bytestring               >= 0.10
+      , conduit                  >= 1.2.12
+      , containers               >= 0.5
+      , exceptions               >= 0.8
+      , hspec                    >= 2.4
+      , hspec-expectations
+      , HUnit
+      , monad-control
+      , monad-logger             >= 0.3.25
+      , mtl
+      , path-pieces              >= 0.2
+      , QuickCheck               >= 2.9
+      , quickcheck-instances     >= 0.3
+      , random                   >= 1.1
+      , resourcet                >= 1.1
+      , text                     >= 1.2
+      , time                     >= 1.6
+      , transformers             >= 0.5
+      , transformers-base
+      , unliftio
+      , unliftio-core
+      , unordered-containers
 
   default-language: Haskell2010
   default-extensions:
-                    ExistentialQuantification
-                    FlexibleContexts
-                    FlexibleInstances
-                    MultiParamTypeClasses
-                    OverloadedStrings
-                    QuasiQuotes
-                    TemplateHaskell
-                    TypeFamilies
-                    StandaloneDeriving
-                    DerivingStrategies
-                    GeneralizedNewtypeDeriving
-                    DataKinds
+      ExistentialQuantification
+      FlexibleContexts
+      FlexibleInstances
+      MultiParamTypeClasses
+      OverloadedStrings
+      QuasiQuotes
+      TemplateHaskell
+      TypeFamilies
+      StandaloneDeriving
+      DerivingStrategies
+      GeneralizedNewtypeDeriving
+      DataKinds
 
 source-repository head
   type:     git


### PR DESCRIPTION
Currently, persistent-test has a bit of version rot. This MR updates the
package's version bounds to be appropriate. Corresponding version bounds
have been pushed to Hackage as revisions.

Before submitting your PR, check that you've:

- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
