### PR TITLE
Fix references Migrations

### DIFF
--- a/persistent-mysql/ChangeLog.md
+++ b/persistent-mysql/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for persistent-mysql
 
+## 2.10.3.1
+* Fix foreign key migrations [#1167] https://github.com/yesodweb/persistent/pull/1167
+  * Fix a bug where a foreign key of a field to its table was ignored.
+
 ## 2.10.3
 
 * Compatibility with latest persistent

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -361,7 +361,7 @@ migrate' connectInfo allDefs getter val = do
                     let refTarget =
                           addReference allDefs refConstraintName refTblName cname (crFieldCascade cRef)
 
-                    guard $ refTblName /= name && cname /= fieldDB (entityId val)
+                    guard $ cname /= fieldDB (entityId val)
                     return $ AlterColumn name (refTblName, refTarget)
 
             let foreignsAlt =

--- a/persistent-mysql/persistent-mysql.cabal
+++ b/persistent-mysql/persistent-mysql.cabal
@@ -1,5 +1,5 @@
 name:            persistent-mysql
-version:         2.10.3
+version:         2.10.3.1
 license:         MIT
 license-file:    LICENSE
 author:          Felipe Lessa <felipe.lessa@gmail.com>, Michael Snoyman

--- a/persistent-postgresql/ChangeLog.md
+++ b/persistent-postgresql/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for persistent-postgresql
 
+##  2.11.0.1
+* Fix foreign key migrations [#1167] https://github.com/yesodweb/persistent/pull/1167
+  * Fix a bug where a foreign key of a field to its table was ignored.
+  * Fix a bug where a altering details of a foreign key didn't trigger a migration
+
 ##  2.11.0.0
 
 * Foreign Key improvements [#1121] https://github.com/yesodweb/persistent/pull/1121

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -1237,8 +1237,7 @@ findAlters defs edef col@(Column name isNull sqltype def _gen _defConstraintName
                 refAdd (Just colRef) =
                     case find ((== crTableName colRef) . entityDB) defs of
                         Just refdef
-                            | entityDB edef /= crTableName colRef
-                            && _oldName /= fieldDB (entityId edef)
+                            | _oldName /= fieldDB (entityId edef)
                             ->
                             [ ( crTableName colRef
                               , AddReference
@@ -1317,7 +1316,7 @@ getAddReference
     -> ColumnReference
     -> Maybe AlterDB
 getAddReference allDefs entity cname cr@ColumnReference {crTableName = s, crConstraintName=constraintName} = do
-    guard $ table /= s && cname /= fieldDB (entityId entity)
+    guard $ cname /= fieldDB (entityId entity)
     pure $ AlterColumn
         table
         ( s

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -1253,7 +1253,7 @@ findAlters defs edef col@(Column name isNull sqltype def _gen _defConstraintName
                             error $ "could not find the entityDef for reftable["
                                 ++ show (crTableName colRef) ++ "]"
                 modRef =
-                    if fmap crConstraintName ref == fmap crConstraintName ref'
+                    if equivalentRef ref ref'
                         then []
                         else refDrop ref' ++ refAdd ref
                 modNull = case (isNull, isNull') of
@@ -1290,6 +1290,24 @@ findAlters defs edef col@(Column name isNull sqltype def _gen _defConstraintName
                 ( modRef ++ modDef ++ modNull ++ modType
                 , filter (\c -> cName c /= name) cols
                 )
+
+-- We check if we should alter a foreign key. This is almost an equality check,
+-- except we consider 'Nothing' and 'Just Restrict' equivalent.
+equivalentRef :: Maybe ColumnReference -> Maybe ColumnReference -> Bool
+equivalentRef Nothing Nothing = True
+equivalentRef (Just cr1) (Just cr2) =
+       crTableName cr1 == crTableName cr2
+    && crConstraintName cr1 == crConstraintName cr2
+    && eqCascade (fcOnUpdate $ crFieldCascade cr1) (fcOnUpdate $ crFieldCascade cr2)
+    && eqCascade (fcOnDelete $ crFieldCascade cr1) (fcOnDelete $ crFieldCascade cr2)
+  where
+    eqCascade :: Maybe CascadeAction -> Maybe CascadeAction -> Bool
+    eqCascade Nothing Nothing         = True
+    eqCascade Nothing (Just Restrict) = True
+    eqCascade (Just Restrict) Nothing = True
+    eqCascade (Just cs1) (Just cs2)   = cs1 == cs2
+    eqCascade _ _                     = False
+equivalentRef _ _ = False
 
 -- | Get the references to be added to a table for the given column.
 getAddReference

--- a/persistent-postgresql/persistent-postgresql.cabal
+++ b/persistent-postgresql/persistent-postgresql.cabal
@@ -1,5 +1,5 @@
 name:            persistent-postgresql
-version:         2.11.0.0
+version:         2.11.0.1
 license:         MIT
 license-file:    LICENSE
 author:          Felipe Lessa, Michael Snoyman <michael@snoyman.com>

--- a/persistent-test/src/ForeignKey.hs
+++ b/persistent-test/src/ForeignKey.hs
@@ -92,6 +92,11 @@ Chain2
     previous Chain2Id Maybe noreference
     Foreign Chain2 OnDeleteCascade fkChain previous References Id
     deriving Show Eq
+
+Chain3
+    name Int
+    previous Chain3Id Maybe OnDeleteCascade
+    deriving Show Eq
 |]
 
 specsWith :: (MonadIO m, MonadFail m) => RunDb SqlBackend m -> Spec
@@ -179,6 +184,14 @@ specsWith runDb = describe "foreign keys options" $ do
         delete k1
         cs <- selectList [] []
         let expected = [] :: [Entity Chain2]
+        cs @== expected
+    it "deletes cascades with field self reference to the whole chain" $ runDb $ do
+        k1 <- insert $ Chain3 1 Nothing
+        k2 <- insert $ Chain3 2 (Just k1)
+        insert_ $ Chain3 3 (Just k2)
+        delete k1
+        cs <- selectList [] []
+        let expected = [] :: [Entity Chain3]
         cs @== expected
 
     describe "EntityDef" $ do


### PR DESCRIPTION
I noticed that when the cascade behavior of a field foreign key changes (ie by adding OnDeleteCascade), no migrations is generated. Is there any reason not to? There is a comment `An unspecified 'CascadeAction' is defaulted to 'Restrict' when doing migrations.`, so maybe there is already a way to make migrations work that I missed?

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
