### PR TITLE
Add QoL API for using BaseBackend/BackendCompatible

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for persistent
 
+## 2.11.1
+
+* [#1178](https://github.com/yesodweb/persistent/pull/1178)
+  * Added 'withBaseBackend', 'withCompatible' to ease use of base/compatible backend queries in external code.
+
 ## 2.11.0.2
 
 * Fix a bug where an empty entity definition would break parsing of `EntityDef`s. [#1176](https://github.com/yesodweb/persistent/issues/1176)

--- a/persistent/Database/Persist/Class.hs
+++ b/persistent/Database/Persist/Class.hs
@@ -126,9 +126,11 @@ module Database.Persist.Class
 
     -- * Lifting
     , HasPersistBackend (..)
+    , withBaseBackend
     , IsPersistBackend ()
     , liftPersist
     , BackendCompatible (..)
+    , withCompatibleBackend
 
     -- * JSON utilities
     , keyValueEntityToJSON, keyValueEntityFromJSON

--- a/persistent/Database/Persist/Class/PersistStore.hs
+++ b/persistent/Database/Persist/Class/PersistStore.hs
@@ -49,6 +49,8 @@ class HasPersistBackend backend where
 -- | Run a query against a larger backend by plucking out @BaseBackend backend@
 --
 -- This is a helper for reusing existing queries when expanding the backend type.
+--
+-- @since 2.11.1
 withBaseBackend :: (HasPersistBackend backend)
                 => ReaderT (BaseBackend backend) m a -> ReaderT backend m a
 withBaseBackend = withReaderT persistBackend
@@ -113,6 +115,8 @@ class BackendCompatible sup sub where
 --
 -- This is a helper for using queries which run against a specific backend type
 -- that your backend is compatible with.
+--
+-- @since 2.11.1
 withCompatibleBackend :: (BackendCompatible sup sub)
                       => ReaderT sup m a -> ReaderT sub m a
 withCompatibleBackend = withReaderT projectBackend

--- a/persistent/Database/Persist/Class/PersistStore.hs
+++ b/persistent/Database/Persist/Class/PersistStore.hs
@@ -116,7 +116,7 @@ class BackendCompatible sup sub where
 -- This is a helper for using queries which run against a specific backend type
 -- that your backend is compatible with.
 --
--- @since 2.11.1
+-- @since 2.12.0
 withCompatibleBackend :: (BackendCompatible sup sub)
                       => ReaderT sup m a -> ReaderT sub m a
 withCompatibleBackend = withReaderT projectBackend

--- a/persistent/Database/Persist/Class/PersistStore.hs
+++ b/persistent/Database/Persist/Class/PersistStore.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE ExplicitForAll #-}
 module Database.Persist.Class.PersistStore
     ( HasPersistBackend (..)
+    , withBaseBackend
     , IsPersistBackend (..)
     , PersistRecordBackend
     , liftPersist
@@ -17,12 +18,13 @@ module Database.Persist.Class.PersistStore
     , insertRecord
     , ToBackendKey(..)
     , BackendCompatible(..)
+    , withCompatibleBackend
     ) where
 
 import Control.Exception (throwIO)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Reader (MonadReader (ask), runReaderT)
-import Control.Monad.Trans.Reader (ReaderT)
+import Control.Monad.Trans.Reader (ReaderT, withReaderT)
 import qualified Data.Aeson as A
 import Data.Map (Map)
 import qualified Data.Map as Map
@@ -43,6 +45,14 @@ import Database.Persist.Types
 class HasPersistBackend backend where
     type BaseBackend backend
     persistBackend :: backend -> BaseBackend backend
+
+-- | Run a query against a larger backend by plucking out @BaseBackend backend@
+--
+-- This is a helper for reusing existing queries when expanding the backend type.
+withBaseBackend :: (HasPersistBackend backend)
+                => ReaderT (BaseBackend backend) m a -> ReaderT backend m a
+withBaseBackend = withReaderT persistBackend
+
 -- | Class which witnesses that @backend@ is essentially the same as @BaseBackend backend@.
 -- That is, they're isomorphic and @backend@ is just some wrapper over @BaseBackend backend@.
 class (HasPersistBackend backend) => IsPersistBackend backend where
@@ -50,6 +60,10 @@ class (HasPersistBackend backend) => IsPersistBackend backend where
     -- It should be used carefully and only when actually constructing a @backend@. Careless use allows us
     -- to accidentally run a write query against a read-only database.
     mkPersistBackend :: BaseBackend backend -> backend
+
+-- NB: there is a deliberate *lack* of an equivalent to 'withBaseBackend' for
+-- 'IsPersistentBackend'. We don't want it to be easy for the user to construct
+-- a backend when they're not meant to.
 
 -- | This class witnesses that two backend are compatible, and that you can
 -- convert from the @sub@ backend into the @sup@ backend. This is similar
@@ -88,12 +102,20 @@ class (HasPersistBackend backend) => IsPersistBackend backend where
 --
 -- -- after:
 -- asdf' :: 'BackendCompatible' SqlBackend backend => ReaderT backend m ()
--- asdf' = withReaderT 'projectBackend' asdf
+-- asdf' = 'withCompatibleBackend' asdf
 -- @
 --
 -- @since 2.7.1
 class BackendCompatible sup sub where
     projectBackend :: sub -> sup
+
+-- | Run a query against a compatible backend, by projecting the backend
+--
+-- This is a helper for using queries which run against a specific backend type
+-- that your backend is compatible with.
+withCompatibleBackend :: (BackendCompatible sup sub)
+                      => ReaderT sup m a -> ReaderT sub m a
+withCompatibleBackend = withReaderT projectBackend
 
 -- | A convenient alias for common type signatures
 type PersistRecordBackend record backend = (PersistEntity record, PersistEntityBackend record ~ BaseBackend backend)

--- a/persistent/Database/Persist/Class/PersistStore.hs
+++ b/persistent/Database/Persist/Class/PersistStore.hs
@@ -50,7 +50,7 @@ class HasPersistBackend backend where
 --
 -- This is a helper for reusing existing queries when expanding the backend type.
 --
--- @since 2.11.1
+-- @since 2.12.0
 withBaseBackend :: (HasPersistBackend backend)
                 => ReaderT (BaseBackend backend) m a -> ReaderT backend m a
 withBaseBackend = withReaderT persistBackend

--- a/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
@@ -83,7 +83,7 @@ getTableName :: forall record m backend.
              , BackendCompatible SqlBackend backend
              , Monad m
              ) => record -> ReaderT backend m Text
-getTableName rec = withReaderT projectBackend $ do
+getTableName rec = withCompatibleBackend $ do
     conn <- ask
     return $ connEscapeName conn $ tableDBName rec
 
@@ -103,7 +103,7 @@ getFieldName :: forall record typ m backend.
              , Monad m
              )
              => EntityField record typ -> ReaderT backend m Text
-getFieldName rec = withReaderT projectBackend $ do
+getFieldName rec = withCompatibleBackend $ do
     conn <- ask
     return $ connEscapeName conn $ fieldDBName rec
 
@@ -301,16 +301,16 @@ instance PersistStoreWrite SqlBackend where
             , wher conn
             ]
 instance PersistStoreWrite SqlWriteBackend where
-    insert v = withReaderT persistBackend $ insert v
-    insertMany vs = withReaderT persistBackend $ insertMany vs
-    insertMany_ vs = withReaderT persistBackend $ insertMany_ vs
-    insertEntityMany vs = withReaderT persistBackend $ insertEntityMany vs
-    insertKey k v = withReaderT persistBackend $ insertKey k v
-    repsert k v = withReaderT persistBackend $ repsert k v
-    replace k v = withReaderT persistBackend $ replace k v
-    delete k = withReaderT persistBackend $ delete k
-    update k upds = withReaderT persistBackend $ update k upds
-    repsertMany krs = withReaderT persistBackend $ repsertMany krs
+    insert v = withBaseBackend $ insert v
+    insertMany vs = withBaseBackend $ insertMany vs
+    insertMany_ vs = withBaseBackend $ insertMany_ vs
+    insertEntityMany vs = withBaseBackend $ insertEntityMany vs
+    insertKey k v = withBaseBackend $ insertKey k v
+    repsert k v = withBaseBackend $ repsert k v
+    replace k v = withBaseBackend $ replace k v
+    delete k = withBaseBackend $ delete k
+    update k upds = withBaseBackend $ update k upds
+    repsertMany krs = withBaseBackend $ repsertMany krs
 
 instance PersistStoreRead SqlBackend where
     get k = do
@@ -341,11 +341,11 @@ instance PersistStoreRead SqlBackend where
             return $ Map.fromList $ fmap (\e -> (entityKey e, entityVal e)) es
 
 instance PersistStoreRead SqlReadBackend where
-    get k = withReaderT persistBackend $ get k
-    getMany ks = withReaderT persistBackend $ getMany ks
+    get k = withBaseBackend $ get k
+    getMany ks = withBaseBackend $ getMany ks
 instance PersistStoreRead SqlWriteBackend where
-    get k = withReaderT persistBackend $ get k
-    getMany ks = withReaderT persistBackend $ getMany ks
+    get k = withBaseBackend $ get k
+    getMany ks = withBaseBackend $ getMany ks
 
 dummyFromKey :: Key record -> Maybe record
 dummyFromKey = Just . recordTypeFromKey

--- a/persistent/Database/Persist/Sql/Orphan/PersistUnique.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistUnique.hs
@@ -6,7 +6,7 @@ module Database.Persist.Sql.Orphan.PersistUnique
 
 import Control.Exception (throwIO)
 import Control.Monad.IO.Class (liftIO)
-import Control.Monad.Trans.Reader (ask, withReaderT)
+import Control.Monad.Trans.Reader (ask)
 import qualified Data.Conduit.List as CL
 import Data.Function (on)
 import Data.List (nubBy)
@@ -79,9 +79,9 @@ instance PersistUniqueWrite SqlBackend where
                 Nothing -> defaultPutMany rs
 
 instance PersistUniqueWrite SqlWriteBackend where
-    deleteBy uniq = withReaderT persistBackend $ deleteBy uniq
-    upsert rs us = withReaderT persistBackend $ upsert rs us
-    putMany rs = withReaderT persistBackend $ putMany rs
+    deleteBy uniq = withBaseBackend $ deleteBy uniq
+    upsert rs us = withBaseBackend $ upsert rs us
+    putMany rs = withBaseBackend $ putMany rs
 
 instance PersistUniqueRead SqlBackend where
     getBy uniq = do
@@ -113,10 +113,10 @@ instance PersistUniqueRead SqlBackend where
         toFieldNames' = map snd . persistUniqueToFieldNames
 
 instance PersistUniqueRead SqlReadBackend where
-    getBy uniq = withReaderT persistBackend $ getBy uniq
+    getBy uniq = withBaseBackend $ getBy uniq
 
 instance PersistUniqueRead SqlWriteBackend where
-    getBy uniq = withReaderT persistBackend $ getBy uniq
+    getBy uniq = withBaseBackend $ getBy uniq
 
 dummyFromUnique :: Unique v -> Maybe v
 dummyFromUnique _ = Nothing


### PR DESCRIPTION
`withBaseBackend` and `withCompatibleBackend` are simple wrappers for `withReaderT` that use the appropriate read-transforming function from their respective instances.

Also dogfoods these functions into the codebase.

Before submitting your PR, check that you've:

- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
