### PR TITLE
Add newtype, TH functions for deriving instances from backend compat

### DIFF
--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -10,6 +11,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 -- | A sqlite backend for persistent.
 --
 -- Note: If you prepend @WAL=off @ to your connection string, it will disable
@@ -51,7 +53,7 @@ import qualified Control.Exception as E
 import Control.Monad (forM_)
 import Control.Monad.IO.Unlift (MonadIO (..), MonadUnliftIO, askRunInIO, withRunInIO, withUnliftIO, unliftIO, withRunInIO)
 import Control.Monad.Logger (NoLoggingT, runNoLoggingT, MonadLoggerIO, logWarn, runLoggingT, askLoggerIO)
-import Control.Monad.Trans.Reader (ReaderT, runReaderT, withReaderT)
+import Control.Monad.Trans.Reader (ReaderT, runReaderT)
 import Control.Monad.Trans.Writer (runWriterT)
 import Data.Acquire (Acquire, mkAcquire, with)
 import Data.Maybe
@@ -71,6 +73,7 @@ import qualified Data.Text.IO as TIO
 import Lens.Micro.TH (makeLenses)
 import UnliftIO.Resource (ResourceT, runResourceT)
 
+import Database.Persist.Compatible
 import Database.Persist.Sql
 import qualified Database.Persist.Sql.Util as Util
 import qualified Database.Sqlite as Sqlite
@@ -854,68 +857,15 @@ data RawSqlite backend = RawSqlite
     , _rawSqliteConnection :: Sqlite.Connection -- ^ The underlying `Sqlite.Connection`
     }
 
-instance HasPersistBackend b => HasPersistBackend (RawSqlite b) where
-    type BaseBackend (RawSqlite b) = BaseBackend b
-    persistBackend = persistBackend . _persistentBackend
-
 instance BackendCompatible b (RawSqlite b) where
     projectBackend = _persistentBackend
 
+makeCompatibleInstances [t| forall b. Compatible b (RawSqlite b) |]
+
 instance (PersistCore b) => PersistCore (RawSqlite b) where
-    newtype BackendKey (RawSqlite b) = RawSqliteKey (BackendKey b)
+  newtype BackendKey (RawSqlite b) = RawSqliteKey { unRawSqliteKey :: BackendKey (Compatible b (RawSqlite b)) }
 
-deriving instance (Show (BackendKey b)) => Show (BackendKey (RawSqlite b))
-deriving instance (Read (BackendKey b)) => Read (BackendKey (RawSqlite b))
-deriving instance (Eq (BackendKey b)) => Eq (BackendKey (RawSqlite b))
-deriving instance (Ord (BackendKey b)) => Ord (BackendKey (RawSqlite b))
-deriving instance (Num (BackendKey b)) => Num (BackendKey (RawSqlite b))
-deriving instance (Integral (BackendKey b)) => Integral (BackendKey (RawSqlite b))
-deriving instance (PersistField (BackendKey b)) => PersistField (BackendKey (RawSqlite b))
-deriving instance (PersistFieldSql (BackendKey b)) => PersistFieldSql (BackendKey (RawSqlite b))
-deriving instance (Real (BackendKey b)) => Real (BackendKey (RawSqlite b))
-deriving instance (Enum (BackendKey b)) => Enum (BackendKey (RawSqlite b))
-deriving instance (Bounded (BackendKey b)) => Bounded (BackendKey (RawSqlite b))
-deriving instance (ToJSON (BackendKey b)) => ToJSON (BackendKey (RawSqlite b))
-deriving instance (FromJSON (BackendKey b)) => FromJSON (BackendKey (RawSqlite b))
-
-instance (PersistStoreRead b) => PersistStoreRead (RawSqlite b) where
-    get = withReaderT _persistentBackend . get
-    getMany = withReaderT _persistentBackend . getMany
-
-instance (PersistQueryRead b) => PersistQueryRead (RawSqlite b) where
-    selectSourceRes filts opts = withReaderT _persistentBackend $ selectSourceRes filts opts
-    selectFirst filts opts = withReaderT _persistentBackend $ selectFirst filts opts
-    selectKeysRes filts opts = withReaderT _persistentBackend $ selectKeysRes filts opts
-    count = withReaderT _persistentBackend . count
-    exists = withReaderT _persistentBackend . exists
-
-instance (PersistQueryWrite b) => PersistQueryWrite (RawSqlite b) where
-    updateWhere filts updates = withReaderT _persistentBackend $ updateWhere filts updates
-    deleteWhere = withReaderT _persistentBackend . deleteWhere
-
-instance (PersistUniqueRead b) => PersistUniqueRead (RawSqlite b) where
-    getBy = withReaderT _persistentBackend . getBy
-
-instance (PersistStoreWrite b) => PersistStoreWrite (RawSqlite b) where
-    insert = withReaderT _persistentBackend . insert
-    insert_ = withReaderT _persistentBackend . insert_
-    insertMany = withReaderT _persistentBackend . insertMany
-    insertMany_ = withReaderT _persistentBackend . insertMany_
-    insertEntityMany = withReaderT _persistentBackend . insertEntityMany
-    insertKey k = withReaderT _persistentBackend . insertKey k
-    repsert k = withReaderT _persistentBackend . repsert k
-    repsertMany = withReaderT _persistentBackend . repsertMany
-    replace k = withReaderT _persistentBackend . replace k
-    delete = withReaderT _persistentBackend . delete
-    update k = withReaderT _persistentBackend . update k
-    updateGet k = withReaderT _persistentBackend . updateGet k
-
-instance (PersistUniqueWrite b) => PersistUniqueWrite (RawSqlite b) where
-    deleteBy = withReaderT _persistentBackend . deleteBy
-    insertUnique = withReaderT _persistentBackend . insertUnique
-    upsert rec = withReaderT _persistentBackend . upsert rec
-    upsertBy uniq rec = withReaderT _persistentBackend . upsertBy uniq rec
-    putMany = withReaderT _persistentBackend . putMany
+makeCompatibleKeyInstances [t| forall b. Compatible b (RawSqlite b) |]
 
 makeLenses ''RawSqlite
 makeLenses ''SqliteConnectionInfo

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -9,6 +9,9 @@
 * [#1178](https://github.com/yesodweb/persistent/pull/1178)
   * Added 'withBaseBackend', 'withCompatible' to ease use of base/compatible backend queries in external code.
 * Added GHC 8.2.2 and GHC 8.4.4 back into the CI and `persistent` builds on 8.2.2 again [#1181](https://github.com/yesodweb/persistent/issues/1181)
+* [#1179](https://github.com/yesodweb/persistent/pull/1179)
+  * Added `Compatible`, a newtype for marking a backend as compatible with another. Use it with `DerivingVia` to derive simple instances based on backend compatibility.
+  * Added `makeCompatibleInstances` and `makeCompatibleKeyInstances`, TemplateHaskell invocations for auto-generating standalone derivations using `Compatible` and `DerivingVia`.
 
 ## 2.11.0.2
 * Fix a bug where an empty entity definition would break parsing of `EntityDef`s. [#1176](https://github.com/yesodweb/persistent/issues/1176)

--- a/persistent/Database/Persist/Compatible.hs
+++ b/persistent/Database/Persist/Compatible.hs
@@ -1,8 +1,8 @@
 module Database.Persist.Compatible
-  ( Compatible(..)
-  , makeCompatibleInstances
-  , makeCompatibleKeyInstances
-  ) where
+    ( Compatible(..)
+    , makeCompatibleInstances
+    , makeCompatibleKeyInstances
+    ) where
 
 import Database.Persist.Compatible.Types
 import Database.Persist.Compatible.TH

--- a/persistent/Database/Persist/Compatible.hs
+++ b/persistent/Database/Persist/Compatible.hs
@@ -1,0 +1,9 @@
+module Database.Persist.Compatible
+  ( Compatible(..)
+  , makeCompatibleInstances
+  , makeCompatibleKeyInstances
+  ) where
+
+import Database.Persist.Compatible.Types
+import Database.Persist.Compatible.TH
+

--- a/persistent/Database/Persist/Compatible/TH.hs
+++ b/persistent/Database/Persist/Compatible/TH.hs
@@ -5,9 +5,9 @@
 {-# LANGUAGE TupleSections #-}
 
 module Database.Persist.Compatible.TH
-  ( makeCompatibleInstances
-  , makeCompatibleKeyInstances
-  ) where
+    ( makeCompatibleInstances
+    , makeCompatibleKeyInstances
+    ) where
 
 import Data.Aeson
 import Database.Persist.Class
@@ -31,32 +31,32 @@ import Database.Persist.Compatible.Types
 -- @since 2.12
 makeCompatibleInstances :: Q Type -> Q [Dec]
 makeCompatibleInstances compatibleType = do
-  (b, s) <- compatibleType >>= \case
-    ForallT _ _ (AppT (AppT (ConT conTName) b) s) ->
-      if conTName == ''Compatible
-        then pure (b, s)
-        else fail $
-              "Cannot make `deriving via` instances if the argument is " <>
-              "not of the form `forall v1 ... vn. Compatible sub sup`"
-    AppT (AppT (ConT conTName) b) s ->
-      if conTName == ''Compatible
-        then pure (b, s)
-        else fail $
-              "Cannot make `deriving via` instances if the argument is " <>
-              "not of the form `Compatible sub sup`"
-    _ -> fail $
-          "Cannot make `deriving via` instances if the argument is " <>
-          "not of the form `Compatible sub sup`"
+        (b, s) <- compatibleType >>= \case
+            ForallT _ _ (AppT (AppT (ConT conTName) b) s) ->
+                if conTName == ''Compatible
+                    then pure (b, s)
+                    else fail $
+                                "Cannot make `deriving via` instances if the argument is " <>
+                                "not of the form `forall v1 ... vn. Compatible sub sup`"
+            AppT (AppT (ConT conTName) b) s ->
+                if conTName == ''Compatible
+                    then pure (b, s)
+                    else fail $
+                                "Cannot make `deriving via` instances if the argument is " <>
+                                "not of the form `Compatible sub sup`"
+            _ -> fail $
+                        "Cannot make `deriving via` instances if the argument is " <>
+                        "not of the form `Compatible sub sup`"
 
-  [d|
-      deriving via (Compatible $(return b) $(return s)) instance (HasPersistBackend $(return b)) => HasPersistBackend $(return s)
-      deriving via (Compatible $(return b) $(return s)) instance (HasPersistBackend $(return b), PersistStoreRead $(return b)) => PersistStoreRead $(return s)
-      deriving via (Compatible $(return b) $(return s)) instance (HasPersistBackend $(return b), PersistQueryRead $(return b)) => PersistQueryRead $(return s)
-      deriving via (Compatible $(return b) $(return s)) instance (HasPersistBackend $(return b), PersistUniqueRead $(return b)) => PersistUniqueRead $(return s)
-      deriving via (Compatible $(return b) $(return s)) instance (HasPersistBackend $(return b), PersistStoreWrite $(return b)) => PersistStoreWrite $(return s)
-      deriving via (Compatible $(return b) $(return s)) instance (HasPersistBackend $(return b), PersistQueryWrite $(return b)) => PersistQueryWrite $(return s)
-      deriving via (Compatible $(return b) $(return s)) instance (HasPersistBackend $(return b), PersistUniqueWrite $(return b)) => PersistUniqueWrite $(return s)
-    |]
+        [d|
+                deriving via (Compatible $(return b) $(return s)) instance (HasPersistBackend $(return b)) => HasPersistBackend $(return s)
+                deriving via (Compatible $(return b) $(return s)) instance (HasPersistBackend $(return b), PersistStoreRead $(return b)) => PersistStoreRead $(return s)
+                deriving via (Compatible $(return b) $(return s)) instance (HasPersistBackend $(return b), PersistQueryRead $(return b)) => PersistQueryRead $(return s)
+                deriving via (Compatible $(return b) $(return s)) instance (HasPersistBackend $(return b), PersistUniqueRead $(return b)) => PersistUniqueRead $(return s)
+                deriving via (Compatible $(return b) $(return s)) instance (HasPersistBackend $(return b), PersistStoreWrite $(return b)) => PersistStoreWrite $(return s)
+                deriving via (Compatible $(return b) $(return s)) instance (HasPersistBackend $(return b), PersistQueryWrite $(return b)) => PersistQueryWrite $(return s)
+                deriving via (Compatible $(return b) $(return s)) instance (HasPersistBackend $(return b), PersistUniqueWrite $(return b)) => PersistUniqueWrite $(return s)
+            |]
 
 -- | Gives a bunch of useful instance declarations for a backend key based on
 -- its compatibility with another backend & key, using 'Compatible'.
@@ -73,35 +73,35 @@ makeCompatibleInstances compatibleType = do
 -- @since 2.12
 makeCompatibleKeyInstances :: Q Type -> Q [Dec]
 makeCompatibleKeyInstances compatibleType = do
-  (b, s) <- compatibleType >>= \case
-    ForallT _ _ (AppT (AppT (ConT conTName) b) s) ->
-      if conTName == ''Compatible
-        then pure (b, s)
-        else fail $
-              "Cannot make `deriving via` instances if the argument is " <>
-              "not of the form `forall v1 ... vn. Compatible sub sup`"
-    AppT (AppT (ConT conTName) b) s ->
-      if conTName == ''Compatible
-        then pure (b, s)
-        else fail $
-              "Cannot make `deriving via` instances if the argument is " <>
-              "not of the form `Compatible sub sup`"
-    _ -> fail $
-          "Cannot make `deriving via` instances if the argument is " <>
-          "not of the form `Compatible sub sup`"
+    (b, s) <- compatibleType >>= \case
+        ForallT _ _ (AppT (AppT (ConT conTName) b) s) ->
+            if conTName == ''Compatible
+                then pure (b, s)
+                else fail $
+                            "Cannot make `deriving via` instances if the argument is " <>
+                            "not of the form `forall v1 ... vn. Compatible sub sup`"
+        AppT (AppT (ConT conTName) b) s ->
+            if conTName == ''Compatible
+                then pure (b, s)
+                else fail $
+                            "Cannot make `deriving via` instances if the argument is " <>
+                            "not of the form `Compatible sub sup`"
+        _ -> fail $
+                    "Cannot make `deriving via` instances if the argument is " <>
+                    "not of the form `Compatible sub sup`"
 
-  [d|
-      deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), Show (BackendKey $(return b))) => Show (BackendKey $(return s))
-      deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), Read (BackendKey $(return b))) => Read (BackendKey $(return s))
-      deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), Eq (BackendKey $(return b))) => Eq (BackendKey $(return s))
-      deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), Ord (BackendKey $(return b))) => Ord (BackendKey $(return s))
-      deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), Num (BackendKey $(return b))) => Num (BackendKey $(return s))
-      deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), Integral (BackendKey $(return b))) => Integral (BackendKey $(return s))
-      deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), PersistField (BackendKey $(return b))) => PersistField (BackendKey $(return s))
-      deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), PersistFieldSql (BackendKey $(return b))) => PersistFieldSql (BackendKey $(return s))
-      deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), Real (BackendKey $(return b))) => Real (BackendKey $(return s))
-      deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), Enum (BackendKey $(return b))) => Enum (BackendKey $(return s))
-      deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), Bounded (BackendKey $(return b))) => Bounded (BackendKey $(return s))
-      deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), ToJSON (BackendKey $(return b))) => ToJSON (BackendKey $(return s))
-      deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), FromJSON (BackendKey $(return b))) => FromJSON (BackendKey $(return s))
-    |]
+    [d|
+            deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), Show (BackendKey $(return b))) => Show (BackendKey $(return s))
+            deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), Read (BackendKey $(return b))) => Read (BackendKey $(return s))
+            deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), Eq (BackendKey $(return b))) => Eq (BackendKey $(return s))
+            deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), Ord (BackendKey $(return b))) => Ord (BackendKey $(return s))
+            deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), Num (BackendKey $(return b))) => Num (BackendKey $(return s))
+            deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), Integral (BackendKey $(return b))) => Integral (BackendKey $(return s))
+            deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), PersistField (BackendKey $(return b))) => PersistField (BackendKey $(return s))
+            deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), PersistFieldSql (BackendKey $(return b))) => PersistFieldSql (BackendKey $(return s))
+            deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), Real (BackendKey $(return b))) => Real (BackendKey $(return s))
+            deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), Enum (BackendKey $(return b))) => Enum (BackendKey $(return s))
+            deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), Bounded (BackendKey $(return b))) => Bounded (BackendKey $(return s))
+            deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), ToJSON (BackendKey $(return b))) => ToJSON (BackendKey $(return s))
+            deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), FromJSON (BackendKey $(return b))) => FromJSON (BackendKey $(return s))
+        |]

--- a/persistent/Database/Persist/Compatible/TH.hs
+++ b/persistent/Database/Persist/Compatible/TH.hs
@@ -27,6 +27,8 @@ import Database.Persist.Compatible.Types
 --
 -- @v1 ... vn@ are implicitly quantified in the instance, which is derived via
 -- @'Compatible' b s@.
+--
+-- @since 2.12
 makeCompatibleInstances :: Q Type -> Q [Dec]
 makeCompatibleInstances compatibleType = do
   (b, s) <- compatibleType >>= \case
@@ -67,6 +69,8 @@ makeCompatibleInstances compatibleType = do
 --
 -- @v1 ... vn@ are implicitly quantified in the instance, which is derived via
 -- @'BackendKey' ('Compatible' b s)@.
+--
+-- @since 2.12
 makeCompatibleKeyInstances :: Q Type -> Q [Dec]
 makeCompatibleKeyInstances compatibleType = do
   (b, s) <- compatibleType >>= \case

--- a/persistent/Database/Persist/Compatible/TH.hs
+++ b/persistent/Database/Persist/Compatible/TH.hs
@@ -1,0 +1,103 @@
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TupleSections #-}
+
+module Database.Persist.Compatible.TH
+  ( makeCompatibleInstances
+  , makeCompatibleKeyInstances
+  ) where
+
+import Data.Aeson
+import Database.Persist.Class
+import Database.Persist.Sql.Class
+import Language.Haskell.TH
+
+import Database.Persist.Compatible.Types
+
+-- | Gives a bunch of useful instance declarations for a backend based on its
+-- compatibility with another backend, using 'Compatible'.
+--
+-- The argument should be a type of the form @ forall v1 ... vn. Compatible b s @
+-- (Quantification is optional, but supported because TH won't let you have
+-- unbound type variables in a type splice). The instance is produced for @s@
+-- based on the instance defined for @b@, which is constrained in the instance
+-- head to exist.
+--
+-- @v1 ... vn@ are implicitly quantified in the instance, which is derived via
+-- @'Compatible' b s@.
+makeCompatibleInstances :: Q Type -> Q [Dec]
+makeCompatibleInstances compatibleType = do
+  (b, s) <- compatibleType >>= \case
+    ForallT _ _ (AppT (AppT (ConT conTName) b) s) ->
+      if conTName == ''Compatible
+        then pure (b, s)
+        else fail $
+              "Cannot make `deriving via` instances if the argument is " <>
+              "not of the form `forall v1 ... vn. Compatible sub sup`"
+    AppT (AppT (ConT conTName) b) s ->
+      if conTName == ''Compatible
+        then pure (b, s)
+        else fail $
+              "Cannot make `deriving via` instances if the argument is " <>
+              "not of the form `Compatible sub sup`"
+    _ -> fail $
+          "Cannot make `deriving via` instances if the argument is " <>
+          "not of the form `Compatible sub sup`"
+
+  [d|
+      deriving via (Compatible $(return b) $(return s)) instance (HasPersistBackend $(return b)) => HasPersistBackend $(return s)
+      deriving via (Compatible $(return b) $(return s)) instance (HasPersistBackend $(return b), PersistStoreRead $(return b)) => PersistStoreRead $(return s)
+      deriving via (Compatible $(return b) $(return s)) instance (HasPersistBackend $(return b), PersistQueryRead $(return b)) => PersistQueryRead $(return s)
+      deriving via (Compatible $(return b) $(return s)) instance (HasPersistBackend $(return b), PersistUniqueRead $(return b)) => PersistUniqueRead $(return s)
+      deriving via (Compatible $(return b) $(return s)) instance (HasPersistBackend $(return b), PersistStoreWrite $(return b)) => PersistStoreWrite $(return s)
+      deriving via (Compatible $(return b) $(return s)) instance (HasPersistBackend $(return b), PersistQueryWrite $(return b)) => PersistQueryWrite $(return s)
+      deriving via (Compatible $(return b) $(return s)) instance (HasPersistBackend $(return b), PersistUniqueWrite $(return b)) => PersistUniqueWrite $(return s)
+    |]
+
+-- | Gives a bunch of useful instance declarations for a backend key based on
+-- its compatibility with another backend & key, using 'Compatible'.
+--
+-- The argument should be a type of the form @ forall v1 ... vn. Compatible b s @
+-- (Quantification is optional, but supported because TH won't let you have
+-- unbound type variables in a type splice). The instance is produced for
+-- @'BackendKey' s@ based on the instance defined for @'BackendKey' b@, which
+-- is constrained in the instance head to exist.
+--
+-- @v1 ... vn@ are implicitly quantified in the instance, which is derived via
+-- @'BackendKey' ('Compatible' b s)@.
+makeCompatibleKeyInstances :: Q Type -> Q [Dec]
+makeCompatibleKeyInstances compatibleType = do
+  (b, s) <- compatibleType >>= \case
+    ForallT _ _ (AppT (AppT (ConT conTName) b) s) ->
+      if conTName == ''Compatible
+        then pure (b, s)
+        else fail $
+              "Cannot make `deriving via` instances if the argument is " <>
+              "not of the form `forall v1 ... vn. Compatible sub sup`"
+    AppT (AppT (ConT conTName) b) s ->
+      if conTName == ''Compatible
+        then pure (b, s)
+        else fail $
+              "Cannot make `deriving via` instances if the argument is " <>
+              "not of the form `Compatible sub sup`"
+    _ -> fail $
+          "Cannot make `deriving via` instances if the argument is " <>
+          "not of the form `Compatible sub sup`"
+
+  [d|
+      deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), Show (BackendKey $(return b))) => Show (BackendKey $(return s))
+      deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), Read (BackendKey $(return b))) => Read (BackendKey $(return s))
+      deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), Eq (BackendKey $(return b))) => Eq (BackendKey $(return s))
+      deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), Ord (BackendKey $(return b))) => Ord (BackendKey $(return s))
+      deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), Num (BackendKey $(return b))) => Num (BackendKey $(return s))
+      deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), Integral (BackendKey $(return b))) => Integral (BackendKey $(return s))
+      deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), PersistField (BackendKey $(return b))) => PersistField (BackendKey $(return s))
+      deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), PersistFieldSql (BackendKey $(return b))) => PersistFieldSql (BackendKey $(return s))
+      deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), Real (BackendKey $(return b))) => Real (BackendKey $(return s))
+      deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), Enum (BackendKey $(return b))) => Enum (BackendKey $(return s))
+      deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), Bounded (BackendKey $(return b))) => Bounded (BackendKey $(return s))
+      deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), ToJSON (BackendKey $(return b))) => ToJSON (BackendKey $(return s))
+      deriving via (BackendKey (Compatible $(return b) $(return s))) instance (PersistCore $(return b), PersistCore $(return s), FromJSON (BackendKey $(return b))) => FromJSON (BackendKey $(return s))
+    |]

--- a/persistent/Database/Persist/Compatible/Types.hs
+++ b/persistent/Database/Persist/Compatible/Types.hs
@@ -1,0 +1,139 @@
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
+{- You can't export a data family constructor, so there's an "unused" warning -}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Database.Persist.Compatible.Types
+  ( Compatible(..)
+  ) where
+
+import Data.Aeson
+import Database.Persist.Class
+import Database.Persist.Sql.Class
+import Control.Monad.Trans.Reader (withReaderT)
+
+
+-- | A newtype wrapper for compatible backends, mainly useful for @DerivingVia@.
+--
+-- When writing a new backend that is 'BackendCompatible' with an existing backend,
+-- instances for the new backend can be naturally defined in terms of the
+-- instances for the existing backend.
+--
+-- For example, if you decide to augment the 'SqlBackend' with some additional
+-- features:
+--
+-- @
+-- data BetterSqlBackend = BetterSqlBackend { sqlBackend :: SqlBackend, ... }
+--
+-- instance BackendCompatible SqlBackend BetterSqlBackend where
+--   projectBackend = sqlBackend
+-- @
+--
+-- Then you can use @DerivingVia@ to automatically get instances like:
+--
+-- @
+-- deriving via (Compatible SqlBackend BetterSqlBackend) instance PersistStoreRead BetterSqlBackend
+-- deriving via (Compatible SqlBackend BetterSqlBackend) instance PersistStoreWrite BetterSqlBackend
+-- ...
+-- @
+--
+-- These instances will go through the compatible backend (in this case, 'SqlBackend')
+-- for all their queries.
+--
+-- These instances require that both backends have the same 'BaseBackend', but
+-- deriving 'HasPersistBackend' will enforce that for you.
+--
+-- @
+-- deriving via (Compatible SqlBackend BetterSqlBackend) instance HasPersistBackend BetterSqlBackend
+-- @
+newtype Compatible b s = Compatible { unCompatible :: s }
+
+instance (BackendCompatible b s, HasPersistBackend b) => HasPersistBackend (Compatible b s) where
+    type BaseBackend (Compatible b s) = BaseBackend b
+    persistBackend = persistBackend . projectBackend @b @s . unCompatible
+
+instance (BackendCompatible b s, PersistCore b) => PersistCore (Compatible b s) where
+    -- | A newtype wrapper around @'BackendKey' b@, mainly useful for @DerivingVia@.
+    --
+    -- Similarly to @'Compatible' b s@, this data family instance is handy for deriving
+    -- instances for @'BackendKey' s@ by defining them in terms of @'BackendKey' b@.
+    --
+    --
+    -- For example, if you decide to augment the 'SqlBackend' with some additional
+    -- features:
+    --
+    -- @
+    -- data BetterSqlBackend = BetterSqlBackend { sqlBackend :: SqlBackend, ... }
+    --
+    -- instance PersistCore BetterSqlBackend where
+    --   newtype BackendKey BetterSqlBackend = BSQLKey { unBSQLKey :: BackendKey (Compatible SqlBackend BetterSqlBackend) }
+    -- @
+    --
+    -- Then you can use @DerivingVia@ to automatically get instances like:
+    --
+    -- @
+    -- deriving via BackendKey (Compatible SqlBackend BetterSqlBackend) instance Show (BackendKey BetterSqlBackend)
+    -- ...
+    -- @
+    --
+    -- These instances will go through the compatible backend's key (in this case,
+    -- @'BackendKey' 'SqlBackend'@) for all their logic.
+    newtype BackendKey (Compatible b s) = CompatibleKey { unCompatibleKey :: BackendKey b }
+
+instance (HasPersistBackend b, BackendCompatible b s, PersistStoreRead b) => PersistStoreRead (Compatible b s) where
+    get = withReaderT (projectBackend @b @s . unCompatible) . get
+    getMany = withReaderT (projectBackend @b @s . unCompatible) . getMany
+
+instance (HasPersistBackend b, BackendCompatible b s, PersistQueryRead b) => PersistQueryRead (Compatible b s) where
+    selectSourceRes filts opts = withReaderT (projectBackend @b @s . unCompatible) $ selectSourceRes filts opts
+    selectFirst filts opts = withReaderT (projectBackend @b @s . unCompatible) $ selectFirst filts opts
+    selectKeysRes filts opts = withReaderT (projectBackend @b @s . unCompatible) $ selectKeysRes filts opts
+    count = withReaderT (projectBackend @b @s . unCompatible) . count
+    exists = withReaderT (projectBackend @b @s . unCompatible) . exists
+
+instance (HasPersistBackend b, BackendCompatible b s, PersistQueryWrite b) => PersistQueryWrite (Compatible b s) where
+    updateWhere filts updates = withReaderT (projectBackend @b @s . unCompatible) $ updateWhere filts updates
+    deleteWhere = withReaderT (projectBackend @b @s . unCompatible) . deleteWhere
+
+instance (HasPersistBackend b, BackendCompatible b s, PersistUniqueRead b) => PersistUniqueRead (Compatible b s) where
+    getBy = withReaderT (projectBackend @b @s . unCompatible) . getBy
+
+instance (HasPersistBackend b, BackendCompatible b s, PersistStoreWrite b) => PersistStoreWrite (Compatible b s) where
+    insert = withReaderT (projectBackend @b @s . unCompatible) . insert
+    insert_ = withReaderT (projectBackend @b @s . unCompatible) . insert_
+    insertMany = withReaderT (projectBackend @b @s . unCompatible) . insertMany
+    insertMany_ = withReaderT (projectBackend @b @s . unCompatible) . insertMany_
+    insertEntityMany = withReaderT (projectBackend @b @s . unCompatible) . insertEntityMany
+    insertKey k = withReaderT (projectBackend @b @s . unCompatible) . insertKey k
+    repsert k = withReaderT (projectBackend @b @s . unCompatible) . repsert k
+    repsertMany = withReaderT (projectBackend @b @s . unCompatible) . repsertMany
+    replace k = withReaderT (projectBackend @b @s . unCompatible) . replace k
+    delete = withReaderT (projectBackend @b @s . unCompatible) . delete
+    update k = withReaderT (projectBackend @b @s . unCompatible) . update k
+    updateGet k = withReaderT (projectBackend @b @s . unCompatible) . updateGet k
+
+instance (HasPersistBackend b, BackendCompatible b s, PersistUniqueWrite b) => PersistUniqueWrite (Compatible b s) where
+    deleteBy = withReaderT (projectBackend @b @s . unCompatible) . deleteBy
+    insertUnique = withReaderT (projectBackend @b @s . unCompatible) . insertUnique
+    upsert rec = withReaderT (projectBackend @b @s . unCompatible) . upsert rec
+    upsertBy uniq rec = withReaderT (projectBackend @b @s . unCompatible) . upsertBy uniq rec
+    putMany = withReaderT (projectBackend @b @s . unCompatible) . putMany
+
+deriving via (BackendKey b) instance (BackendCompatible b s, Show (BackendKey b)) => Show (BackendKey (Compatible b s))
+deriving via (BackendKey b) instance (BackendCompatible b s, Read (BackendKey b)) => Read (BackendKey (Compatible b s))
+deriving via (BackendKey b) instance (BackendCompatible b s, Eq (BackendKey b)) => Eq (BackendKey (Compatible b s))
+deriving via (BackendKey b) instance (BackendCompatible b s, Ord (BackendKey b)) => Ord (BackendKey (Compatible b s))
+deriving via (BackendKey b) instance (BackendCompatible b s, Num (BackendKey b)) => Num (BackendKey (Compatible b s))
+deriving via (BackendKey b) instance (BackendCompatible b s, Integral (BackendKey b)) => Integral (BackendKey (Compatible b s))
+deriving via (BackendKey b) instance (BackendCompatible b s, PersistField (BackendKey b)) => PersistField (BackendKey (Compatible b s))
+deriving via (BackendKey b) instance (BackendCompatible b s, PersistFieldSql (BackendKey b)) => PersistFieldSql (BackendKey (Compatible b s))
+deriving via (BackendKey b) instance (BackendCompatible b s, Real (BackendKey b)) => Real (BackendKey (Compatible b s))
+deriving via (BackendKey b) instance (BackendCompatible b s, Enum (BackendKey b)) => Enum (BackendKey (Compatible b s))
+deriving via (BackendKey b) instance (BackendCompatible b s, Bounded (BackendKey b)) => Bounded (BackendKey (Compatible b s))
+deriving via (BackendKey b) instance (BackendCompatible b s, ToJSON (BackendKey b)) => ToJSON (BackendKey (Compatible b s))
+deriving via (BackendKey b) instance (BackendCompatible b s, FromJSON (BackendKey b)) => FromJSON (BackendKey (Compatible b s))

--- a/persistent/Database/Persist/Compatible/Types.hs
+++ b/persistent/Database/Persist/Compatible/Types.hs
@@ -51,6 +51,8 @@ import Control.Monad.Trans.Reader (withReaderT)
 -- @
 -- deriving via (Compatible SqlBackend BetterSqlBackend) instance HasPersistBackend BetterSqlBackend
 -- @
+--
+-- @since 2.12
 newtype Compatible b s = Compatible { unCompatible :: s }
 
 instance (BackendCompatible b s, HasPersistBackend b) => HasPersistBackend (Compatible b s) where

--- a/persistent/Database/Persist/Compatible/Types.hs
+++ b/persistent/Database/Persist/Compatible/Types.hs
@@ -9,8 +9,8 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module Database.Persist.Compatible.Types
-  ( Compatible(..)
-  ) where
+    ( Compatible(..)
+    ) where
 
 import Data.Aeson
 import Database.Persist.Class

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -59,7 +59,6 @@ library
 
                      Database.Persist.Types
                      Database.Persist.Class
-                     Database.Persist.Compatible
                      Database.Persist.Sql
                      Database.Persist.Sql.Util
                      Database.Persist.Sql.Types.Internal
@@ -73,9 +72,6 @@ library
                      Database.Persist.Class.PersistField
                      Database.Persist.Class.PersistStore
 
-                     Database.Persist.Compatible.Types
-                     Database.Persist.Compatible.TH
-
                      Database.Persist.Sql.Migration
                      Database.Persist.Sql.Internal
                      Database.Persist.Sql.Types
@@ -85,6 +81,12 @@ library
                      Database.Persist.Sql.Orphan.PersistQuery
                      Database.Persist.Sql.Orphan.PersistStore
                      Database.Persist.Sql.Orphan.PersistUnique
+
+    -- These modules only make sense for compilers with access to DerivingVia
+    if impl(ghc >= 8.6.1)
+      exposed-modules: Database.Persist.Compatible
+      other-modules: Database.Persist.Compatible.Types
+                     Database.Persist.Compatible.TH
 
     ghc-options:     -Wall
     default-language: Haskell2010

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -40,6 +40,7 @@ library
                    , resourcet-pool
                    , scientific
                    , silently
+                   , template-haskell         >= 2.4
                    , text                     >= 1.2
                    , time                     >= 1.6
                    , transformers             >= 0.5
@@ -58,6 +59,7 @@ library
 
                      Database.Persist.Types
                      Database.Persist.Class
+                     Database.Persist.Compatible
                      Database.Persist.Sql
                      Database.Persist.Sql.Util
                      Database.Persist.Sql.Types.Internal
@@ -70,6 +72,9 @@ library
                      Database.Persist.Class.PersistConfig
                      Database.Persist.Class.PersistField
                      Database.Persist.Class.PersistStore
+
+                     Database.Persist.Compatible.Types
+                     Database.Persist.Compatible.TH
 
                      Database.Persist.Sql.Migration
                      Database.Persist.Sql.Internal


### PR DESCRIPTION
If a backend is compatible with another, it has a lot of obvious instances for various Persistent classes in terms of the backend it is compatible with - `RawSqlite` in the codebase is one example.

This adds a newtype, `Compatible`, which has these compatible instances declared on it. `Compatible` is designed to be used with `DerivingVia` to automatically yield these compatible instances when given a witness of backend compatibility.

To help use `Compatible` and write all the standalone derivations necessary to get a fully-featured compatible backend, this also adds some TH invocations to generate the standalone derivations for a given pair of compatible backend types.

`RawSqlite` is rewritten to dogfood on thes invocations, to prove their effectiveness and simplify the code somewhat.

Before submitting your PR, check that you've:

- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
