### PR TITLE
Relaxes mysql upper bound

### DIFF
--- a/persistent-mysql/persistent-mysql.cabal
+++ b/persistent-mysql/persistent-mysql.cabal
@@ -35,7 +35,7 @@ library
                    , conduit          >= 1.2.12
                    , containers       >= 0.5
                    , monad-logger
-                   , mysql            >= 0.1.4    && < 0.2
+                   , mysql            >= 0.1.4    && < 0.3
                    , mysql-simple     >= 0.4.4    && < 0.5
                    , resourcet        >= 1.1
                    , resource-pool


### PR DESCRIPTION
Relates to https://github.com/commercialhaskell/stackage/issues/5891.

I haven't tested this out locally, but the changelog for `mysql-0.2` makes it seem like the only breaking change introduced doesn't affect `persistent-mysql` at first glance (cf. https://hackage.haskell.org/package/mysql-0.2/changelog).

Hopefully CI is enough of a sanity check, but let me know if there's anything I should try out locally that would help get this merged.