### PR TITLE
that's what i get for trusting my zsh prompt

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,6 +1,6 @@
 # Changelog for persistent
 
-## 2.12 (unreleased)
+## 2.12.0.1 (unreleased)
 
 * Refactor [] to NonEmpty in Quasi module [#1193](https://github.com/yesodweb/persistent/pull/1193)
 * [#1162](https://github.com/yesodweb/persistent/pull/1162)

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:            persistent
-version:         2.12.0.0
+version:         2.12.0.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
I accidentally published `persistent-2.12.0.0` -_-

This MR bumps the version.

I've deprecated the 2.12 release as it's not ready to go yet and made it unbuildable on Hackage.