### PR TITLE
Refactoring name generating functions in TH

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 2.12.1.0
 
-* [#1218](https://github.com/yesodweb/persistent/pull/1218) Refactoring name generating functions in TH
+* Refactoring name generating functions in TH [#1218](https://github.com/yesodweb/persistent/pull/1218)
 * [#1226](https://github.com/yesodweb/persistent/pull/1226)
     * Expose the `filterClause` and `filterClauseWithValues` functions to support
       the `upsertWhere` functionality in `persistent-postgresql`.

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -2,7 +2,8 @@
 
 ## 2.12.1.0
 
-*  [#1226](https://github.com/yesodweb/persistent/pull/1226)
+* [#1218](https://github.com/yesodweb/persistent/pull/1218) Refactoring name generating functions in TH
+* [#1226](https://github.com/yesodweb/persistent/pull/1226)
     * Expose the `filterClause` and `filterClauseWithValues` functions to support
       the `upsertWhere` functionality in `persistent-postgresql`.
 

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -2,7 +2,8 @@
 
 ## 2.12.1.0
 
-* Refactoring name generating functions in TH [#1218](https://github.com/yesodweb/persistent/pull/1218)
+* [#1218](https://github.com/yesodweb/persistent/pull/1218)
+    * Refactoring name generating functions in TH 
 * [#1226](https://github.com/yesodweb/persistent/pull/1226)
     * Expose the `filterClause` and `filterClauseWithValues` functions to support
       the `upsertWhere` functionality in `persistent-postgresql`.

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -1503,8 +1503,8 @@ mkEntityDefList entityList entityDefs = do
     let entityListName = mkName entityList
     edefs <- fmap ListE
         . forM entityDefs
-        $ \entityDef ->
-            let entityType = conT (mkEntityDefName entityDef)
+        $ \entDef ->
+            let entityType = conT (mkEntityDefName entDef)
              in [|entityDef (Proxy :: Proxy $(entityType))|]
     typ <- [t|[EntityDef]|]
     pure

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -1736,26 +1736,6 @@ mkField mps et cd = do
 maybeNullable :: FieldDef -> Bool
 maybeNullable fd = nullable (fieldAttrs fd) == Nullable ByMaybeAttr
 
-filterConName :: MkPersistSettings
-              -> EntityDef
-              -> FieldDef
-              -> Name
-filterConName mps entity field = filterConName' mps (entityHaskell entity) (fieldHaskell field)
-
-filterConName' :: MkPersistSettings
-               -> EntityNameHS
-               -> FieldNameHS
-               -> Name
-filterConName' mps entity field = mkName $ unpack name
-    where
-        name
-            | field == FieldNameHS "Id" = entityName ++ fieldName
-            | mpsPrefixFields mps       = modifiedName
-            | otherwise                 = fieldName
-        modifiedName = mpsConstraintLabelModifier mps entityName fieldName
-        entityName   = unEntityNameHS entity
-        fieldName    = upperFirst $ unFieldNameHS field
-
 ftToType :: FieldType -> Type
 ftToType (FTTypeCon Nothing t) = ConT $ mkName $ unpack t
 -- This type is generated from the Quasi-Quoter.
@@ -2045,3 +2025,23 @@ keyFieldName :: MkPersistSettings -> EntityDef -> FieldDef -> Name
 keyFieldName mps entDef fieldDef
   | pkNewtype mps entDef = unKeyName entDef
   | otherwise = mkName $ T.unpack $ lowerFirst (keyText entDef) `mappend` unFieldNameHS (fieldHaskell fieldDef)
+
+filterConName :: MkPersistSettings
+              -> EntityDef
+              -> FieldDef
+              -> Name
+filterConName mps entity field = filterConName' mps (entityHaskell entity) (fieldHaskell field)
+
+filterConName' :: MkPersistSettings
+               -> EntityNameHS
+               -> FieldNameHS
+               -> Name
+filterConName' mps entity field = mkName $ unpack name
+    where
+        name
+            | field == FieldNameHS "Id" = entityName ++ fieldName
+            | mpsPrefixFields mps       = modifiedName
+            | otherwise                 = fieldName
+        modifiedName = mpsConstraintLabelModifier mps entityName fieldName
+        entityName   = unEntityNameHS entity
+        fieldName    = upperFirst $ unFieldNameHS field

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -611,7 +611,7 @@ dataTypeDec mps entDef = do
     (nameFinal, paramsFinal)
         | mpsGeneric mps = (mkEntityDefGenericName entDef, [PlainTV backendName])
         | otherwise = (mkEntityDefName entDef, [])
-    cols = map (mkCol $ entityHaskell entDef) $ entityFields entDef
+    cols = map (mkCol entDef) $ entityFields entDef
 
     constrs
         | entitySum entDef = map sumCon $ entityFields entDef
@@ -835,7 +835,7 @@ mkLensClauses mps entDef = do
         [ConP (filterConName mps entDef f) []]
         (lens' `AppE` getter `AppE` setter)
       where
-        fieldName = mkRecName mps (entityHaskell entDef) (fieldHaskell f)
+        fieldName = mkRecName mps entDef (fieldHaskell f)
         getter = InfixE (Just $ VarE fieldName) dot (Just getVal)
         setter = LamE
             [ ConP 'Entity [VarP keyVar, VarP valName]
@@ -1114,7 +1114,7 @@ mkEntity entityMap mps entDef = do
                 recordName <- newName "record"
                 let keyCon = keyConName entDef
                     keyFields' =
-                        map (mkRecName mps entName . fieldHaskell)
+                        map (mkRecName mps entDef . fieldHaskell)
                             (compositeFields prim)
                     constr =
                         foldl'
@@ -1269,7 +1269,7 @@ mkLenses mps _ | not (mpsGenerateLenses mps) = return []
 mkLenses _ ent | entitySum ent = return []
 mkLenses mps ent = fmap mconcat $ forM (entityFields ent) $ \field -> do
     let lensName = mkName $ T.unpack $ recNameNoUnderscore mps (entityHaskell ent) (fieldHaskell field)
-        fieldName = mkRecName mps (entityHaskell ent) (fieldHaskell field)
+        fieldName = mkRecName mps ent (fieldHaskell field)
     needleN <- newName "needle"
     setterN <- newName "setter"
     fN <- newName "f"
@@ -1315,7 +1315,7 @@ mkLenses mps ent = fmap mconcat $ forM (entityFields ent) $ \field -> do
 mkForeignKeysComposite :: MkPersistSettings -> EntityDef -> ForeignDef -> Q [Dec]
 mkForeignKeysComposite mps entDef ForeignDef {..} =
     if not foreignToPrimary then return [] else do
-    let fieldName f = mkRecName mps (entityHaskell entDef) f
+    let fieldName f = mkRecName mps entDef f
     let fname = fieldName (constraintToField foreignConstraintNameHaskell)
     let reftableString = unpack $ unEntityNameHS foreignRefTableHaskell
     let reftableKeyName = mkName $ reftableString `mappend` "Key"
@@ -1960,8 +1960,8 @@ entityDefConE = ConE . mkEntityDefName
 --   name Text
 --
 -- This would generate `customerName` as a TH Name
-mkRecName :: MkPersistSettings -> EntityNameHS -> FieldNameHS -> Name
-mkRecName mps entName fieldName = mkName $ T.unpack $ recNameF mps entName fieldName
+mkRecName :: MkPersistSettings -> EntityDef -> FieldNameHS -> Name
+mkRecName mps entDef fieldName = mkName $ T.unpack $ recNameF mps (entityHaskell entDef) fieldName
 
 -- | Take an EntityDef's `entityDerives` and turn them into TH Names
 mkEntityDefDeriveNames :: EntityDef -> [Name]

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -639,8 +639,8 @@ uniqueTypeDec mps entDef =
 #endif
 
 mkUnique :: MkPersistSettings -> EntityDef -> UniqueDef -> Con
-mkUnique mps entDef (UniqueDef (ConstraintNameHS constr) _ fields attrs) =
-    NormalC (mkName $ unpack constr) types
+mkUnique mps entDef (UniqueDef constr _ fields attrs) =
+    NormalC (mkConstraintName constr) types
   where
     types =
       map (go . flip lookup3 (entityFields entDef) . unFieldNameHS . fst) fields
@@ -653,7 +653,7 @@ mkUnique mps entDef (UniqueDef (ConstraintNameHS constr) _ fields attrs) =
 
     lookup3 :: Text -> [FieldDef] -> (FieldDef, IsNullable)
     lookup3 s [] =
-        error $ unpack $ "Column not found: " ++ s ++ " in unique " ++ constr
+        error $ unpack $ "Column not found: " ++ s ++ " in unique " ++ unConstraintNameHS constr
     lookup3 x (fd@FieldDef {..}:rest)
         | x == unFieldNameHS fieldHaskell = (fd, nullable fieldAttrs)
         | otherwise = lookup3 x rest
@@ -2037,3 +2037,8 @@ sumConstrName mps entDef FieldDef {..} = mkName $ T.unpack name
         modifiedName = mpsConstraintLabelModifier mps entityName fieldName
         entityName   = unEntityNameHS $ entityHaskell entDef
         fieldName    = upperFirst $ unFieldNameHS fieldHaskell
+
+-- | Turn a ConstraintName into a TH Name
+mkConstraintName :: ConstraintNameHS -> Name
+mkConstraintName (ConstraintNameHS name) =
+    mkName (T.unpack name)

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -574,7 +574,7 @@ upperFirst t =
 
 dataTypeDec :: MkPersistSettings -> EntityDef -> Q Dec
 dataTypeDec mps entDef = do
-    let entityInstances     = map (mkName . unpack) $ entityDerives entDef
+    let entityInstances     = mkEntityDefDeriveNames entDef
         additionalInstances = filter (`notElem` entityInstances) $ mpsDeriveInstances mps
         names               = entityInstances <> additionalInstances
 
@@ -2026,3 +2026,7 @@ unFieldNameHSForJSON = fixTypeUnderscore . unFieldNameHS
 -- This would generate `customerName` as a TH Name
 mkRecName :: MkPersistSettings -> EntityNameHS -> FieldNameHS -> Name
 mkRecName mps entName fieldName = mkName $ T.unpack $ recNameF mps entName fieldName
+
+-- | Take an EntityDef's `entityDerives` and turn them into TH Names
+mkEntityDefDeriveNames :: EntityDef -> [Name]
+mkEntityDefDeriveNames = fmap (mkName . T.unpack) . entityDerives

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -1503,8 +1503,8 @@ mkEntityDefList entityList entityDefs = do
     let entityListName = mkName entityList
     edefs <- fmap ListE
         . forM entityDefs
-        $ \(EntityDef { entityHaskell = EntityNameHS haskellName }) ->
-            let entityType = conT (mkName (T.unpack haskellName))
+        $ \entityDef ->
+            let entityType = conT (mkEntityDefName entityDef)
              in [|entityDef (Proxy :: Proxy $(entityType))|]
     typ <- [t|[EntityDef]|]
     pure
@@ -1526,7 +1526,7 @@ mkUniqueKeys def = do
             return (x, x')
         let pcs = map (go xs) $ entityUniques def
         let pat = ConP
-                (mkName $ unpack $ unEntityNameHS $ entityHaskell def)
+                (mkEntityDefName def)
                 (map (VarP . snd) xs)
         return $ normalClause [pat] (ListE pcs)
 
@@ -1896,13 +1896,13 @@ mkSymbolToFieldInstances mps ed = do
                 litT $ strTyLit $ T.unpack $ unFieldNameHS $ fieldHaskell fieldDef
                     :: Q Type
 
-            nameG = mkName $ unpack $ unEntityNameHS (entityHaskell ed) ++ "Generic"
+            nameG = mkEntityDefGenericName ed
 
             recordNameT
                 | mpsGeneric mps =
                     conT nameG `appT` varT backendName
                 | otherwise =
-                    conT $ mkName $ T.unpack $ unEntityNameHS $ entityHaskell ed
+                    conT $ mkEntityDefName ed
 
             fieldTypeT =
                 maybeIdType mps fieldDef Nothing Nothing

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -1204,7 +1204,7 @@ mkUniqueKeyInstances mps entDef = do
     withPersistStoreWriteCxt =
         if mpsGeneric mps
             then do
-                write <- [t|PersistStoreWrite $(pure (VarT $ mkName "backend")) |]
+                write <- [t|PersistStoreWrite $(pure backendT) |]
                 pure [write]
             else do
                 pure []

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -966,39 +966,6 @@ mkKeyTypeDec mps entDef = do
     supplement :: [Name] -> [Name]
     supplement names = names <> (filter (`notElem` names) $ mpsDeriveInstances mps)
 
-keyIdName :: EntityDef -> Name
-keyIdName = mkName . unpack . keyIdText
-
-keyIdText :: EntityDef -> Text
-keyIdText entDef = unEntityNameHS (entityHaskell entDef) `mappend` "Id"
-
-unKeyName :: EntityDef -> Name
-unKeyName entDef = mkName $ "un" `mappend` keyString entDef
-
-unKeyExp :: EntityDef -> Exp
-unKeyExp = VarE . unKeyName
-
-backendT :: Type
-backendT = VarT backendName
-
-backendName :: Name
-backendName = mkName "backend"
-
-keyConName :: EntityDef -> Name
-keyConName entDef = mkName $ resolveConflict $ keyString entDef
-  where
-    resolveConflict kn = if conflict then kn `mappend` "'" else kn
-    conflict = any ((== FieldNameHS "key") . fieldHaskell) $ entityFields entDef
-
-keyConExp :: EntityDef -> Exp
-keyConExp = ConE . keyConName
-
-keyString :: EntityDef -> String
-keyString = unpack . keyText
-
-keyText :: EntityDef -> Text
-keyText entDef = unEntityNameHS (entityHaskell entDef) ++ "Key"
-
 -- | Returns 'True' if the key definition has more than 1 field.
 --
 -- @since 2.11.0.0
@@ -1023,11 +990,6 @@ keyFields mps entDef = case entityPrimary entDef of
                        , notStrict
                        , ftToType $ fieldType fieldDef
                        )
-
-keyFieldName :: MkPersistSettings -> EntityDef -> FieldDef -> Name
-keyFieldName mps entDef fieldDef
-  | pkNewtype mps entDef = unKeyName entDef
-  | otherwise = mkName $ unpack $ lowerFirst (keyText entDef) `mappend` unFieldNameHS (fieldHaskell fieldDef)
 
 mkKeyToValues :: MkPersistSettings -> EntityDef -> Q Dec
 mkKeyToValues mps entDef = do
@@ -2049,3 +2011,38 @@ sumConstrName mps entDef FieldDef {..} = mkName $ T.unpack name
 mkConstraintName :: ConstraintNameHS -> Name
 mkConstraintName (ConstraintNameHS name) =
     mkName (T.unpack name)
+
+keyIdName :: EntityDef -> Name
+keyIdName = mkName . T.unpack . keyIdText
+
+keyIdText :: EntityDef -> Text
+keyIdText entDef = unEntityNameHS (entityHaskell entDef) `mappend` "Id"
+
+unKeyName :: EntityDef -> Name
+unKeyName entDef = mkName $ T.unpack $ "un" `mappend` keyText entDef
+
+unKeyExp :: EntityDef -> Exp
+unKeyExp = VarE . unKeyName
+
+backendT :: Type
+backendT = VarT backendName
+
+backendName :: Name
+backendName = mkName "backend"
+
+keyConName :: EntityDef -> Name
+keyConName entDef = mkName $ T.unpack $ resolveConflict $ keyText entDef
+  where
+    resolveConflict kn = if conflict then kn `mappend` "'" else kn
+    conflict = any ((== FieldNameHS "key") . fieldHaskell) $ entityFields entDef
+
+keyConExp :: EntityDef -> Exp
+keyConExp = ConE . keyConName
+
+keyText :: EntityDef -> Text
+keyText entDef = unEntityNameHS (entityHaskell entDef) ++ "Key"
+
+keyFieldName :: MkPersistSettings -> EntityDef -> FieldDef -> Name
+keyFieldName mps entDef fieldDef
+  | pkNewtype mps entDef = unKeyName entDef
+  | otherwise = mkName $ T.unpack $ lowerFirst (keyText entDef) `mappend` unFieldNameHS (fieldHaskell fieldDef)

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -573,9 +573,7 @@ upperFirst t =
 
 dataTypeDec :: MkPersistSettings -> EntityDef -> Q Dec
 dataTypeDec mps entDef = do
-    let entityInstances     = mkEntityDefDeriveNames entDef
-        additionalInstances = filter (`notElem` entityInstances) $ mpsDeriveInstances mps
-        names               = entityInstances <> additionalInstances
+    let names = mkEntityDefDeriveNames mps entDef
 
     let (stocks, anyclasses) = partitionEithers (map stratFor names)
     let stockDerives = do
@@ -1963,9 +1961,12 @@ entityDefConE = ConE . mkEntityDefName
 mkRecName :: MkPersistSettings -> EntityDef -> FieldNameHS -> Name
 mkRecName mps entDef fieldName = mkName $ T.unpack $ recNameF mps (entityHaskell entDef) fieldName
 
--- | Take an EntityDef's `entityDerives` and turn them into TH Names
-mkEntityDefDeriveNames :: EntityDef -> [Name]
-mkEntityDefDeriveNames = fmap (mkName . T.unpack) . entityDerives
+-- | Construct a list of TH Names for the typeclasses of an EntityDef's `entityDerives`
+mkEntityDefDeriveNames :: MkPersistSettings -> EntityDef -> [Name]
+mkEntityDefDeriveNames mps entDef =
+    let entityInstances = mkName . T.unpack <$> entityDerives entDef
+        additionalInstances = filter (`notElem` entityInstances) $ mpsDeriveInstances mps
+     in entityInstances <> additionalInstances
 
 -- | Make a TH Name for the EntityDef's Haskell type
 mkEntityDefName :: EntityDef -> Name

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -1268,9 +1268,8 @@ mkLenses :: MkPersistSettings -> EntityDef -> Q [Dec]
 mkLenses mps _ | not (mpsGenerateLenses mps) = return []
 mkLenses _ ent | entitySum ent = return []
 mkLenses mps ent = fmap mconcat $ forM (entityFields ent) $ \field -> do
-    let lensName' = recNameNoUnderscore mps (entityHaskell ent) (fieldHaskell field)
-        lensName = mkName $ unpack lensName'
-        fieldName = mkName $ unpack $ "_" ++ lensName'
+    let lensName = mkName $ T.unpack $ recNameNoUnderscore mps (entityHaskell ent) (fieldHaskell field)
+        fieldName = mkRecName mps (entityHaskell ent) (fieldHaskell field)
     needleN <- newName "needle"
     setterN <- newName "setter"
     fN <- newName "f"

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -622,16 +622,6 @@ dataTypeDec mps entDef = do
         (sumConstrName mps entDef fieldDef)
         [(notStrict, maybeIdType mps fieldDef Nothing Nothing)]
 
-sumConstrName :: MkPersistSettings -> EntityDef -> FieldDef -> Name
-sumConstrName mps entDef FieldDef {..} = mkName $ unpack name
-    where
-        name
-            | mpsPrefixFields mps = modifiedName ++ "Sum"
-            | otherwise           = fieldName ++ "Sum"
-        modifiedName = mpsConstraintLabelModifier mps entityName fieldName
-        entityName   = unEntityNameHS $ entityHaskell entDef
-        fieldName    = upperFirst $ unFieldNameHS fieldHaskell
-
 uniqueTypeDec :: MkPersistSettings -> EntityDef -> Dec
 uniqueTypeDec mps entDef =
 #if MIN_VERSION_template_haskell(2,15,0)
@@ -2028,10 +2018,22 @@ mkRecName mps entName fieldName = mkName $ T.unpack $ recNameF mps entName field
 mkEntityDefDeriveNames :: EntityDef -> [Name]
 mkEntityDefDeriveNames = fmap (mkName . T.unpack) . entityDerives
 
+-- | Make a TH Name for the EntityDef's Haskell type
+mkEntityDefName :: EntityDef -> Name
+mkEntityDefName entDef =
+    mkName $ T.unpack $ unEntityNameHS (entityHaskell entDef)
+
+-- | Make a TH Name for the EntityDef's Haskell type, when using mpsGeneric
 mkEntityDefGenericName :: EntityDef -> Name
 mkEntityDefGenericName entDef =
     mkName $ T.unpack $ unEntityNameHS (entityHaskell entDef) <> "Generic"
 
-mkEntityDefName :: EntityDef -> Name
-mkEntityDefName entDef =
-    mkName $ T.unpack $ unEntityNameHS (entityHaskell entDef)
+sumConstrName :: MkPersistSettings -> EntityDef -> FieldDef -> Name
+sumConstrName mps entDef FieldDef {..} = mkName $ T.unpack name
+    where
+        name
+            | mpsPrefixFields mps = modifiedName ++ "Sum"
+            | otherwise           = fieldName ++ "Sum"
+        modifiedName = mpsConstraintLabelModifier mps entityName fieldName
+        entityName   = unEntityNameHS $ entityHaskell entDef
+        fieldName    = upperFirst $ unFieldNameHS fieldHaskell

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -1319,7 +1319,7 @@ mkForeignKeysComposite mps entDef ForeignDef {..} =
     let fname = fieldName (constraintToField foreignConstraintNameHaskell)
     let reftableString = unpack $ unEntityNameHS foreignRefTableHaskell
     let reftableKeyName = mkName $ reftableString `mappend` "Key"
-    let tablename = mkName $ unpack $ entityText entDef
+    let tablename = mkEntityDefName entDef
     recordName <- newName "record"
 
     let mkFldE ((foreignName, _),ff) = case ff of

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -2036,7 +2036,7 @@ filterConName' :: MkPersistSettings
                -> EntityNameHS
                -> FieldNameHS
                -> Name
-filterConName' mps entity field = mkName $ unpack name
+filterConName' mps entity field = mkName $ T.unpack name
     where
         name
             | field == FieldNameHS "Id" = entityName ++ fieldName

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -754,7 +754,7 @@ mkToFieldNames pairs = do
         names' <- lift names
         return $
             normalClause
-                [RecP (mkName $ unpack $ unConstraintNameHS constr) []]
+                [RecP (mkConstraintName constr) []]
                 names'
 
 mkUniqueToValues :: [UniqueDef] -> Q Dec
@@ -765,7 +765,7 @@ mkUniqueToValues pairs = do
     go :: UniqueDef -> Q Clause
     go (UniqueDef constr _ names _) = do
         xs <- mapM (const $ newName "x") names
-        let pat = ConP (mkName $ unpack $ unConstraintNameHS constr) $ map VarP xs
+        let pat = ConP (mkConstraintName constr) $ map VarP xs
         tpv <- [|toPersistValue|]
         let bod = ListE $ map (AppE tpv . VarE) xs
         return $ normalClause [pat] bod
@@ -1572,7 +1572,7 @@ mkUniqueKeys def = do
 
     go :: [(FieldNameHS, Name)] -> UniqueDef -> Exp
     go xs (UniqueDef name _ cols _) =
-        foldl' (go' xs) (ConE (mkName $ unpack $ unConstraintNameHS name)) (map fst cols)
+        foldl' (go' xs) (ConE (mkConstraintName name)) (map fst cols)
 
     go' :: [(FieldNameHS, Name)] -> Exp -> FieldNameHS -> Exp
     go' xs front col =

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -782,8 +782,7 @@ mkFromPersistValues :: MkPersistSettings -> EntityDef -> Q [Clause]
 mkFromPersistValues _ entDef@(EntityDef { entitySum = False }) =
     fromValues entDef "fromPersistValues" entE $ entityFields entDef
   where
-    entE = ConE $ mkName $ unpack entName
-    entName = unEntityNameHS $ entityHaskell entDef
+    entE = ConE $ mkEntityDefName entDef
 
 mkFromPersistValues mps entDef@(EntityDef { entitySum = True }) = do
     nothing <- [|Left ("Invalid fromPersistValues input: sum type with all nulls. Entity: " `mappend` entName)|]

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -602,7 +602,7 @@ dataTypeDec mps entDef = do
         ]
         )
     mkCol x fd@FieldDef {..} =
-        (mkRecName mps x fieldHaskell,
+        (mkFieldDefRecordName mps x fieldHaskell,
          if fieldStrict then isStrict else notStrict,
          maybeIdType mps fd Nothing Nothing
         )
@@ -833,7 +833,7 @@ mkLensClauses mps entDef = do
         [ConP (filterConName mps entDef f) []]
         (lens' `AppE` getter `AppE` setter)
       where
-        fieldName = mkRecName mps entDef (fieldHaskell f)
+        fieldName = mkFieldDefRecordName mps entDef (fieldHaskell f)
         getter = InfixE (Just $ VarE fieldName) dot (Just getVal)
         setter = LamE
             [ ConP 'Entity [VarP keyVar, VarP valName]
@@ -1112,7 +1112,7 @@ mkEntity entityMap mps entDef = do
                 recordName <- newName "record"
                 let keyCon = keyConName entDef
                     keyFields' =
-                        map (mkRecName mps entDef . fieldHaskell)
+                        map (mkFieldDefRecordName mps entDef . fieldHaskell)
                             (compositeFields prim)
                     constr =
                         foldl'
@@ -1267,7 +1267,7 @@ mkLenses mps _ | not (mpsGenerateLenses mps) = return []
 mkLenses _ ent | entitySum ent = return []
 mkLenses mps ent = fmap mconcat $ forM (entityFields ent) $ \field -> do
     let lensName = mkName $ T.unpack $ recNameNoUnderscore mps (entityHaskell ent) (fieldHaskell field)
-        fieldName = mkRecName mps ent (fieldHaskell field)
+        fieldName = mkFieldDefRecordName mps ent (fieldHaskell field)
     needleN <- newName "needle"
     setterN <- newName "setter"
     fN <- newName "f"
@@ -1313,7 +1313,7 @@ mkLenses mps ent = fmap mconcat $ forM (entityFields ent) $ \field -> do
 mkForeignKeysComposite :: MkPersistSettings -> EntityDef -> ForeignDef -> Q [Dec]
 mkForeignKeysComposite mps entDef ForeignDef {..} =
     if not foreignToPrimary then return [] else do
-    let fieldName f = mkRecName mps entDef f
+    let fieldName f = mkFieldDefRecordName mps entDef f
     let fname = fieldName (constraintToField foreignConstraintNameHaskell)
     let reftableString = unpack $ unEntityNameHS foreignRefTableHaskell
     let reftableKeyName = mkName $ reftableString `mappend` "Key"
@@ -1958,8 +1958,8 @@ entityDefConE = ConE . mkEntityDefName
 --   name Text
 --
 -- This would generate `customerName` as a TH Name
-mkRecName :: MkPersistSettings -> EntityDef -> FieldNameHS -> Name
-mkRecName mps entDef fieldName = mkName $ T.unpack $ recNameF mps (entityHaskell entDef) fieldName
+mkFieldDefRecordName :: MkPersistSettings -> EntityDef -> FieldNameHS -> Name
+mkFieldDefRecordName mps entDef fieldName = mkName $ T.unpack $ recNameF mps (entityHaskell entDef) fieldName
 
 -- | Construct a list of TH Names for the typeclasses of an EntityDef's `entityDerives`
 mkEntityDefDeriveNames :: MkPersistSettings -> EntityDef -> [Name]

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -610,16 +610,13 @@ dataTypeDec mps entDef = do
          maybeIdType mps fd Nothing Nothing
         )
     (nameFinal, paramsFinal)
-        | mpsGeneric mps = (nameG, [PlainTV backend])
-        | otherwise = (name, [])
-    nameG = mkName $ unpack $ unEntityNameHS (entityHaskell entDef) ++ "Generic"
-    name = mkName $ unpack $ unEntityNameHS $ entityHaskell entDef
+        | mpsGeneric mps = (mkEntityDefGenericName entDef, [PlainTV backendName])
+        | otherwise = (mkEntityDefName entDef, [])
     cols = map (mkCol $ entityHaskell entDef) $ entityFields entDef
-    backend = backendName
 
     constrs
         | entitySum entDef = map sumCon $ entityFields entDef
-        | otherwise = [RecC name cols]
+        | otherwise = [RecC (mkEntityDefName entDef) cols]
 
     sumCon fieldDef = NormalC
         (sumConstrName mps entDef fieldDef)
@@ -2030,3 +2027,11 @@ mkRecName mps entName fieldName = mkName $ T.unpack $ recNameF mps entName field
 -- | Take an EntityDef's `entityDerives` and turn them into TH Names
 mkEntityDefDeriveNames :: EntityDef -> [Name]
 mkEntityDefDeriveNames = fmap (mkName . T.unpack) . entityDerives
+
+mkEntityDefGenericName :: EntityDef -> Name
+mkEntityDefGenericName entDef =
+    mkName $ T.unpack $ unEntityNameHS (entityHaskell entDef) <> "Generic"
+
+mkEntityDefName :: EntityDef -> Name
+mkEntityDefName entDef =
+    mkName $ T.unpack $ unEntityNameHS (entityHaskell entDef)


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

---

Refactors the `TH` module, specifically themed around generating `TH` `Name`s, or `Exp` values that use those names. 

Now I think this module is a lot dry'er, where we have some duplication currently scattered around this module dealing with how names are generated.

For example, the Entity name when using `mpsGeneric` was duplicated in 3 different places, this change has DRY'd this up into a single function.

I considered moving these functions out and into their own module, and adding some HSpec tests for each name generating function, for the key name generating functions at least, such as the constructor name/field accessor names, but thought this might be over kill. I think this functionality is largely covered in `persistent-test` so thought best of doing that. I have grouped these functions at the bottom of the module anyway.

I think there is probably more we can do here to make this module a bit easier to follow in line with https://github.com/yesodweb/persistent/issues/1156 while also trying to balance out not changing too much in a single change request. Hopefully there are some values/functions in here now with some slightly clearer names too.

I took a very incremental approach to this change, so there are a lot of commits here. I've left them as they are for now, but if it is preferred that they're squashed into a single commit I can do so :+1: 