### PR TITLE
Add upper bound on template-haskell

### DIFF
--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -32,7 +32,7 @@ library
                    , resourcet                >= 1.1.10
                    , scientific
                    , silently
-                   , template-haskell         >= 2.11
+                   , template-haskell         >= 2.11 && < 2.17
                    , text                     >= 1.2
                    , time                     >= 1.6
                    , transformers             >= 0.5


### PR DESCRIPTION
`template-haskell-2.17` has some breaking changes, as reported in #1220 

This PR blocks `template-haskell-2.17` in the repo to correspond with the Hackage revision I made.