### PR TITLE
Fixing Haddock formatting for a new method

### DIFF
--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -1874,14 +1874,10 @@ upsertManyWhere ::
       PersistEntity record,
       MonadIO m
     ) =>
-    -- | A list of the records you want to insert, or update
-    [record] ->
-    -- | A list of the fields you want to copy over.
-    [HandleUpdateCollision record] ->
-    -- | A list of the updates to apply that aren't dependent on the record being inserted.
-    [Update record] ->
-    -- | A filter condition that dictates the scope of the updates
-    [Filter record] ->
+    [record] -> -- ^ A list of the records you want to insert, or update
+    [HandleUpdateCollision record] -> -- ^ A list of the fields you want to copy over.
+    [Update record] -> -- ^ A list of the updates to apply that aren't dependent on the record being inserted.
+    [Filter record] -> -- ^ A filter condition that dictates the scope of the updates
     ReaderT backend m ()
 upsertManyWhere [] _ _ _ = return ()
 upsertManyWhere records fieldValues updates filters = do

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -1865,7 +1865,7 @@ excludeNotEqualToOriginal field =
 -- Called thusly, this method will insert a new record (if none exists) OR update a recordField with a new value
 -- assuming the condition in the last block is met.
 --
--- -- @since 2.12.1.0
+-- @since 2.12.1.0
 upsertManyWhere ::
     forall record backend m.
     ( backend ~ PersistEntityBackend record,


### PR DESCRIPTION
This change fixes https://github.com/yesodweb/persistent/issues/1227

Before submitting your PR, check that you've:

- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [x] Ran `stylish-haskell` on any changed files.
- [x] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
