### PR TITLE
Simplify Line type in Quasi module, always use NonEmpty

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,9 +1,12 @@
 # Changelog for persistent
 
-## 2.12.1.0
+## 2.12.1.1
 
 * [#1231](https://github.com/yesodweb/persistent/pull/1231)
     * Simplify Line type in Quasi module, always use NonEmpty 
+
+## 2.12.1.0
+
 * [#1218](https://github.com/yesodweb/persistent/pull/1218)
     * Refactoring name generating functions in TH 
 * [#1226](https://github.com/yesodweb/persistent/pull/1226)

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## 2.12.1.0
 
+* [#1231](https://github.com/yesodweb/persistent/pull/1231)
+    * Simplify Line type in Quasi module, always use NonEmpty 
 * [#1218](https://github.com/yesodweb/persistent/pull/1218)
     * Refactoring name generating functions in TH 
 * [#1226](https://github.com/yesodweb/persistent/pull/1226)

--- a/persistent/Database/Persist/Quasi.hs
+++ b/persistent/Database/Persist/Quasi.hs
@@ -544,8 +544,7 @@ preparse txt = do
 
 parseLine :: Text -> Maybe Line
 parseLine txt = do
-    parsedTokens <- NEL.nonEmpty (tokenize txt)
-    pure $ Line (parseIndentationAmount txt) parsedTokens
+    Line (parseIndentationAmount txt) <$> NEL.nonEmpty (tokenize txt)
 
 -- | A token used by the parser.
 data Token = Token Text    -- ^ @Token tok@ is token @tok@ already unquoted.
@@ -624,11 +623,7 @@ data Line = Line
 lineText :: Line -> NonEmpty Text
 lineText = fmap tokenText . tokens
 
-lowestIndent
-    :: Functor f
-    => Foldable f
-    => f Line
-    -> Int
+lowestIndent :: NonEmpty Line -> Int
 lowestIndent = minimum . fmap lineIndent
 
 -- | Divide lines into blocks and make entity definitions.

--- a/persistent/Database/Persist/Quasi.hs
+++ b/persistent/Database/Persist/Quasi.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -434,15 +434,15 @@ module Database.Persist.Quasi
 
 import Prelude hiding (lines)
 
-import Control.Applicative ( Alternative((<|>)) )
+import Control.Applicative (Alternative((<|>)))
 import Control.Arrow ((&&&))
-import Control.Monad (msum, mplus)
-import Data.Char ( isLower, isSpace, isUpper, toLower )
+import Control.Monad (mplus, msum)
+import Data.Char (isLower, isSpace, isUpper, toLower)
 import Data.List (find, foldl')
-import qualified Data.List.NonEmpty as NEL
 import Data.List.NonEmpty (NonEmpty(..))
+import qualified Data.List.NonEmpty as NEL
 import qualified Data.Map as M
-import Data.Maybe (mapMaybe, fromMaybe, maybeToList, listToMaybe)
+import Data.Maybe (fromMaybe, listToMaybe, mapMaybe, maybeToList)
 import Data.Monoid (mappend)
 #if !MIN_VERSION_base(4,11,0)
 -- This can be removed when GHC < 8.2.2 isn't supported anymore

--- a/persistent/test/main.hs
+++ b/persistent/test/main.hs
@@ -9,7 +9,7 @@ import Test.QuickCheck
 import qualified Data.Char as Char
 import qualified Data.Text as T
 import Data.List
-import Data.List.NonEmpty (NonEmpty(..))
+import Data.List.NonEmpty (NonEmpty(..), (<|))
 import qualified Data.List.NonEmpty as NEL
 import qualified Data.Map as Map
 #if !MIN_VERSION_base(4,11,0)
@@ -34,8 +34,8 @@ main = hspec $ do
 
     THSpec.spec
     describe "splitExtras" $ do
-        let helloWorldTokens = asTokens ["hello", "world"]
-            foobarbazTokens = asTokens ["foo", "bar", "baz"]
+        let helloWorldTokens = Token "hello" :| [Token "world"]
+            foobarbazTokens = Token "foo" :| [Token "bar", Token "baz"]
         it "works" $ do
             splitExtras []
                 `shouldBe`
@@ -45,20 +45,21 @@ main = hspec $ do
                 [ Line 0 helloWorldTokens
                 ]
                 `shouldBe`
-                    ( [helloWorldTokens], mempty )
+                    ( [NEL.toList helloWorldTokens], mempty )
         it "works3" $ do
             splitExtras
                 [ Line 0 helloWorldTokens
                 , Line 2 foobarbazTokens
                 ]
                 `shouldBe`
-                    ( [helloWorldTokens, foobarbazTokens], mempty )
+                    ( [NEL.toList helloWorldTokens, NEL.toList foobarbazTokens], mempty )
         it "works4" $ do
             let foobarbarz = ["foo", "Bar", "baz"]
+                fbbTokens = Token <$> nonEmptyOrFail foobarbarz
             splitExtras
-                [ Line 0 [Token "Hello"]
-                , Line 2 (asTokens foobarbarz)
-                , Line 2 (asTokens foobarbarz)
+                [ Line 0 (pure (Token "Hello"))
+                , Line 2 fbbTokens
+                , Line 2 fbbTokens
                 ]
                 `shouldBe`
                     ( []
@@ -68,10 +69,11 @@ main = hspec $ do
                     )
         it "works5" $ do
             let foobarbarz = ["foo", "Bar", "baz"]
+                fbbTokens = Token <$> nonEmptyOrFail foobarbarz
             splitExtras
-                [ Line 0 (asTokens ["Hello"])
-                , Line 2 (asTokens foobarbarz)
-                , Line 4 (asTokens foobarbarz)
+                [ Line 0 (pure (Token "Hello"))
+                , Line 2 fbbTokens
+                , Line 4 fbbTokens
                 ]
                 `shouldBe`
                     ( []
@@ -138,7 +140,7 @@ main = hspec $ do
         it "handles normal words" $
             parseLine " foo   bar  baz" `shouldBe`
                 Just
-                    ( Line 1
+                    ( Line 1 $ nonEmptyOrFail
                         [ Token "foo"
                         , Token "bar"
                         , Token "baz"
@@ -148,7 +150,7 @@ main = hspec $ do
         it "handles quotes" $
             parseLine "  \"foo bar\"  \"baz\"" `shouldBe`
                 Just
-                    ( Line 2
+                    ( Line 2 $ nonEmptyOrFail
                         [ Token "foo bar"
                         , Token "baz"
                         ]
@@ -157,7 +159,7 @@ main = hspec $ do
         it "handles quotes mid-token" $
             parseLine "  x=\"foo bar\"  \"baz\"" `shouldBe`
                 Just
-                    ( Line 2
+                    ( Line 2 $ nonEmptyOrFail
                         [ Token "x=foo bar"
                         , Token "baz"
                         ]
@@ -166,7 +168,7 @@ main = hspec $ do
         it "handles escaped quote mid-token" $
             parseLine "  x=\\\"foo bar\"  \"baz\"" `shouldBe`
                 Just
-                    ( Line 2
+                    ( Line 2 $ nonEmptyOrFail
                         [ Token "x=\\\"foo"
                         , Token "bar\""
                         , Token "baz"
@@ -176,7 +178,7 @@ main = hspec $ do
         it "handles unnested parantheses" $
             parseLine "  (foo bar)  (baz)" `shouldBe`
                 Just
-                    ( Line 2
+                    ( Line 2 $ nonEmptyOrFail
                         [ Token "foo bar"
                         , Token "baz"
                         ]
@@ -185,7 +187,7 @@ main = hspec $ do
         it "handles unnested parantheses mid-token" $
             parseLine "  x=(foo bar)  (baz)" `shouldBe`
                 Just
-                    ( Line 2
+                    ( Line 2 $ nonEmptyOrFail
                         [ Token "x=foo bar"
                         , Token "baz"
                         ]
@@ -194,7 +196,7 @@ main = hspec $ do
         it "handles nested parantheses" $
             parseLine "  (foo (bar))  (baz)" `shouldBe`
                 Just
-                    ( Line 2
+                    ( Line 2 $ nonEmptyOrFail
                         [ Token "foo (bar)"
                         , Token "baz"
                         ]
@@ -203,7 +205,7 @@ main = hspec $ do
         it "escaping" $
             parseLine "  (foo \\(bar)  y=\"baz\\\"\"" `shouldBe`
                 Just
-                    ( Line 2
+                    ( Line 2 $ nonEmptyOrFail
                         [ Token "foo (bar"
                         , Token "y=baz\""
                         ]
@@ -212,7 +214,7 @@ main = hspec $ do
         it "mid-token quote in later token" $
             parseLine "foo bar baz=(bin\")" `shouldBe`
                 Just
-                    ( Line 0
+                    ( Line 0 $ nonEmptyOrFail
                         [ Token "foo"
                         , Token "bar"
                         , Token "baz=bin\""
@@ -223,22 +225,21 @@ main = hspec $ do
             it "recognizes one line" $ do
                 parseLine "-- | this is a comment" `shouldBe`
                     Just
-                        ( Line 0
-                            [ DocComment "this is a comment"
-                            ]
+                        ( Line 0 $ pure
+                            (DocComment "this is a comment")
                         )
 
             it "map parseLine" $ do
                 mapM parseLine ["Foo", "-- | Hello"]
                     `shouldBe`
                         Just
-                            [ Line 0 [Token "Foo"]
-                            , Line 0 [DocComment "Hello"]
+                            [ Line 0 (pure (Token "Foo"))
+                            , Line 0 (pure (DocComment "Hello"))
                             ]
 
             it "works if comment is indented" $ do
                 parseLine "  -- | comment" `shouldBe`
-                    Just (Line 2 [ DocComment "comment"])
+                    Just (Line 2 (pure (DocComment "comment")))
 
     describe "parse" $ do
         let subject =
@@ -415,9 +416,7 @@ Baz
         it "preparse works" $ do
             (length <$> preparsed) `shouldBe` Just 10
 
-        let skippedEmpty =
-                maybe [] skipEmpty preparsed
-            fooLines =
+        let fooLines =
                 [ Line
                     { lineIndent = 0
                     , tokens = Token "Foo" :| []
@@ -473,11 +472,10 @@ Baz
                     , bazLines
                     ]
 
-        it "skipEmpty works" $ do
-            skippedEmpty `shouldBe` resultLines
-
         let linesAssociated =
-                associateLines skippedEmpty
+                case preparsed of
+                    Nothing -> error "preparsed failed"
+                    Just lines -> associateLines lines
         it "associateLines works" $ do
             linesAssociated `shouldMatchList`
                 [ LinesWithComments
@@ -529,20 +527,20 @@ Baz
 
         it "recognizes entity" $ do
             let expected =
-                    Line { lineIndent = 0, tokens = asTokens ["Person"] } :|
-                    [ Line { lineIndent = 2, tokens = asTokens ["name", "String"] }
-                    , Line { lineIndent = 2, tokens = asTokens ["age", "Int"] }
+                    Line { lineIndent = 0, tokens = pure (Token "Person") } :|
+                    [ Line { lineIndent = 2, tokens = Token "name" :| [Token "String"] }
+                    , Line { lineIndent = 2, tokens = Token "age" :| [Token "Int"] }
                     ]
             preparse "Person\n  name String\n  age Int" `shouldBe` Just expected
 
         it "recognizes comments" $ do
             let text = "Foo\n  x X\n-- | Hello\nBar\n name String"
             let expected =
-                    Line { lineIndent = 0, tokens = asTokens ["Foo"] } :|
-                    [ Line { lineIndent = 2, tokens = asTokens ["x", "X"] }
-                    , Line { lineIndent = 0, tokens = [DocComment "Hello"] }
-                    , Line { lineIndent = 0, tokens = asTokens ["Bar"] }
-                    , Line { lineIndent = 1, tokens = asTokens ["name", "String"] }
+                    Line { lineIndent = 0, tokens = pure (Token "Foo") } :|
+                    [ Line { lineIndent = 2, tokens = Token "x" :| [Token "X"] }
+                    , Line { lineIndent = 0, tokens = pure (DocComment "Hello") }
+                    , Line { lineIndent = 0, tokens = pure (Token "Bar") }
+                    , Line { lineIndent = 1, tokens = Token "name" :| [Token "String"] }
                     ]
             preparse text `shouldBe` Just expected
 
@@ -556,11 +554,11 @@ Baz
                     , "    name String"
                     ]
                 expected =
-                    Line { lineIndent = 2, tokens = asTokens ["Foo"] } :|
-                    [ Line { lineIndent = 4, tokens = asTokens ["x", "X"] }
-                    , Line { lineIndent = 2, tokens = [DocComment "Comment"] }
-                    , Line { lineIndent = 2, tokens = asTokens ["Bar"] }
-                    , Line { lineIndent = 4, tokens = asTokens ["name", "String"] }
+                    Line { lineIndent = 2, tokens = pure (Token "Foo") } :|
+                    [ Line { lineIndent = 4, tokens = Token "x" :| [Token "X"] }
+                    , Line { lineIndent = 2, tokens = pure (DocComment "Comment") }
+                    , Line { lineIndent = 2, tokens = pure (Token "Bar") }
+                    , Line { lineIndent = 4, tokens = Token "name" :| [Token "String"] }
                     ]
             preparse t `shouldBe` Just expected
 
@@ -575,13 +573,13 @@ Baz
                     , "    something"
                     ]
                 expected =
-                    Line { lineIndent = 0, tokens = asTokens ["LowerCaseTable"] } :|
-                    [ Line { lineIndent = 2, tokens = asTokens ["name", "String"] }
-                    , Line { lineIndent = 2, tokens = asTokens ["ExtraBlock"] }
-                    , Line { lineIndent = 4, tokens = asTokens ["foo", "bar"] }
-                    , Line { lineIndent = 4, tokens = asTokens ["baz"] }
-                    , Line { lineIndent = 2, tokens = asTokens ["ExtraBlock2"] }
-                    , Line { lineIndent = 4, tokens = asTokens ["something"] }
+                    Line { lineIndent = 0, tokens = pure (Token "LowerCaseTable") } :|
+                    [ Line { lineIndent = 2, tokens = Token "name" :| [Token "String"] }
+                    , Line { lineIndent = 2, tokens = pure (Token "ExtraBlock") }
+                    , Line { lineIndent = 4, tokens = Token "foo" :| [Token "bar"] }
+                    , Line { lineIndent = 4, tokens = pure (Token "baz") }
+                    , Line { lineIndent = 2, tokens = pure (Token "ExtraBlock2") }
+                    , Line { lineIndent = 4, tokens = pure (Token "something") }
                     ]
             preparse t `shouldBe` Just expected
 
@@ -593,10 +591,10 @@ Baz
                     , "  name String"
                     ]
                 expected =
-                    Line { lineIndent = 0, tokens = [DocComment "Model"] } :|
-                    [ Line { lineIndent = 0, tokens = asTokens ["Foo"] }
-                    , Line { lineIndent = 2, tokens = [DocComment "Field"] }
-                    , Line { lineIndent = 2, tokens = asTokens ["name", "String"] }
+                    Line { lineIndent = 0, tokens = pure (DocComment "Model") } :|
+                    [ Line { lineIndent = 0, tokens = pure (Token "Foo") }
+                    , Line { lineIndent = 2, tokens = pure (DocComment "Field") }
+                    , Line { lineIndent = 2, tokens = Token "name" :| [Token "String"] }
                     ]
             preparse text `shouldBe` Just expected
 
@@ -618,10 +616,10 @@ Baz
                     }
         it "works" $ do
             associateLines
-                [ comment
-                , foo
+                ( comment :|
+                [ foo
                 , name'String
-                ]
+                ])
                 `shouldBe`
                     [ LinesWithComments
                         { lwcComments = ["comment"]
@@ -631,7 +629,7 @@ Baz
         let bar =
                 Line
                     { lineIndent = 0
-                    , tokens = Token "Bar" :| asTokens ["sql", "=", "bars"]
+                    , tokens = Token "Bar" :| [Token "sql", Token "=", Token "bars"]
                     }
             age'Int =
                 Line
@@ -640,12 +638,12 @@ Baz
                     }
         it "works when used consecutively" $ do
             associateLines
-                [ bar
-                , age'Int
+                ( bar :|
+                [ age'Int
                 , comment
                 , foo
                 , name'String
-                ]
+                ])
                 `shouldBe`
                     [ LinesWithComments
                         { lwcComments = []
@@ -657,11 +655,9 @@ Baz
                         }
                     ]
         it "works with textual input" $ do
-            let text = "Foo\n  x X\n-- | Hello\nBar\n name String"
-                parsed = preparse text
-                allFull = maybe [] skipEmpty parsed
-            associateLines allFull
-                `shouldBe`
+            let text = preparse "Foo\n  x X\n-- | Hello\nBar\n name String"
+            associateLines <$> text
+                `shouldBe` Just
                     [ LinesWithComments
                         { lwcLines =
                             Line {lineIndent = 0, tokens = Token "Foo" :| []}
@@ -678,7 +674,7 @@ Baz
                         }
                     ]
         it "works with extra blocks" $ do
-            let text = maybe [] skipEmpty . preparse . T.unlines $
+            let text = preparse . T.unlines $
                     [ "LowerCaseTable"
                     , "    Id             sql=my_id"
                     , "    fullName Text"
@@ -689,7 +685,7 @@ Baz
                     , "    ExtraBlock2"
                     , "        something"
                     ]
-            associateLines text `shouldBe`
+            associateLines <$> text `shouldBe` Just
                 [ LinesWithComments
                     { lwcLines =
                         Line { lineIndent = 0, tokens = pure (Token "LowerCaseTable") } :|
@@ -707,7 +703,7 @@ Baz
                 ]
 
         it "works with extra blocks twice" $ do
-            let text = maybe [] skipEmpty . preparse . T.unlines $
+            let text = preparse . T.unlines $
                     [ "IdTable"
                     , "    Id Day default=CURRENT_DATE"
                     , "    name Text"
@@ -722,11 +718,11 @@ Baz
                     , "    ExtraBlock2"
                     , "        something"
                     ]
-            associateLines text `shouldBe`
+            associateLines <$> text `shouldBe` Just
                 [ LinesWithComments
                     { lwcLines = Line 0 (pure (Token "IdTable")) :|
-                        [ Line 4 (Token "Id" :| asTokens ["Day", "default=CURRENT_DATE"])
-                        , Line 4 (Token "name" :| asTokens ["Text"])
+                        [ Line 4 (Token "Id" <| Token "Day" :| [Token "default=CURRENT_DATE"])
+                        , Line 4 (Token "name" :| [Token "Text"])
                         ]
                     , lwcComments = []
                     }
@@ -748,13 +744,13 @@ Baz
 
 
         it "works with field comments" $ do
-            let text = maybe [] skipEmpty . preparse . T.unlines $
+            let text = preparse . T.unlines $
                     [ "-- | Model"
                     , "Foo"
                     , "  -- | Field"
                     , "  name String"
                     ]
-            associateLines text `shouldBe`
+            associateLines <$> text `shouldBe` Just
                 [ LinesWithComments
                     { lwcLines =
                         Line { lineIndent = 0, tokens = (Token "Foo") :| [] } :|
@@ -900,8 +896,11 @@ takePrefix :: Value -> Value
 takePrefix (String a) = String (T.take 1 a)
 takePrefix a = a
 
-asTokens :: [T.Text] -> [Token]
-asTokens = fmap Token
+nonEmptyOrFail :: [a] -> NonEmpty a
+nonEmptyOrFail = maybe failure id . NEL.nonEmpty
+  where
+    failure =
+        error "nonEmptyOrFail expected a non empty list"
 
 arbitraryWhiteSpaceChar :: Gen Char
 arbitraryWhiteSpaceChar =

--- a/persistent/test/main.hs
+++ b/persistent/test/main.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
 
@@ -229,14 +229,6 @@ main = hspec $ do
                             (DocComment "this is a comment")
                         )
 
-            it "map parseLine" $ do
-                mapM parseLine ["Foo", "-- | Hello"]
-                    `shouldBe`
-                        Just
-                            [ Line 0 (pure (Token "Foo"))
-                            , Line 0 (pure (DocComment "Hello"))
-                            ]
-
             it "works if comment is indented" $ do
                 parseLine "  -- | comment" `shouldBe`
                     Just (Line 2 (pure (DocComment "comment")))
@@ -464,13 +456,6 @@ Baz
                     , tokens = Token "c" :| [Token "FooId"]
                     }
                 ]
-            resultLines =
-                concat
-                    [ fooLines
-                    , emptyLines
-                    , barLines
-                    , bazLines
-                    ]
 
         let linesAssociated =
                 case preparsed of
@@ -825,7 +810,7 @@ Baz
                         , ""
                         ] of
                             [a, b, c] ->
-                                [a, b, c]
+                                [a, b, c] :: [EntityDef]
                             xs ->
                                 error
                                 $ "Expected 3 elements in list, got: "


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [x] Ran `stylish-haskell` on any changed files.
- [ ] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

----

This is a followon from https://github.com/yesodweb/persistent/pull/1206 that addresses the TODO comment here:

https://github.com/yesodweb/persistent/blob/53359c834f649442c2f17379e24d78fb6e8719d4/persistent/Database/Persist/Quasi.hs#L546-L555

Following recent refactoring there is not actually any instance of `Line` where the contents of the list are _not_ `NonEmpty`, so this PR changes that type to always use `NonEmpty`, rather than being polymorphic, which greatly simplifies a lot of the code around `Line`, and means we can also get rid of the `skipEmpty` function, as `NonEmpty` guarantees us nonempty-ness :+1: 