### PR TITLE
Make upserts handle unique fields (#1233)

### DIFF
--- a/persistent-postgresql/ChangeLog.md
+++ b/persistent-postgresql/ChangeLog.md
@@ -1,5 +1,13 @@
 # Changelog for persistent-postgresql
 
+# 2.12.1.1
+
+* [#1235](https://github.com/yesodweb/persistent/pull/1235)
+    * `upsertWhere` and `upsertManyWhere` only worked in cases where a `Primary`
+      key was defined on a record, and no other uniqueness constraints. They
+      have been fixed to only work with records that have a single Uniqueness
+      constraint defined.
+
 ## 2.12.1.0
 
 * Added `upsertWhere` and `upsertManyWhere` to `persistent-postgresql`.  [#1222](https://github.com/yesodweb/persistent/pull/1222).

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -1817,6 +1817,7 @@ upsertWhere
      , MonadIO m
      , PersistStore backend
      , BackendCompatible SqlBackend backend
+     , OnlyOneUniqueKey record
      )
   => record
   -> [Update record]
@@ -1825,11 +1826,43 @@ upsertWhere
 upsertWhere record updates filts =
   upsertManyWhere [record] [] updates filts
 
+-- | Postgres specific 'upsertManyWhere'. This method does the following:
+-- It will insert a record if no matching unique key exists.
+-- If a unique key exists, it will update the relevant field with a user-supplied value, however,
+-- it will only do this update on a user-supplied condition.
+-- For example, here's how this method could be called like such:
+--
+-- upsertManyWhere [record] [recordField =. newValue] [recordField !=. newValue]
+--
+-- Called thusly, this method will insert a new record (if none exists) OR update a recordField with a new value
+-- assuming the condition in the last block is met.
+--
+-- @since 2.12.1.0
+upsertManyWhere 
+    :: forall record backend m.
+    ( backend ~ PersistEntityBackend record
+    , BackendCompatible SqlBackend backend
+    , PersistEntityBackend record ~ SqlBackend
+    , PersistEntity record
+    , OnlyOneUniqueKey record
+    , MonadIO m
+    ) 
+    => [record] -- ^ A list of the records you want to insert, or update
+    -> [HandleUpdateCollision record] -- ^ A list of the fields you want to copy over.
+    -> [Update record] -- ^ A list of the updates to apply that aren't dependent on the record being inserted.
+    -> [Filter record] -- ^ A filter condition that dictates the scope of the updates
+    -> ReaderT backend m ()
+upsertManyWhere [] _ _ _ = return ()
+upsertManyWhere records fieldValues updates filters = do
+  conn <- asks projectBackend
+  uncurry rawExecute $
+    mkBulkUpsertQuery records conn fieldValues updates filters
+
 -- | Exclude any record field if it doesn't match the filter record.  Used only in `upsertWhere` and
 -- `upsertManyWhere`
 --
 -- @since 2.12.1.0
--- TODO: we could probably make a sum type for the `Filter` record that's passed into the `upserWhere` and
+-- TODO: we could probably make a sum type for the `Filter` record that's passed into the `upsertWhere` and
 -- `upsertManyWhere` methods that has similar behavior to the HandleCollisionUpdate type.
 excludeNotEqualToOriginal ::
   (PersistField typ
@@ -1854,43 +1887,12 @@ excludeNotEqualToOriginal field =
         "EXCLUDED."
           <> fieldName field
 
--- | Postgres specific 'upsertManyWhere'. This method does the following:
--- It will insert a record if no matching unique key exists.
--- If a unique key exists, it will update the relevant field with a user-supplied value, however,
--- it will only do this update on a user-supplied condition.
--- For example, here's how this method could be called like such:
---
--- upsertManyWhere [record] [recordField =. newValue] [recordField /= newValue]
---
--- Called thusly, this method will insert a new record (if none exists) OR update a recordField with a new value
--- assuming the condition in the last block is met.
---
--- @since 2.12.1.0
-upsertManyWhere ::
-    forall record backend m.
-    ( backend ~ PersistEntityBackend record,
-      BackendCompatible SqlBackend backend,
-      PersistEntityBackend record ~ SqlBackend,
-      PersistEntity record,
-      MonadIO m
-    ) =>
-    [record] -> -- ^ A list of the records you want to insert, or update
-    [HandleUpdateCollision record] -> -- ^ A list of the fields you want to copy over.
-    [Update record] -> -- ^ A list of the updates to apply that aren't dependent on the record being inserted.
-    [Filter record] -> -- ^ A filter condition that dictates the scope of the updates
-    ReaderT backend m ()
-upsertManyWhere [] _ _ _ = return ()
-upsertManyWhere records fieldValues updates filters = do
-  conn <- asks projectBackend
-  uncurry rawExecute $
-    mkBulkUpsertQuery records conn fieldValues updates filters
-
 -- | This creates the query for 'upsertManyWhere'. If you
 -- provide an empty list of updates to perform, then it will generate
 -- a dummy/no-op update using the first field of the record. This avoids
 -- duplicate key exceptions.
 mkBulkUpsertQuery
-    :: (PersistEntity record, PersistEntityBackend record ~ SqlBackend)
+    :: (PersistEntity record, PersistEntityBackend record ~ SqlBackend, OnlyOneUniqueKey record)
     => [record] -- ^ A list of the records you want to insert, or update
     -> SqlBackend
     -> [HandleUpdateCollision record] -- ^ A list of the fields you want to copy over.
@@ -1906,7 +1908,7 @@ mkBulkUpsertQuery records conn fieldValues updates filters =
     (fieldsToMaybeCopy, updateFieldNames) = partitionEithers $ map mfieldDef fieldValues
     fieldDbToText = escapeF . fieldDB
     entityDef' = entityDef records
-    conflictColumns = escapeF . fieldDB <$> entityKeyFields entityDef'
+    conflictColumns = (escapeF . fieldDB <$> entityKeyFields entityDef') ++ concatMap (map (escapeF . snd) . uniqueFields) (entityUniques entityDef')
     firstField = case entityFieldNames of
         [] -> error "The entity you're trying to insert does not have any fields."
         (field:_) -> field

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -1838,7 +1838,7 @@ upsertWhere record updates filts =
 -- assuming the condition in the last block is met.
 --
 -- @since 2.12.1.0
-upsertManyWhere 
+upsertManyWhere
     :: forall record backend m.
     ( backend ~ PersistEntityBackend record
     , BackendCompatible SqlBackend backend
@@ -1846,46 +1846,51 @@ upsertManyWhere
     , PersistEntity record
     , OnlyOneUniqueKey record
     , MonadIO m
-    ) 
-    => [record] -- ^ A list of the records you want to insert, or update
-    -> [HandleUpdateCollision record] -- ^ A list of the fields you want to copy over.
-    -> [Update record] -- ^ A list of the updates to apply that aren't dependent on the record being inserted.
-    -> [Filter record] -- ^ A filter condition that dictates the scope of the updates
+    )
+    => [record]
+    -- ^ A list of the records you want to insert, or update
+    -> [HandleUpdateCollision record]
+    -- ^ A list of the fields you want to copy over.
+    -> [Update record]
+    -- ^ A list of the updates to apply that aren't dependent on the record
+    -- being inserted.
+    -> [Filter record]
+    -- ^ A filter condition that dictates the scope of the updates
     -> ReaderT backend m ()
 upsertManyWhere [] _ _ _ = return ()
 upsertManyWhere records fieldValues updates filters = do
-  conn <- asks projectBackend
-  uncurry rawExecute $
-    mkBulkUpsertQuery records conn fieldValues updates filters
+    conn <- asks projectBackend
+    uncurry rawExecute $
+        mkBulkUpsertQuery records conn fieldValues updates filters
 
 -- | Exclude any record field if it doesn't match the filter record.  Used only in `upsertWhere` and
 -- `upsertManyWhere`
 --
--- @since 2.12.1.0
 -- TODO: we could probably make a sum type for the `Filter` record that's passed into the `upsertWhere` and
 -- `upsertManyWhere` methods that has similar behavior to the HandleCollisionUpdate type.
-excludeNotEqualToOriginal ::
-  (PersistField typ
-  , PersistEntity rec) =>
-  EntityField rec typ ->
-  Filter rec
+--
+-- @since 2.12.1.0
+excludeNotEqualToOriginal
+    :: (PersistField typ, PersistEntity rec)
+    => EntityField rec typ
+    -> Filter rec
 excludeNotEqualToOriginal field =
-  Filter
-    { filterField =
-        field,
-      filterFilter =
-        Ne,
-      filterValue =
-        UnsafeValue $
-          PersistLiteral_
-            Unescaped
-            bsForExcludedField
-    }
+    Filter
+        { filterField =
+            field
+        , filterFilter =
+            Ne
+        , filterValue =
+            UnsafeValue $
+                PersistLiteral_
+                    Unescaped
+                    bsForExcludedField
+        }
   where
     bsForExcludedField =
-      T.encodeUtf8 $
-        "EXCLUDED."
-          <> fieldName field
+        T.encodeUtf8
+            $ "EXCLUDED."
+            <> fieldName field
 
 -- | This creates the query for 'upsertManyWhere'. If you
 -- provide an empty list of updates to perform, then it will generate
@@ -1908,7 +1913,9 @@ mkBulkUpsertQuery records conn fieldValues updates filters =
     (fieldsToMaybeCopy, updateFieldNames) = partitionEithers $ map mfieldDef fieldValues
     fieldDbToText = escapeF . fieldDB
     entityDef' = entityDef records
-    conflictColumns = (escapeF . fieldDB <$> entityKeyFields entityDef') ++ concatMap (map (escapeF . snd) . uniqueFields) (entityUniques entityDef')
+    -- conflictColumns = (escapeF . fieldDB <$> entityKeyFields entityDef') ++ concatMap (map (escapeF . snd) . uniqueFields) (entityUniques entityDef')
+    conflictColumns =
+        concatMap (map (escapeF . snd) . uniqueFields) (entityUniques entityDef')
     firstField = case entityFieldNames of
         [] -> error "The entity you're trying to insert does not have any fields."
         (field:_) -> field
@@ -1916,33 +1923,46 @@ mkBulkUpsertQuery records conn fieldValues updates filters =
     nameOfTable = escapeE . entityDB $ entityDef'
     copyUnlessValues = map snd fieldsToMaybeCopy
     recordValues = concatMap (map toPersistValue . toPersistFields) records
-    recordPlaceholders = Util.commaSeparated $ map (Util.parenWrapped . Util.commaSeparated . map (const "?") . toPersistFields) records
+    recordPlaceholders =
+        Util.commaSeparated
+        $ map (Util.parenWrapped . Util.commaSeparated . map (const "?") . toPersistFields)
+        $ records
     mkCondFieldSet n _ =
-      T.concat
-        [ n
-        , "=COALESCE("
-        ,   "NULLIF("
-        ,     "EXCLUDED."
-        ,       n
-        ,         ","
-        ,           "?"
-        ,         ")"
-        ,       ","
-        ,     nameOfTable
-        ,   "."
-        ,   n
-        ,")"
-        ]
+        T.concat
+            [ n
+            , "=COALESCE("
+            ,   "NULLIF("
+            ,     "EXCLUDED."
+            ,       n
+            ,         ","
+            ,           "?"
+            ,         ")"
+            ,       ","
+            ,     nameOfTable
+            ,   "."
+            ,   n
+            ,")"
+            ]
     condFieldSets = map (uncurry mkCondFieldSet) fieldsToMaybeCopy
     fieldSets = map (\n -> T.concat [n, "=EXCLUDED.", n, ""]) updateFieldNames
     upds = map (Util.mkUpdateText' (escapeF) (\n -> T.concat [nameOfTable, ".", n])) updates
     updsValues = map (\(Update _ val _) -> toPersistValue val) updates
-    (wher, whereVals) = if null filters
-                          then ("", [])
-                          else (filterClauseWithVals (Just PrefixTableName) conn filters)
-    updateText = case fieldSets <> upds <> condFieldSets of
-        [] -> T.concat [firstField, "=EXCLUDED.", firstField]
-        xs -> Util.commaSeparated xs
+    (wher, whereVals) =
+        if null filters
+        then ("", [])
+        else (filterClauseWithVals (Just PrefixTableName) conn filters)
+    updateText =
+        case fieldSets <> upds <> condFieldSets of
+            [] ->
+                -- This case is really annoying, and probably unlikely to be
+                -- actually hit - someone would have had to call something like
+                -- `upsertManyWhere [] [] []`, but that would have been caught
+                -- by the prior case.
+                -- Would be nice to have something like a `NonEmpty (These ...)`
+                -- instead of multiple lists...
+                T.concat [firstField, "=", nameOfTable, ".", firstField]
+            xs ->
+                Util.commaSeparated xs
     q = T.concat
         [ "INSERT INTO "
         , nameOfTable

--- a/persistent-postgresql/persistent-postgresql.cabal
+++ b/persistent-postgresql/persistent-postgresql.cabal
@@ -68,6 +68,7 @@ test-suite test
                    , HUnit
                    , hspec                >= 2.4
                    , hspec-expectations
+                   , hspec-expectations-lifted
                    , monad-logger
                    , QuickCheck
                    , quickcheck-instances

--- a/persistent-postgresql/persistent-postgresql.cabal
+++ b/persistent-postgresql/persistent-postgresql.cabal
@@ -1,5 +1,5 @@
 name:            persistent-postgresql
-version:         2.12.1.0
+version:         2.12.1.1
 license:         MIT
 license-file:    LICENSE
 author:          Felipe Lessa, Michael Snoyman <michael@snoyman.com>

--- a/persistent-postgresql/test/PgInit.hs
+++ b/persistent-postgresql/test/PgInit.hs
@@ -1,58 +1,85 @@
-{-# LANGUAGE ScopedTypeVariables, OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module PgInit (
-  runConn
-  , runConn_
-  , runConnAssert
-  , runConnAssertUseConf
+module PgInit
+    ( runConn
+    , runConn_
+    , runConnAssert
+    , runConnAssertUseConf
 
-  , MonadIO
-  , persistSettings
-  , MkPersistSettings (..)
-  , BackendKey(..)
-  , GenerateKey(..)
+    , MonadIO
+    , persistSettings
+    , MkPersistSettings (..)
+    , BackendKey(..)
+    , GenerateKey(..)
 
-   -- re-exports
-  , module Control.Monad.Trans.Reader
-  , module Control.Monad
-  , module Database.Persist.Sql
-  , module Database.Persist
-  , module Database.Persist.Sql.Raw.QQ
-  , module Init
-  , module Test.Hspec
-  , module Test.HUnit
-  , BS.ByteString
-  , Int32, Int64
-  , liftIO
-  , mkPersist, mkMigrate, share, sqlSettings, persistLowerCase, persistUpperCase
-  , SomeException
-  , Text
-  , TestFn(..)
-  ) where
+     -- re-exports
+    , module Control.Monad.Trans.Reader
+    , module Control.Monad
+    , module Database.Persist.Sql
+    , module Database.Persist
+    , module Database.Persist.Sql.Raw.QQ
+    , module Init
+    , module Test.Hspec
+    , module Test.Hspec.Expectations.Lifted
+    , module Test.HUnit
+    , BS.ByteString
+    , Int32, Int64
+    , liftIO
+    , mkPersist, mkMigrate, share, sqlSettings, persistLowerCase, persistUpperCase
+    , SomeException
+    , Text
+    , TestFn(..)
+    , LoggingT
+    , ResourceT
+    ) where
 
 import Init
-    ( TestFn(..), truncateTimeOfDay, truncateUTCTime
-    , truncateToMicro, arbText, liftA2, GenerateKey(..)
-    , (@/=), (@==), (==@), MonadFail
-    , assertNotEqual, assertNotEmpty, assertEmpty, asIO
-    , isTravis, RunDb
-    )
+       ( GenerateKey(..)
+       , MonadFail
+       , RunDb
+       , TestFn(..)
+       , arbText
+       , asIO
+       , assertEmpty
+       , assertNotEmpty
+       , assertNotEqual
+       , isTravis
+       , liftA2
+       , truncateTimeOfDay
+       , truncateToMicro
+       , truncateUTCTime
+       , (==@)
+       , (@/=)
+       , (@==)
+       )
 
 -- re-exports
 import Control.Exception (SomeException)
-import UnliftIO
-import Control.Monad (void, replicateM, liftM, when, forM_)
+import Control.Monad (forM_, liftM, replicateM, void, when)
 import Control.Monad.Trans.Reader
 import Data.Aeson (Value(..))
-import Database.Persist.TH (mkPersist, mkMigrate, share, sqlSettings, persistLowerCase, persistUpperCase, MkPersistSettings(..))
+import Database.Persist.Postgresql.JSON ()
 import Database.Persist.Sql.Raw.QQ
-import Database.Persist.Postgresql.JSON()
+import Database.Persist.TH
+       ( MkPersistSettings(..)
+       , mkMigrate
+       , mkPersist
+       , persistLowerCase
+       , persistUpperCase
+       , share
+       , sqlSettings
+       )
 import Test.Hspec
+       (Spec, afterAll_, before, beforeAll, describe, fdescribe, fit, it,
+       before_, SpecWith, Arg, hspec)
+import Test.Hspec.Expectations.Lifted
 import Test.QuickCheck.Instances ()
+import UnliftIO
 
 -- testing
-import Test.HUnit ((@?=),(@=?), Assertion, assertFailure, assertBool)
+import Test.HUnit (Assertion, assertBool, assertFailure, (@=?), (@?=))
 import Test.QuickCheck
 
 import Control.Monad (unless, (>=>))

--- a/persistent-postgresql/test/UpsertWhere.hs
+++ b/persistent-postgresql/test/UpsertWhere.hs
@@ -1,179 +1,178 @@
-{-# LANGUAGE DataKinds, FlexibleInstances, MultiParamTypeClasses, ExistentialQuantification #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 module UpsertWhere where
 
-import Data.List              (sort)
-
-import Database.Persist.Postgresql
 import PgInit
 
-share [mkPersist sqlSettings, mkMigrate "upsertWhereMigrate"] [persistLowerCase|
-  Item
-     name        Text sqltype=varchar(80)
-     UniqueName  name
-     description Text
-     price       Double Maybe
-     quantity    Int Maybe
+import Database.Persist.Postgresql
 
-     Primary name
-     deriving Eq Show Ord
+share [mkPersist sqlSettings, mkMigrate "upsertWhereMigrate"] [persistLowerCase|
+
+Item
+    name        Text sqltype=varchar(80)
+    description Text
+    price       Double Maybe
+    quantity    Int Maybe
+
+    UniqueName name
+    deriving Eq Show Ord
 
 |]
 
+wipe :: IO ()
+wipe = runConnAssert $ do
+    deleteWhere ([] :: [Filter Item])
+
+itDb :: String -> SqlPersistT (LoggingT (ResourceT IO)) a -> SpecWith (Arg (IO ()))
+itDb msg action = it msg $ runConnAssert $ void action
+
 specs :: Spec
 specs = describe "UpsertWhere" $ do
-  let item1 = Item "item1" "" (Just 3) Nothing
-      item2 = Item "item2" "hello world" Nothing (Just 2)
-      items = [item1, item2]
+    let item1 = Item "item1" "" (Just 3) Nothing
+        item2 = Item "item2" "hello world" Nothing (Just 2)
+        items = [item1, item2]
 
-  describe "upsertWhere" $ do
-    it "inserts appropriately" $ runConnAssert $ do
-      deleteWhere ([] :: [Filter Item])
-      upsertWhere item1 [ItemDescription =. "i am item 1"] []
-      Just item <- get (ItemKey "item1")
-      item @== item1
-    it "performs only updates given if record already exists" $ runConnAssert $ do
-      deleteWhere ([] :: [Filter Item])
-      let newDescription = "I am a new description"
-      insert_ item1
-      upsertWhere
-        (Item "item1" "i am an inserted description" (Just 1) (Just 2))
-        [ItemDescription =. newDescription] 
-        []
-      Just item <- get (ItemKey "item1")
-      item @== item1 { itemDescription = newDescription }
+    describe "upsertWhere" $ before_ wipe $ do
+        itDb "inserts appropriately" $ do
+            upsertWhere item1 [ItemDescription =. "i am item 1"] []
+            Just item <- fmap entityVal <$> getBy (UniqueName "item1")
+            item `shouldBe` item1
+        itDb "performs only updates given if record already exists" $ do
+            let newDescription = "I am a new description"
+            insert_ item1
+            upsertWhere
+                (Item "item1" "i am an inserted description" (Just 1) (Just 2))
+                [ItemDescription =. newDescription]
+                []
+            Just item <- fmap entityVal <$> getBy (UniqueName "item1")
+            item `shouldBe` item1 { itemDescription = newDescription }
 
-  describe "upsertManyWhere" $ do
-    it "inserts fresh records" $ runConnAssert $ do
-      deleteWhere ([] :: [Filter Item])
-      insertMany_ items
-      let newItem = Item "item3" "fresh" Nothing Nothing
-      upsertManyWhere
-        (newItem : items)
-        [copyField ItemDescription]
-        []
-        []
-      dbItems <- map entityVal <$> selectList [] []
-      sort dbItems @== sort (newItem : items)
-    it "updates existing records" $ runConnAssert $ do
-      deleteWhere ([] :: [Filter Item])
-      let postUpdate = map (\i -> i { itemQuantity = fmap (+1) (itemQuantity i) }) items
-      insertMany_ items
-      upsertManyWhere
-        items
-        []
-        [ItemQuantity +=. Just 1]
-        []
-      dbItems <- sort . fmap entityVal <$> selectList [] []
-      dbItems @== sort postUpdate
-    it "only copies passing values" $ runConnAssert $ do
-      deleteWhere ([] :: [Filter Item])
-      insertMany_ items
-      let newItems = map (\i -> i { itemQuantity = Just 0, itemPrice = fmap (*2) (itemPrice i) }) items
-          postUpdate = map (\i -> i { itemPrice = fmap (*2) (itemPrice i) }) items
-      upsertManyWhere
-        newItems
-        [ 
-          copyUnlessEq ItemQuantity (Just 0)
-        , copyField ItemPrice
-        ]
-        []
-        []
-      dbItems <- sort . fmap entityVal <$> selectList [] []
-      dbItems @== sort postUpdate
-    it "inserts without modifying existing records if no updates specified" $ runConnAssert $ do
-      let newItem = Item "item3" "hi friends!" Nothing Nothing
-      deleteWhere ([] :: [Filter Item])
-      insertMany_ items
-      upsertManyWhere
-        (newItem : items)
-        []
-        []
-        []
-      dbItems <- sort . fmap entityVal <$> selectList [] []
-      dbItems @== sort (newItem : items)
-    it "inserts without modifying existing records if no updates specified and there's a filter with True condition" $
-      runConnAssert $ do
-        let newItem = Item "item3" "hi friends!" Nothing Nothing
-        deleteWhere ([] :: [Filter Item])
-        insertMany_ items
-        upsertManyWhere
-          (newItem : items)
-          []
-          []
-          [ItemDescription ==. "hi friends!"]
-        dbItems <- sort . fmap entityVal <$> selectList [] []
-        dbItems @== sort (newItem : items)
-    it "inserts without updating existing records if there are updates specified but there's a filter with a False condition" $
-      runConnAssert $ do
-        let newItem = Item "item3" "hi friends!" Nothing Nothing
-        deleteWhere ([] :: [Filter Item])
-        insertMany_ items
-        upsertManyWhere
-          (newItem : items)
-          []
-          [ItemQuantity +=. Just 1]
-          [ItemDescription ==. "hi friends!"]
-        dbItems <- sort . fmap entityVal <$> selectList [] []
-        dbItems @== sort (newItem : items)
-    it "inserts new records but does not update existing records if there are updates specified but the modification condition is False" $
-      runConnAssert $ do
-        let newItem = Item "item3" "hi friends!" Nothing Nothing
-        deleteWhere ([] :: [Filter Item])
-        insertMany_ items
-        upsertManyWhere
-          (newItem : items)
-          []
-          [ItemQuantity +=. Just 1]
-          [excludeNotEqualToOriginal ItemDescription]
-        dbItems <- sort . fmap entityVal <$> selectList [] []
-        dbItems @== sort (newItem : items)
-    it "inserts new records and updates existing records if there are updates specified and the modification condition is True (because it's empty)" $
-      runConnAssert $ do
-        let newItem = Item "item3" "hello world" Nothing Nothing
-            postUpdate = map (\i -> i {itemQuantity = fmap (+ 1) (itemQuantity i)}) items
-        deleteWhere ([] :: [Filter Item])
-        insertMany_ items
-        upsertManyWhere
-          (newItem : items)
-          []
-          [ItemQuantity +=. Just 1]
-          []
-        dbItems <- sort . fmap entityVal <$> selectList [] []
-        dbItems @== sort (newItem : postUpdate)
-    it "inserts new records and updates existing records if there are updates specified and the modification filter condition is triggered" $
-       runConnAssert $ do
-        let newItem = Item "item3" "hi friends!" Nothing Nothing
-            postUpdate = map (\i -> i {itemQuantity = fmap (+1) (itemQuantity i)}) items
-        deleteWhere ([] :: [Filter Item])
-        insertMany_ items
-        upsertManyWhere
-          (newItem : items)
-          [ 
-            copyUnlessEq ItemDescription "hi friends!"
-          , copyField ItemPrice
-          ]
-          [ItemQuantity +=. Just 1]
-          [ItemDescription !=. "bye friends!"]
-        dbItems <- sort . fmap entityVal <$> selectList [] []
-        dbItems @== sort (newItem : postUpdate)
-    it "inserts an item and doesn't apply the update if the filter condition is triggered" $ 
-      runConnAssert $ do
-        let newItem = Item "item3" "hello world" Nothing Nothing 
-        deleteWhere ([] :: [Filter Item])
-        insertMany_ items
-        upsertManyWhere
-          (newItem : items)
-          []
-          [ItemQuantity +=. Just 1]
-          [excludeNotEqualToOriginal ItemDescription]
-        dbItems <- sort . fmap entityVal <$> selectList [] []
-        dbItems @== sort (newItem : items)
+    describe "upsertManyWhere" $ do
+        itDb "inserts fresh records" $ do
+            insertMany_ items
+            let newItem = Item "item3" "fresh" Nothing Nothing
+            upsertManyWhere
+                (newItem : items)
+                [copyField ItemDescription]
+                []
+                []
+            dbItems <- map entityVal <$> selectList [] []
+            dbItems `shouldMatchList` (newItem : items)
+        itDb "updates existing records" $ do
+            let
+                postUpdate =
+                    map (\i -> i { itemQuantity = fmap (+1) (itemQuantity i) }) items
+            insertMany_ items
+            upsertManyWhere
+                items
+                []
+                [ItemQuantity +=. Just 1]
+                []
+            dbItems <- fmap entityVal <$> selectList [] []
+            dbItems `shouldMatchList` postUpdate
+        itDb "only copies passing values" $ do
+            insertMany_ items
+            let newItems = map (\i -> i { itemQuantity = Just 0, itemPrice = fmap (*2) (itemPrice i) }) items
+                postUpdate = map (\i -> i { itemPrice = fmap (*2) (itemPrice i) }) items
+            upsertManyWhere
+                newItems
+                [ copyUnlessEq ItemQuantity (Just 0)
+                , copyField ItemPrice
+                ]
+                []
+                []
+            dbItems <- fmap entityVal <$> selectList [] []
+            dbItems `shouldMatchList` postUpdate
+        itDb "inserts without modifying existing records if no updates specified" $ do
+            let newItem = Item "item3" "hi friends!" Nothing Nothing
+            insertMany_ items
+            upsertManyWhere
+                (newItem : items)
+                []
+                []
+                []
+            dbItems <- fmap entityVal <$> selectList [] []
+            dbItems `shouldMatchList` (newItem : items)
+        itDb "inserts without modifying existing records if no updates specified and there's a filter with True condition" $
+          do
+            let newItem = Item "item3" "hi friends!" Nothing Nothing
+            insertMany_ items
+            upsertManyWhere
+              (newItem : items)
+              []
+              []
+              [ItemDescription ==. "hi friends!"]
+            dbItems <- fmap entityVal <$> selectList [] []
+            dbItems `shouldMatchList` (newItem : items)
+        itDb "inserts without updating existing records if there are updates specified but there's a filter with a False condition" $
+          do
+            let newItem = Item "item3" "hi friends!" Nothing Nothing
+            insertMany_ items
+            upsertManyWhere
+              (newItem : items)
+              []
+              [ItemQuantity +=. Just 1]
+              [ItemDescription ==. "hi friends!"]
+            dbItems <- fmap entityVal <$> selectList [] []
+            dbItems `shouldMatchList` (newItem : items)
+        itDb "inserts new records but does not update existing records if there are updates specified but the modification condition is False" $
+          do
+            let newItem = Item "item3" "hi friends!" Nothing Nothing
+            insertMany_ items
+            upsertManyWhere
+              (newItem : items)
+              []
+              [ItemQuantity +=. Just 1]
+              [excludeNotEqualToOriginal ItemDescription]
+            dbItems <- fmap entityVal <$> selectList [] []
+            dbItems `shouldMatchList` (newItem : items)
+        itDb "inserts new records and updates existing records if there are updates specified and the modification condition is True (because it's empty)" $
+          do
+            let newItem = Item "item3" "hello world" Nothing Nothing
+                postUpdate = map (\i -> i {itemQuantity = fmap (+ 1) (itemQuantity i)}) items
+            insertMany_ items
+            upsertManyWhere
+              (newItem : items)
+              []
+              [ItemQuantity +=. Just 1]
+              []
+            dbItems <- fmap entityVal <$> selectList [] []
+            dbItems `shouldMatchList` (newItem : postUpdate)
+        itDb "inserts new records and updates existing records if there are updates specified and the modification filter condition is triggered" $
+           do
+            let newItem = Item "item3" "hi friends!" Nothing Nothing
+                postUpdate = map (\i -> i {itemQuantity = fmap (+1) (itemQuantity i)}) items
+            insertMany_ items
+            upsertManyWhere
+              (newItem : items)
+              [
+                copyUnlessEq ItemDescription "hi friends!"
+              , copyField ItemPrice
+              ]
+              [ItemQuantity +=. Just 1]
+              [ItemDescription !=. "bye friends!"]
+            dbItems <- fmap entityVal <$> selectList [] []
+            dbItems `shouldMatchList` (newItem : postUpdate)
+        itDb "inserts an item and doesn't apply the update if the filter condition is triggered" $
+          do
+            let newItem = Item "item3" "hello world" Nothing Nothing
+            insertMany_ items
+            upsertManyWhere
+              (newItem : items)
+              []
+              [ItemQuantity +=. Just 1]
+              [excludeNotEqualToOriginal ItemDescription]
+            dbItems <- fmap entityVal <$> selectList [] []
+            dbItems `shouldMatchList` (newItem : items)

--- a/persistent-postgresql/test/UpsertWhere.hs
+++ b/persistent-postgresql/test/UpsertWhere.hs
@@ -18,6 +18,7 @@ import PgInit
 share [mkPersist sqlSettings, mkMigrate "upsertWhereMigrate"] [persistLowerCase|
   Item
      name        Text sqltype=varchar(80)
+     UniqueName  name
      description Text
      price       Double Maybe
      quantity    Int Maybe
@@ -44,7 +45,7 @@ specs = describe "UpsertWhere" $ do
       let newDescription = "I am a new description"
       insert_ item1
       upsertWhere
-        (Item "item1" "i am inserted description" (Just 1) (Just 2))
+        (Item "item1" "i am an inserted description" (Just 1) (Just 2))
         [ItemDescription =. newDescription] 
         []
       Just item <- get (ItemKey "item1")

--- a/persistent/Database/Persist/Class/PersistUnique.hs
+++ b/persistent/Database/Persist/Class/PersistUnique.hs
@@ -297,7 +297,7 @@ class PersistEntity record => OnlyOneUniqueKey record where
 -- | Given a proxy for a 'PersistEntity' record, this returns the sole
 -- 'UniqueDef' for that entity.
 --
--- @since 2.10.0
+-- @since TODO release me
 onlyOneUniqueDef
     :: (OnlyOneUniqueKey record, Monad proxy)
     => proxy record


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [x] Ran `stylish-haskell` on any changed files.
- [x] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->

# Problem:

Postgrseql's `ON CONFLICT DO UPDATE` behavior only allows for a *single* conflicting column. You cannot let it be a catch-all, "on any conflict do update" sort of behavior. 

The initial tests relied on the buggy behavior where a `Primary` was not considered a `Unique` key (see #1090 for more details). Since there was only the one `Primary` key, this behavior went unnoticed. Additionally, the code *only* used the columns for the `Key` of the record - so any other Uniqueness constraints would fail to match.

In app code, the table we wanted to use this on had *two* unique constraints: a custom Unique and an ID columns. This caused a unique key violation error, which we thought this would capture. It did not. So instead, the feature is rewritten to *require* a `OnlyOneUniqueKey` constraint - this means that the original tests needed to be rewritten to use a `UniqueName name` instead of the `Primary name` situation.

I'm doing this as a patch version bump. While this is a breaking change, any compile errors caused by this would have *also* been run-time errors.