### PR TITLE
Remove nonEmptyOrFail function from recent tests

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for persistent
 
+## Unreleased
+
+* [#1237](https://github.com/yesodweb/persistent/pull/1237)
+    * Remove nonEmptyOrFail function from recent tests
+
 ## 2.12.1.1
 
 * [#1231](https://github.com/yesodweb/persistent/pull/1231)

--- a/persistent/test/main.hs
+++ b/persistent/test/main.hs
@@ -229,13 +229,14 @@ main = hspec $ do
             it "recognizes one line" $ do
                 parseLine "-- | this is a comment" `shouldBe`
                     Just
-                        ( Line 0 $ pure
-                            (DocComment "this is a comment")
+                        ( Line 0
+                            [ DocComment "this is a comment"
+                            ]
                         )
 
             it "works if comment is indented" $ do
                 parseLine "  -- | comment" `shouldBe`
-                    Just (Line 2 (pure (DocComment "comment")))
+                    Just (Line 2 [ DocComment "comment"])
 
     describe "parse" $ do
         let subject =
@@ -580,10 +581,10 @@ Baz
                     , "  name String"
                     ]
                 expected =
-                    Line { lineIndent = 0, tokens = pure (DocComment "Model") } :|
-                    [ Line { lineIndent = 0, tokens = pure (Token "Foo") }
-                    , Line { lineIndent = 2, tokens = pure (DocComment "Field") }
-                    , Line { lineIndent = 2, tokens = Token "name" :| [Token "String"] }
+                    Line { lineIndent = 0, tokens = [DocComment "Model"] } :|
+                    [ Line { lineIndent = 0, tokens = [Token "Foo"] }
+                    , Line { lineIndent = 2, tokens = [DocComment "Field"] }
+                    , Line { lineIndent = 2, tokens = (Token <$> ["name", "String"]) }
                     ]
             preparse text `shouldBe` Just expected
 

--- a/persistent/test/main.hs
+++ b/persistent/test/main.hs
@@ -3,23 +3,23 @@
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
 
-import Test.Hspec
-import Test.Hspec.QuickCheck
-import Test.QuickCheck
 import qualified Data.Char as Char
-import qualified Data.Text as T
 import Data.List
 import Data.List.NonEmpty (NonEmpty(..), (<|))
 import qualified Data.List.NonEmpty as NEL
 import qualified Data.Map as Map
+import qualified Data.Text as T
+import Test.Hspec
+import Test.Hspec.QuickCheck
+import Test.QuickCheck
 #if !MIN_VERSION_base(4,11,0)
 -- This can be removed when GHC < 8.2.2 isn't supported anymore
 import Data.Semigroup ((<>))
 #endif
-import Data.Time
-import Text.Shakespeare.Text
 import Data.Aeson
 import qualified Data.ByteString.Char8 as BS8
+import Data.Time
+import Text.Shakespeare.Text
 
 import Database.Persist.Class.PersistField
 import Database.Persist.Quasi
@@ -236,7 +236,7 @@ main = hspec $ do
 
             it "works if comment is indented" $ do
                 parseLine "  -- | comment" `shouldBe`
-                    Just (Line 2 [ DocComment "comment"])
+                    Just (Line 2 [DocComment "comment"])
 
     describe "parse" $ do
         let subject =


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [ ] Ran `stylish-haskell` on any changed files.
- [ ] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

---

Removes the `nonEmptyOrFail` function in favour of making use of `OverloadedLists` after changes in https://github.com/yesodweb/persistent/pull/1231
