### PR TITLE
Refactor setEmbedField to use do notation

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for persistent
 
+## Unreleased
+
+* [1242](https://github.com/yesodweb/persistent/pull/1242)
+    * Refactor setEmbedField to use do notation
+
 ## 2.12.1.1
 
 * [#1231](https://github.com/yesodweb/persistent/pull/1231)

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -344,8 +344,9 @@ mEmbedded ents (FTApp x y) =
         else mEmbedded ents y
 
 setEmbedField :: EntityNameHS -> EmbedEntityMap -> FieldDef -> FieldDef
-setEmbedField entName allEntities field = field
-    { fieldReference =
+setEmbedField entName allEntities field = setFieldReference ref field
+  where
+    ref =
         case fieldReference field of
             NoReference ->
                 case mEmbedded allEntities (fieldType field) of
@@ -372,7 +373,9 @@ setEmbedField entName allEntities field = field
                                  _ -> error $ unpack $ unEntityNameHS entName <> ": a self reference must be a Maybe"
             existing ->
                 existing
-  }
+
+setFieldReference :: ReferenceDef -> FieldDef -> FieldDef
+setFieldReference ref field = field { fieldReference = ref }
 
 mkEntityDefSqlTypeExp :: EmbedEntityMap -> EntityMap -> EntityDef -> EntityDefSqlTypeExp
 mkEntityDefSqlTypeExp emEntities entityMap ent =


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [ ] Ran `stylish-haskell` on any changed files.
- [ ] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

---

A step towards taming the laddering in the `setEmbedField` function. The main part being consolidating this portion to using `do` notation instead:

https://github.com/yesodweb/persistent/blob/93f688426c35c95e6a70caffe13b76eb9ba98e97/persistent/Database/Persist/TH.hs#L353-L364

I've extracted that out into this top level function here:

```hs
lookupEmbedEntity :: EmbedEntityMap -> FieldDef -> Maybe EntityNameHS
lookupEmbedEntity allEntities field = do
    entName <- EntityNameHS <$> stripId (fieldType field)
    guard (M.member entName allEntities) -- check entity name exists in embed map
    pure entName
```