### PR TITLE
Expose `openMySQLConn` for when an explicit reference to the connection may be convenient

### DIFF
--- a/persistent-mysql/ChangeLog.md
+++ b/persistent-mysql/ChangeLog.md
@@ -1,6 +1,6 @@
 # Changelog for persistent-mysql
 
-## 2.12.0.1
+## 2.12.1.0
 
 * Expose `openMySQLConn` for explicit reference to opened connection. [#1248](https://github.com/yesodweb/persistent/pull/1248)
   * Makes it convenient to use with `mysql-simple`.

--- a/persistent-mysql/ChangeLog.md
+++ b/persistent-mysql/ChangeLog.md
@@ -1,6 +1,6 @@
 # Changelog for persistent-mysql
 
-## Unreleased
+## 2.12.0.1
 
 * Expose `openMySQLConn` for explicit reference to opened connection. [#1248](https://github.com/yesodweb/persistent/pull/1248)
   * Makes it convenient to use with `mysql-simple`.

--- a/persistent-mysql/ChangeLog.md
+++ b/persistent-mysql/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for persistent-mysql
 
+## Unreleased
+
+* Expose `openMySQLConn` for explicit reference to opened connection. [#1248](https://github.com/yesodweb/persistent/pull/1248)
+  * Makes it convenient to use with `mysql-simple`.
+
 ## 2.12.0.0
 
 * Decomposed `HaskellName` into `ConstraintNameHS`, `EntityNameHS`, `FieldNameHS`. Decomposed `DBName` into `ConstraintNameDB`, `EntityNameDB`, `FieldNameDB` respectively. [#1174](https://github.com/yesodweb/persistent/pull/1174)

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -123,6 +123,8 @@ withMySQLConn = withSqlConn . open'
 
 -- | Open a connection to MySQL server, initialize the 'SqlBackend' and return
 -- their tuple
+--
+-- @since 2.12.0.1
 openMySQLConn :: MySQL.ConnectInfo -> LogFunc -> IO (MySQL.Connection, SqlBackend)
 openMySQLConn ci logFunc = do
     conn <- MySQL.connect ci

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -35,34 +35,33 @@ module Database.Persist.MySQL
     , openMySQLConn
     ) where
 
-import qualified Blaze.ByteString.Builder.Char8 as BBB
 import qualified Blaze.ByteString.Builder.ByteString as BBS
+import qualified Blaze.ByteString.Builder.Char8 as BBB
 
 import Control.Arrow
 import Control.Monad
-import Control.Monad.IO.Class (MonadIO (..))
+import Control.Monad.IO.Class (MonadIO(..))
 import Control.Monad.IO.Unlift (MonadUnliftIO)
 import Control.Monad.Logger (MonadLoggerIO, runNoLoggingT)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except (ExceptT, runExceptT)
-import Control.Monad.Trans.Reader (runReaderT, ReaderT)
+import Control.Monad.Trans.Reader (ReaderT, runReaderT)
 import Control.Monad.Trans.Writer (runWriterT)
 
-import GHC.Stack
-import Data.Conduit
-import qualified Data.Conduit.List as CL
 import Data.Acquire (Acquire, mkAcquire, with)
 import Data.Aeson
 import Data.Aeson.Types (modifyFailure)
 import Data.ByteString (ByteString)
+import Data.Conduit
+import qualified Data.Conduit.List as CL
 import Data.Either (partitionEithers)
 import Data.Fixed (Pico)
 import Data.Function (on)
-import Data.Int (Int64)
 import Data.IORef
-import Data.List (find, intercalate, sort, groupBy)
+import Data.Int (Int64)
+import Data.List (find, groupBy, intercalate, sort)
 import qualified Data.Map as Map
-import Data.Maybe (listToMaybe, mapMaybe, fromMaybe)
+import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
 import Data.Monoid ((<>))
 import qualified Data.Monoid as Monoid
 import Data.Pool (Pool)
@@ -70,18 +69,19 @@ import Data.Text (Text, pack)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.IO as T
+import GHC.Stack
 import System.Environment (getEnvironment)
 
 import Database.Persist.Sql
 import Database.Persist.Sql.Types.Internal (makeIsolationLevelStatement)
 import qualified Database.Persist.Sql.Util as Util
 
-import qualified Database.MySQL.Base          as MySQLBase
-import qualified Database.MySQL.Base.Types    as MySQLBase
-import qualified Database.MySQL.Simple        as MySQL
-import qualified Database.MySQL.Simple.Param  as MySQL
+import qualified Database.MySQL.Base as MySQLBase
+import qualified Database.MySQL.Base.Types as MySQLBase
+import qualified Database.MySQL.Simple as MySQL
+import qualified Database.MySQL.Simple.Param as MySQL
 import qualified Database.MySQL.Simple.Result as MySQL
-import qualified Database.MySQL.Simple.Types  as MySQL
+import qualified Database.MySQL.Simple.Types as MySQL
 
 -- | Create a MySQL connection pool and run the given action.
 -- The pool is properly released after the action finishes using

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -124,7 +124,7 @@ withMySQLConn = withSqlConn . open'
 -- | Open a connection to MySQL server, initialize the 'SqlBackend' and return
 -- their tuple
 --
--- @since 2.12.0.1
+-- @since 2.12.1.0
 openMySQLConn :: MySQL.ConnectInfo -> LogFunc -> IO (MySQL.Connection, SqlBackend)
 openMySQLConn ci logFunc = do
     conn <- MySQL.connect ci

--- a/persistent-mysql/persistent-mysql.cabal
+++ b/persistent-mysql/persistent-mysql.cabal
@@ -1,5 +1,5 @@
 name:            persistent-mysql
-version:         2.12.0.0
+version:         2.12.1.0
 license:         MIT
 license-file:    LICENSE
 author:          Felipe Lessa <felipe.lessa@gmail.com>, Michael Snoyman


### PR DESCRIPTION
This is for the case where an explicit reference to the opened connection is convenient.

Some of the conditions that make having this helpful are:
1. Being able to control when to call `Database.MySQL.Base.initThread`.
2. Being able to use `mysql-simple` when necessary, but still using `persistent` for model definitions and other advantages, like migrations.

@lehins @f-f @neilmayhew

-----
Before submitting your PR, check that you've:

- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [x] Ran `stylish-haskell` on any changed files.
- [x] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
