### PR TITLE
Support promoted types in Quasi Quoter

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -2,9 +2,11 @@
 
 ## Unreleased
 
+* [#1258](https://github.com/yesodweb/persistent/pull/1258)
+    * Support promoted types in Quasi Quoter
 * [#1243](https://github.com/yesodweb/persistent/pull/1243)
     * Assorted cleanup of TH module
-* [1242](https://github.com/yesodweb/persistent/pull/1242)
+* [#1242](https://github.com/yesodweb/persistent/pull/1242)
     * Refactor setEmbedField to use do notation
 * [#1237](https://github.com/yesodweb/persistent/pull/1237)
     * Remove nonEmptyOrFail function from recent tests

--- a/persistent/Database/Persist/Quasi.hs
+++ b/persistent/Database/Persist/Quasi.hs
@@ -487,20 +487,28 @@ parseFieldType t0 =
                 | c == '(' -> parseEnclosed ')' id t'
                 | c == '[' -> parseEnclosed ']' FTList t'
                 | isUpper c || c == '\'' ->
-                    let (a, b) = T.break (\x -> isSpace x || x `elem` ("()[]"::String)) t
-                     in PSSuccess (getCon a) b
+                    let (a, b) = T.break (\x -> isSpace x || x `elem` ("()[]"::String)) t'
+                     in PSSuccess (parseFieldTypePiece c a) b
                 | otherwise -> PSFail $ show (c, t')
-    getCon t =
-        case T.breakOnEnd "." t of
-            (_, "") -> FTTypeCon Nothing t
-            ("", _) -> FTTypeCon Nothing t
-            (a, b) -> FTTypeCon (Just $ T.init a) b
+
     goMany front t =
         case parse1 t of
             PSSuccess x t' -> goMany (front . (x:)) t'
             PSFail err -> PSFail err
             PSDone -> PSSuccess (front []) t
             -- _ ->
+
+parseFieldTypePiece :: Char -> Text -> FieldType
+parseFieldTypePiece fstChar rest =
+    case fstChar of
+        '\'' ->
+            FTTypePromoted rest
+        _ ->
+            let t = T.cons fstChar rest
+             in case T.breakOnEnd "." t of
+                (_, "") -> FTTypeCon Nothing t
+                ("", _) -> FTTypeCon Nothing t
+                (a, b) -> FTTypeCon (Just $ T.init a) b
 
 data PersistSettings = PersistSettings
     { psToDBName :: !(Text -> Text)

--- a/persistent/Database/Persist/Quasi.hs
+++ b/persistent/Database/Persist/Quasi.hs
@@ -486,7 +486,7 @@ parseFieldType t0 =
                 | isSpace c -> parse1 $ T.dropWhile isSpace t'
                 | c == '(' -> parseEnclosed ')' id t'
                 | c == '[' -> parseEnclosed ']' FTList t'
-                | isUpper c ->
+                | isUpper c || c == '\'' ->
                     let (a, b) = T.break (\x -> isSpace x || x `elem` ("()[]"::String)) t
                      in PSSuccess (getCon a) b
                 | otherwise -> PSFail $ show (c, t')

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -350,7 +350,7 @@ mEmbedded _ (FTTypeCon Just{} _) =
 mEmbedded ents (FTTypeCon Nothing (EntityNameHS -> name)) =
     maybe (Left Nothing) Right $ M.lookup name ents
 mEmbedded ents (FTTypePromoted (EntityNameHS -> name)) =
-    maybe (Left Nothing) Right $ M.lookup name ents
+    Left Nothing
 mEmbedded ents (FTList x) =
     mEmbedded ents x
 mEmbedded ents (FTApp x y) =

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -1758,13 +1758,19 @@ maybeNullable :: FieldDef -> Bool
 maybeNullable fd = nullable (fieldAttrs fd) == Nullable ByMaybeAttr
 
 ftToType :: FieldType -> Type
-ftToType (FTTypeCon Nothing t) = ConT $ mkName $ unpack t
--- This type is generated from the Quasi-Quoter.
--- Adding this special case avoids users needing to import Data.Int
-ftToType (FTTypeCon (Just "Data.Int") "Int64") = ConT ''Int64
-ftToType (FTTypeCon (Just m) t) = ConT $ mkName $ unpack $ concat [m, ".", t]
-ftToType (FTApp x y) = ftToType x `AppT` ftToType y
-ftToType (FTList x) = ListT `AppT` ftToType x
+ftToType = \case
+    FTTypeCon Nothing t ->
+        ConT $ mkName $ T.unpack t
+    -- This type is generated from the Quasi-Quoter.
+    -- Adding this special case avoids users needing to import Data.Int
+    FTTypeCon (Just "Data.Int") "Int64" ->
+        ConT ''Int64
+    FTTypeCon (Just m) t ->
+        ConT $ mkName $ unpack $ concat [m, ".", t]
+    FTApp x y ->
+        ftToType x `AppT` ftToType y
+    FTList x ->
+        ListT `AppT` ftToType x
 
 infixr 5 ++
 (++) :: Text -> Text -> Text

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -349,6 +349,8 @@ mEmbedded _ (FTTypeCon Just{} _) =
     Left Nothing
 mEmbedded ents (FTTypeCon Nothing (EntityNameHS -> name)) =
     maybe (Left Nothing) Right $ M.lookup name ents
+mEmbedded ents (FTTypePromoted (EntityNameHS -> name)) =
+    maybe (Left Nothing) Right $ M.lookup name ents
 mEmbedded ents (FTList x) =
     mEmbedded ents x
 mEmbedded ents (FTApp x y) =
@@ -1767,6 +1769,8 @@ ftToType = \case
         ConT ''Int64
     FTTypeCon (Just m) t ->
         ConT $ mkName $ unpack $ concat [m, ".", t]
+    FTTypePromoted t ->
+        PromotedT $ mkName $ T.unpack t
     FTApp x y ->
         ftToType x `AppT` ftToType y
     FTList x ->

--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -264,6 +264,7 @@ parseFieldAttrs = fmap $ \case
 data FieldType
     = FTTypeCon (Maybe Text) Text
     -- ^ Optional module and name.
+    | FTTypePromoted Text
     | FTApp FieldType FieldType
     | FTList FieldType
     deriving (Show, Eq, Read, Ord, Lift)

--- a/persistent/test/Database/Persist/TH/KindEntitiesSpec.hs
+++ b/persistent/test/Database/Persist/TH/KindEntitiesSpec.hs
@@ -1,16 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
--- {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
--- {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedLabels #-}
--- {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
--- {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Database.Persist.TH.KindEntitiesSpec where
@@ -31,12 +27,11 @@ CustomerTransfer
 
 spec :: Spec
 spec = describe "KindEntities" $ do
-    it "works" $ do
-        {-
-        let UserName = #name
-            OrganizationName = #name
-            DogName = #name
--}
+    it "should support DataKinds in entity definition" $ do
+        let mkTransfer :: CustomerId -> MoneyAmount 'CustomerOwned 'Debit -> CustomerTransfer
+            mkTransfer = CustomerTransfer
+            getAmount :: CustomerTransfer -> MoneyAmount 'CustomerOwned 'Debit
+            getAmount = customerTransferMoneyAmount
         compiles
 
 compiles :: Expectation

--- a/persistent/test/Database/Persist/TH/KindEntitiesSpec.hs
+++ b/persistent/test/Database/Persist/TH/KindEntitiesSpec.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+-- {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+-- {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedLabels #-}
+-- {-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+-- {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Database.Persist.TH.KindEntitiesSpec where
+
+import Database.Persist.TH.KindEntitiesSpecImports
+import TemplateTestImports
+
+mkPersist sqlSettings [persistLowerCase|
+
+Customer
+    name    String
+    age     Int
+
+CustomerTransfer
+    customerId CustomerId
+    moneyAmount (MoneyAmount 'CustomerOwned 'Debit)
+|]
+
+spec :: Spec
+spec = describe "KindEntities" $ do
+    it "works" $ do
+        {-
+        let UserName = #name
+            OrganizationName = #name
+            DogName = #name
+-}
+        compiles
+
+compiles :: Expectation
+compiles = True `shouldBe` True

--- a/persistent/test/Database/Persist/TH/KindEntitiesSpecImports.hs
+++ b/persistent/test/Database/Persist/TH/KindEntitiesSpecImports.hs
@@ -3,6 +3,7 @@
 
 module Database.Persist.TH.KindEntitiesSpecImports where
 
+import Data.Proxy
 import qualified Data.Text as T
 import TemplateTestImports
 
@@ -12,10 +13,10 @@ data AccountKind = Debit | Credit
 newtype MoneyAmount (a :: Owner) (b :: AccountKind) = MoneyAmount Rational
 
 instance PersistFieldSql (MoneyAmount a b) where
-    sqlType _ = SqlInt64
+    sqlType _ = sqlType (Proxy :: Proxy Rational)
 
 instance PersistField (MoneyAmount a b) where
-    toPersistValue (MoneyAmount n) = PersistRational n
-    fromPersistValue = \case
-      PersistRational n -> pure (MoneyAmount n)
-      x -> Left $ T.pack $ "Failed to read MoneyAmount: " ++ show x
+    toPersistValue (MoneyAmount n) =
+        toPersistValue n
+    fromPersistValue v =
+        MoneyAmount <$> fromPersistValue v

--- a/persistent/test/Database/Persist/TH/KindEntitiesSpecImports.hs
+++ b/persistent/test/Database/Persist/TH/KindEntitiesSpecImports.hs
@@ -18,4 +18,4 @@ instance PersistField (MoneyAmount a b) where
     toPersistValue (MoneyAmount n) = PersistRational n
     fromPersistValue = \case
       PersistRational n -> pure (MoneyAmount n)
-      x -> Left $ "Failed to read MoneyAmount: " <> (T.pack (show x))
+      x -> Left $ T.pack $ "Failed to read MoneyAmount: " ++ show x

--- a/persistent/test/Database/Persist/TH/KindEntitiesSpecImports.hs
+++ b/persistent/test/Database/Persist/TH/KindEntitiesSpecImports.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Database.Persist.TH.KindEntitiesSpecImports where
+
+import qualified Data.Text as T
+import TemplateTestImports
+
+data Owner = MerchantOwned | CustomerOwned
+data AccountKind = Debit | Credit
+
+newtype MoneyAmount (a :: Owner) (b :: AccountKind) = MoneyAmount Rational
+
+instance PersistFieldSql (MoneyAmount a b) where
+    sqlType _ = SqlInt64
+
+instance PersistField (MoneyAmount a b) where
+    toPersistValue (MoneyAmount n) = PersistRational n
+    fromPersistValue = \case
+      PersistRational n -> pure (MoneyAmount n)
+      x -> Left $ "Failed to read MoneyAmount: " <> (T.pack (show x))

--- a/persistent/test/Database/Persist/THSpec.hs
+++ b/persistent/test/Database/Persist/THSpec.hs
@@ -42,9 +42,10 @@ import Database.Persist.Sql.Util
 import Database.Persist.TH
 import TemplateTestImports
 
-import qualified Database.Persist.TH.SharedPrimaryKeySpec as SharedPrimaryKeySpec
-import qualified Database.Persist.TH.SharedPrimaryKeyImportedSpec as SharedPrimaryKeyImportedSpec
+import qualified Database.Persist.TH.KindEntitiesSpec as KindEntitiesSpec
 import qualified Database.Persist.TH.OverloadedLabelSpec as OverloadedLabelSpec
+import qualified Database.Persist.TH.SharedPrimaryKeyImportedSpec as SharedPrimaryKeyImportedSpec
+import qualified Database.Persist.TH.SharedPrimaryKeySpec as SharedPrimaryKeySpec
 
 share [mkPersist sqlSettings { mpsGeneric = False, mpsDeriveInstances = [''Generic] }, mkDeleteCascade sqlSettings { mpsGeneric = False }] [persistUpperCase|
 
@@ -131,6 +132,7 @@ instance Arbitrary Address where
 
 spec :: Spec
 spec = do
+    KindEntitiesSpec.spec
     OverloadedLabelSpec.spec
     SharedPrimaryKeySpec.spec
     SharedPrimaryKeyImportedSpec.spec

--- a/persistent/test/main.hs
+++ b/persistent/test/main.hs
@@ -376,7 +376,7 @@ CustomerTransfer
 |]
                 let [customerTransfer] = parse lowerCaseSettings tickedDefinition
                 let expectedType =
-                        FTTypeCon Nothing "MoneyAmount" `FTApp` FTTypeCon Nothing "'Customer" `FTApp` FTTypeCon Nothing "'Debit"
+                        FTTypeCon Nothing "MoneyAmount" `FTApp` FTTypePromoted "Customer" `FTApp` FTTypePromoted "Debit"
 
                 (simplifyField <$> entityFields customerTransfer) `shouldBe`
                     [ (FieldNameHS "customerId", FTTypeCon Nothing "CustomerId")

--- a/persistent/test/main.hs
+++ b/persistent/test/main.hs
@@ -370,13 +370,13 @@ Notification
                 let tickedDefinition = [st|
 CustomerTransfer
     customerId CustomerId
-    moneyAmount (MoneyAmount Customer Debit)
+    moneyAmount (MoneyAmount 'Customer 'Debit)
     currencyCode CurrencyCode
     uuid TransferUuid
 |]
                 let [customerTransfer] = parse lowerCaseSettings tickedDefinition
                 let expectedType =
-                        FTTypeCon Nothing "MoneyAmount" `FTApp` FTTypeCon Nothing "Customer" `FTApp` FTTypeCon Nothing "Debit"
+                        FTTypeCon Nothing "MoneyAmount" `FTApp` FTTypeCon Nothing "'Customer" `FTApp` FTTypeCon Nothing "'Debit"
 
                 (simplifyField <$> entityFields customerTransfer) `shouldBe`
                     [ (FieldNameHS "customerId", FTTypeCon Nothing "CustomerId")

--- a/persistent/test/main.hs
+++ b/persistent/test/main.hs
@@ -363,6 +363,28 @@ Notification
             entityComments car `shouldBe` Just "This is a Car\n"
             entityComments vehicle `shouldBe` Nothing
 
+        describe "ticked types" $ do
+            it "should be able to parse ticked types" $ do
+                let simplifyField field =
+                        (fieldHaskell field, fieldType field)
+                let tickedDefinition = [st|
+CustomerTransfer
+    customerId CustomerId
+    moneyAmount (MoneyAmount Customer Debit)
+    currencyCode CurrencyCode
+    uuid TransferUuid
+|]
+                let [customerTransfer] = parse lowerCaseSettings tickedDefinition
+                let expectedType =
+                        FTTypeCon Nothing "MoneyAmount" `FTApp` FTTypeCon Nothing "Customer" `FTApp` FTTypeCon Nothing "Debit"
+
+                (simplifyField <$> entityFields customerTransfer) `shouldBe`
+                    [ (FieldNameHS "customerId", FTTypeCon Nothing "CustomerId")
+                    , (FieldNameHS "moneyAmount", expectedType)
+                    , (FieldNameHS "currencyCode", FTTypeCon Nothing "CurrencyCode")
+                    , (FieldNameHS "uuid", FTTypeCon Nothing "TransferUuid")
+                    ]
+
     describe "parseFieldType" $ do
         it "simple types" $
             parseFieldType "FooBar" `shouldBe` Right (FTTypeCon Nothing "FooBar")


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [ ] Ran `stylish-haskell` on any changed files.
- [x] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->

--------

Closes https://github.com/yesodweb/persistent/issues/1166

I've opened this as a draft PR with a view towards getting some feedback on it still. I think everything here should be fine for addressing that ticket, but there might be something I have overlooked here. I will annotate what I've got so far.

I have also opened this PR against `master` as it is not a super invasive change, and I would be happy to deal with porting it forward into the `persistent-2.13` branch after it is merged in. Alternatively if it is preferred that this PR goes against that branch, and is backported to `master`, I'd be happy to do that as well.

It may also make sense for this to just go into `2.13` like my other recent change :+1: 