### PR TITLE
Show `keyFromValues` error

### DIFF
--- a/persistent/Database/Persist/Sql/Util.hs
+++ b/persistent/Database/Persist/Sql/Util.hs
@@ -23,7 +23,7 @@ module Database.Persist.Sql.Util
 import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.Maybe as Maybe
 import Data.Monoid ((<>))
-import Data.Text (Text, pack)
+import Data.Text (Text, pack, unpack)
 import qualified Data.Text as T
 
 import Database.Persist
@@ -188,7 +188,7 @@ parseEntityValues t vals =
         case fromPersistValues xs of
             Left e -> Left e
             Right xs' -> case keyFromValues keyvals of
-                Left _ -> error "fromPersistValuesComposite': keyFromValues failed"
+                Left err -> error $ "fromPersistValuesComposite': keyFromValues failed with error: " <> unpack err
                 Right key -> Right (Entity key xs')
 
 


### PR DESCRIPTION
Backends send helpful information on composite key errors but we don't get to see it.

-Before submitting your PR, check that you've:

- [x ] Ran `stylish-haskell` on any changed files.
- [ x] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
