### PR TITLE
Improve documentation around migration safety

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for persistent
 
+## 2.13.0.3
+* [#1277](https://github.com/yesodweb/persistent/pull/1277)
+    * Corrected the documentation of `addMigration` to match the actual
+      behaviour - this will not change the behaviour of your code.
+
 ## 2.13.0.2
 
 * [#1265](https://github.com/yesodweb/persistent/pull/1265)

--- a/persistent/Database/Persist/Sql/Migration.hs
+++ b/persistent/Database/Persist/Sql/Migration.hs
@@ -22,20 +22,20 @@ module Database.Persist.Sql.Migration
 import Control.Exception (throwIO)
 import Control.Monad (liftM, unless)
 import Control.Monad.IO.Unlift
-import Control.Monad.Trans.Class (MonadTrans (..))
-import Control.Monad.Trans.Reader (ReaderT (..), ask)
+import Control.Monad.Trans.Class (MonadTrans(..))
+import Control.Monad.Trans.Reader (ReaderT(..), ask)
 import Control.Monad.Trans.Writer
-import Data.Text (Text, unpack, snoc, isPrefixOf, pack)
+import Data.Text (Text, isPrefixOf, pack, snoc, unpack)
 import qualified Data.Text.IO
+import GHC.Stack
 import System.IO
 import System.IO.Silently (hSilence)
-import GHC.Stack
 
+import Database.Persist.Sql.Orphan.PersistStore ()
+import Database.Persist.Sql.Raw
 import Database.Persist.Sql.Types
 import Database.Persist.Sql.Types.Internal
-import Database.Persist.Sql.Raw
 import Database.Persist.Types
-import Database.Persist.Sql.Orphan.PersistStore()
 
 allSql :: CautiousMigration -> [Sql]
 allSql = map snd

--- a/persistent/Database/Persist/Sql/Migration.hs
+++ b/persistent/Database/Persist/Sql/Migration.hs
@@ -195,12 +195,14 @@ reportErrors = tell
 -- @since 2.9.2
 addMigration
     :: Bool
-    -- ^ Is the migration safe to run? (eg a non-destructive and idempotent
-    -- update on the schema)
+    -- ^ Is the migration unsafe to run? (eg a destructive or non-idempotent
+    -- update on the schema). If 'True', the migration is *unsafe*, and will
+    -- need to be run manually later. If 'False', the migration is *safe*, and
+    -- can be run any number of times.
     -> Sql
     -- ^ A 'Text' value representing the command to run on the database.
     -> Migration
-addMigration isSafe sql = lift (tell [(isSafe, sql)])
+addMigration isUnsafe sql = lift (tell [(isUnsafe, sql)])
 
 -- | Add a 'CautiousMigration' (aka a @[('Bool', 'Text')]@) to the
 -- migration plan.

--- a/persistent/Database/Persist/Sql/Types.hs
+++ b/persistent/Database/Persist/Sql/Types.hs
@@ -63,7 +63,10 @@ type SqlPersistM = SqlPersistT (NoLoggingT (ResourceT IO))
 
 type Sql = Text
 
--- Bool indicates if the Sql is safe
+-- A list of SQL operations, marked with a safety flag. If the 'Bool' is
+-- 'True', then the operation is *unsafe* - it might be destructive, or
+-- otherwise not idempotent. If the 'Bool' is 'False', then the operation
+-- is *safe*, and can be run repeatedly without issues.
 type CautiousMigration = [(Bool, Sql)]
 
 -- | A 'Migration' is a four level monad stack consisting of:

--- a/persistent/Database/Persist/Sql/Types.hs
+++ b/persistent/Database/Persist/Sql/Types.hs
@@ -63,7 +63,7 @@ type SqlPersistM = SqlPersistT (NoLoggingT (ResourceT IO))
 
 type Sql = Text
 
--- A list of SQL operations, marked with a safety flag. If the 'Bool' is
+-- | A list of SQL operations, marked with a safety flag. If the 'Bool' is
 -- 'True', then the operation is *unsafe* - it might be destructive, or
 -- otherwise not idempotent. If the 'Bool' is 'False', then the operation
 -- is *safe*, and can be run repeatedly without issues.

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:            persistent
-version:         2.13.0.2
+version:         2.13.0.3
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
The Haddocks around CautiousMigration were ambiguous, since it wasn't clear if the flag signified whether each migration was safe or not - and there is at least one instance in the code that gets it wrong.

This corrects that error, opting to make the `addMigration` documentation match the code's behaviour.

Personally, I think the better approach to this mess would be to replace all the use of `(Bool, Text)` with a datatype that enforces better usage through a stricter API - something like
```haskell
data CautiousSql = MkCautiousSql { ... } -- Hide this constructor

-- Expose these smart constructors
mkSafeSql :: Sql -> CautiousSql
mkSafeSql = ...

mkUnsafeSql :: Sql -> CautiousSql
mkUnsafeSql = ...

-- Expose these instead of record fields
isUnsafe :: CautiousSql -> Bool
isUnsafe = ...

rawSql :: CautiousSql -> Sql
rawSql = ...

-- Maybe even a smart destructor?
ifSafe :: (Bool -> Sql -> a) -> CautiousSql -> a
ifSafe = ...
```
That way consumers could not be misled about the nature of the `Bool` value. But I thought that would be quite drastic and breaking, so I didn't want to make it my first suggestion.

Fixes #1081.

Before submitting your PR, check that you've:

- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [x] Ran `stylish-haskell` on any changed files.
- [x] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
