### PR TITLE
Derive persistent definitions from a data type

### DIFF
--- a/persistent-sqlite/test/main.hs
+++ b/persistent-sqlite/test/main.hs
@@ -46,6 +46,7 @@ import qualified TransactionLevelTest
 import qualified UniqueTest
 import qualified UpsertTest
 import qualified LongIdentifierTest
+import qualified DerivePersistTest
 
 import Control.Exception (handle, IOException, throwIO)
 import Control.Monad.Catch (catch)
@@ -168,6 +169,7 @@ main = do
             , CustomPersistFieldTest.customFieldMigrate
             , PrimaryTest.migration
             , CustomPrimaryKeyReferenceTest.migration
+            , DerivePersistTest.migration
             , MigrationColumnLengthTest.migration
             , TransactionLevelTest.migration
             , LongIdentifierTest.migration
@@ -237,6 +239,7 @@ main = do
         MigrationTest.specsWith db
         LongIdentifierTest.specsWith db
         GeneratedColumnTestSQL.specsWith db
+        DerivePersistTest.specsWith db
 
         it "issue #328" $ asIO $ runSqliteInfo (mkSqliteConnectionInfo ":memory:") $ do
             void $ runMigrationSilent migrateAll

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -21,6 +21,7 @@ library
         CustomPersistFieldTest
         CustomPrimaryKeyReferenceTest
         DataTypeTest
+        DerivePersistTest
         EmbedTest
         EmbedOrderTest
         EmptyEntityTest

--- a/persistent-test/src/DerivePersistTest.hs
+++ b/persistent-test/src/DerivePersistTest.hs
@@ -17,7 +17,7 @@ data DerivePrimary = DerivePrimary {
 derivePersist persistSettings {mpsGeneric=False, mpsRecordFieldToHaskellName = stripEntityNamePrefix} lowerCaseSettings [
   (mkDeriveEntityDef 'DerivePrimary) {
     deriveFields = [(mkDeriveFieldDef 'derivePrimaryName) {
-      sqlNameOverride=Just "sql_name"
+      sqlNameOverride="sql_name"
       }]
   }]
 

--- a/persistent-test/src/DerivePersistTest.hs
+++ b/persistent-test/src/DerivePersistTest.hs
@@ -2,7 +2,8 @@
 
 module DerivePersistTest where
 
-import Database.Persist.TH (mkDeleteCascade, derivePersist, persistLowerCase, stripEntityNamePrefix, DeriveEntityDef(..), DeriveFieldDef(..), DeriveForeignKey(..), DeriveUniqueDef(..), mkDeriveEntityDef, mkDeriveFieldDef, mkDeriveUniqueDef)
+import Database.Persist.TH (mkDeleteCascade, persistLowerCase)
+import Database.Persist.DerivePersist
 import Database.Persist.Quasi (lowerCaseSettings)
 import Data.Maybe (isJust)
 
@@ -129,9 +130,7 @@ specsWith runDb = describe "derivePersist" $ do
     k3 <- insert m3
     m3' <- get k3
     m3' @== Just m3
-    res <- rawSql "SELECT * FROM menu_object" []
-    liftIO $ print (res :: [(Single Text, Single Text)])
-  
+
   it "Supports composite keys" $ runDb $ do
     -- copy from CompositeTest
     let p1 = TestParent2 "a1" "b1" 11 "p1"

--- a/persistent-test/src/DerivePersistTest.hs
+++ b/persistent-test/src/DerivePersistTest.hs
@@ -13,6 +13,7 @@ data DerivePrimary = DerivePrimary {
   derivePrimaryAge :: Int
 } deriving (Eq, Show)
 
+
 derivePersist persistSettings {mpsGeneric=False, mpsRecordFieldToHaskellName = stripEntityNamePrefix} lowerCaseSettings [
   (mkDeriveEntityDef 'DerivePrimary) {
     deriveFields = [(mkDeriveFieldDef 'derivePrimaryName) {

--- a/persistent-test/src/DerivePersistTest.hs
+++ b/persistent-test/src/DerivePersistTest.hs
@@ -38,7 +38,10 @@ newtype MenuObject2 = MenuObject2 {
 } deriving (Eq, Show)
 
 derivePersist persistSettings {mpsGeneric=False, mpsRecordFieldToHaskellName = stripEntityNamePrefix} lowerCaseSettings [
-  mkDeriveEntityDef 'SubType2,
+  mkDeriveEntityDef 'SubType2
+  ]
+
+derivePersist persistSettings {mpsGeneric=False, mpsRecordFieldToHaskellName = stripEntityNamePrefix} lowerCaseSettings [
   mkDeriveEntityDef 'MenuObject2
   ]
 

--- a/persistent-test/src/DerivePersistTest.hs
+++ b/persistent-test/src/DerivePersistTest.hs
@@ -1,0 +1,132 @@
+{-# LANGUAGE UndecidableInstances, DeriveGeneric #-} -- FIXME
+
+module DerivePersistTest where
+
+import Database.Persist.TH (mkDeleteCascade, derivePersist, persistLowerCase, stripEntityNamePrefix, DeriveEntityDef(..), DeriveFieldDef(..), DeriveForeignKey(..), mkDeriveEntityDef, mkDeriveFieldDef)
+import Database.Persist.Quasi (lowerCaseSettings)
+import Data.Maybe (isJust)
+
+import Init
+
+data DerivePrimary = DerivePrimary {
+  derivePrimaryName :: String,
+  derivePrimaryAge :: Int
+} deriving (Eq, Show)
+
+derivePersist persistSettings {mpsGeneric=False, mpsRecordFieldToHaskellName = stripEntityNamePrefix} lowerCaseSettings [
+  (mkDeriveEntityDef 'DerivePrimary) {
+    deriveFields = [(mkDeriveFieldDef 'derivePrimaryName) {
+      sqlNameOverride=Just "sql_name"
+      }]
+  }]
+
+data DeriveSimpleRef = DeriveSimpleRef {
+  plainPrimaryRefName :: String,
+  plainPrimaryRefRef :: DerivePrimaryId
+} deriving (Eq, Show)
+derivePersist persistSettings {mpsGeneric=False, mpsRecordFieldToHaskellName = stripEntityNamePrefix} lowerCaseSettings [
+  mkDeriveEntityDef 'DeriveSimpleRef
+  ]
+
+newtype SubType2 = SubType2 {
+  menuObject :: [MenuObject2]
+} deriving (Eq, Show)
+
+newtype MenuObject2 = MenuObject2 {
+  sub :: Maybe SubType2
+} deriving (Eq, Show)
+
+derivePersist persistSettings {mpsGeneric=False, mpsRecordFieldToHaskellName = stripEntityNamePrefix} lowerCaseSettings [
+  mkDeriveEntityDef 'SubType2,
+  mkDeriveEntityDef 'MenuObject2
+  ]
+
+share [mkPersist sqlSettings { mpsGeneric = True }] [persistLowerCase|
+
+SubType3
+  object3 [MenuObject3]
+  deriving Show Eq
+
+MenuObject3
+  sub3 SubType3 Maybe
+  deriving Show Eq
+
+|]
+
+data TestParent2 = TestParent2 {
+  testParentName ::  String
+  , testParentName2 :: String
+  , testParentAge :: Int
+  , testParentExtra44 :: String
+  } deriving (Eq, Show)
+
+data TestChild2 = TestChild2 {
+  testChildName :: String
+  , testChildName2 :: String
+  , testChildAge :: Int
+  , testChildExtra4 :: String
+} deriving (Eq, Show)
+
+derivePersist persistSettings {mpsGeneric=False, mpsRecordFieldToHaskellName = stripEntityNamePrefix} lowerCaseSettings [
+    (mkDeriveEntityDef 'TestParent2) {
+      primaryId = Just $ Right ['testParentName, 'testParentName2, 'testParentAge]
+    },
+    (mkDeriveEntityDef 'TestChild2) {
+      foreignKeys = [DeriveForeignKey 'TestParent2 "fkparent" ['testChildName, 'testChildName2, 'testChildAge] Nothing]
+    }
+  ]
+
+migration :: Migration
+migration = do
+  migrate [] (entityDef (Proxy :: Proxy DerivePrimary))
+  migrate [] (entityDef (Proxy :: Proxy DeriveSimpleRef))
+  migrate [] (entityDef (Proxy :: Proxy SubType2))
+  migrate [] (entityDef (Proxy :: Proxy MenuObject2))
+  migrate [] (entityDef (Proxy :: Proxy TestParent2))
+  migrate [] (entityDef (Proxy :: Proxy TestChild2))
+
+specsWith :: (MonadIO m, MonadFail m) => RunDb SqlBackend m -> Spec
+specsWith runDb = describe "derivePersist" $ do
+  it "Supports basic operations" $ runDb $ do
+    let p1 = DerivePrimary "a" 1
+    k <- insert p1
+    p1' <- get k
+    Just p1 @== p1'
+  
+  it "Creates fields" $ runDb $ do
+    let p1 = DerivePrimary "a" 1
+    k <- insert p1
+    p1' <- selectFirst [DerivePrimaryName ==. "a"] []
+    Just (Entity k p1) @== p1'
+
+  it "Supports primary key" $ runDb $ do
+    let p1 = DerivePrimary "a" 1
+    k <- insert p1
+    let p = DeriveSimpleRef "a" k
+    k' <- insert p
+    p' <- get k'
+    Just p @== p'
+
+  it "Supports recursive" $ runDb $ do
+    let m1 = MenuObject2 $ Just $ SubType2 []
+    let m2 = MenuObject2 $ Just $ SubType2 [m1]
+    let m3 = MenuObject2 $ Just $ SubType2 [m2]
+    k3 <- insert m3
+    m3' <- get k3
+    m3' @== Just m3
+    res <- rawSql "SELECT * FROM menu_object" []
+    liftIO $ print (res :: [(Single Text, Single Text)])
+  
+  it "Supports composite keys" $ runDb $ do
+    -- copy from CompositeTest
+    let p1 = TestParent2 "a1" "b1" 11 "p1"
+    let p2 = TestParent2 "a2" "b2" 22 "p2"
+    let c1 = TestChild2 "a1" "b1" 11 "c1"
+    kp1 <- insert p1
+    insert_ p2
+    kc1 <- insert c1
+    mc <- get kc1
+    isJust mc @== True
+    let Just c11 = mc
+    c1 @== c11
+    testChild2Fkparent c11 @== kp1

--- a/persistent/Database/Persist/DerivePersist.hs
+++ b/persistent/Database/Persist/DerivePersist.hs
@@ -1,0 +1,241 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+
+-- | This module provides the tools for defining your database schema and using
+-- it to generate Haskell data types and migrations.
+module Database.Persist.DerivePersist
+    ( -- * Parse entity defs
+
+      derivePersist
+    , stripEntityNamePrefix
+    , OptionalText(..)
+    , DeriveFieldDef(..)
+    , DeriveEntityDef(..)
+    , DeriveForeignKey(..)
+    , DeriveUniqueDef(..)
+    , mkDeriveEntityDef
+    , mkDeriveFieldDef
+    , mkDeriveUniqueDef
+    ) where
+
+
+import Data.String (IsString (fromString))
+import Database.Persist.TH
+import Database.Persist.Quasi (PersistSettings)
+import Language.Haskell.TH
+import qualified Data.List.NonEmpty as NEL
+import qualified Data.Map as M
+import Data.Text (Text, pack, unpack)
+import qualified Data.Text as T
+import Database.Persist
+import Language.Haskell.TH.Datatype
+import qualified Language.Haskell.TH.Datatype as THD
+import Database.Persist.Types.Base (EntityDef(..), EntityIdDef (..))
+import Database.Persist.Quasi.Internal (PersistSettings(..), UnboundEntityDef (..), UnboundForeignDef (..), unbindEntityDef, PrimarySpec (..), mkAutoIdField', isCapitalizedText, UnboundForeignFieldList (..))
+import Data.Maybe (fromMaybe)
+
+
+derivePersist :: MkPersistSettings -> PersistSettings -> [DeriveEntityDef] -> Q [Dec]
+derivePersist mps ps defs = do
+    ents <- mapM (\ded -> datatypeToEntityDef mps ps ded <$> reifyDatatype (entityTypeName ded)) defs
+    let mps' = mps {mpsCreateDataType = False}
+    mkPersist mps' ents
+
+-- | Helper data type for better ergonomics.
+-- Overriding a string with it does not need Just, which makes it easier to use than @Maybe Text@.
+newtype OptionalText = OptionalText {
+    fromOptionalText :: Maybe Text
+}
+instance IsString OptionalText where
+  fromString = OptionalText . Just . pack
+
+data DeriveFieldDef = DeriveFieldDef
+    { fieldRecordName :: Name
+    , sqlNameOverride :: OptionalText
+    , sqlTypeOverride :: OptionalText
+    , generatedOverride :: OptionalText
+    , fieldCascadeOverride :: Maybe FieldCascade
+    , fieldAttrOverride :: [FieldAttr]
+    }
+
+data DeriveEntityDef = DeriveEntityDef
+    { entityTypeName :: Name
+    , primaryId :: Maybe (Either DeriveFieldDef [Name])
+    , deriveEntityDB :: OptionalText
+    , uniques :: [DeriveUniqueDef]
+    , deriveFields :: [DeriveFieldDef]
+    , foreignKeys :: [DeriveForeignKey]
+    }
+
+mkDeriveEntityDef :: Name -> DeriveEntityDef
+mkDeriveEntityDef name = DeriveEntityDef
+    { entityTypeName = name
+    , primaryId = Nothing
+    , deriveEntityDB = OptionalText Nothing
+    , uniques = []
+    , deriveFields = []
+    , foreignKeys = []
+    }
+
+data DeriveUniqueDef = DeriveUniqueDef
+    { uniqueHaskellName :: Text
+    , deriveUniqueDBName :: OptionalText
+    , deriveUniqueFields :: [Name]
+    , forceNullableFields :: Bool
+    }
+
+mkDeriveUniqueDef :: Text -> [Name] -> DeriveUniqueDef
+mkDeriveUniqueDef name fields = DeriveUniqueDef
+    { uniqueHaskellName = name
+    , deriveUniqueDBName = OptionalText Nothing
+    , deriveUniqueFields = fields
+    , forceNullableFields = False
+    }
+
+mkDeriveFieldDef :: Name -> DeriveFieldDef
+mkDeriveFieldDef name = DeriveFieldDef
+    { fieldRecordName = name
+    , sqlNameOverride = OptionalText Nothing
+    , sqlTypeOverride = OptionalText Nothing
+    , generatedOverride = OptionalText Nothing
+    , fieldCascadeOverride = Nothing
+    , fieldAttrOverride = []
+    }  
+
+data DeriveForeignKey = DeriveForeignKey
+    { otherEntity :: Name
+    , constraintName :: Text
+    , ourFields :: [Name]
+    , parentFields :: Maybe [Name]
+    }
+
+stripEntityNamePrefix :: Text -> Text -> Text
+stripEntityNamePrefix entName fieldName = if T.toLower entName `T.isPrefixOf` T.toLower fieldName
+    then T.drop (T.length entName) fieldName
+    else fieldName
+
+datatypeToEntityDef :: MkPersistSettings -> PersistSettings -> DeriveEntityDef -> DatatypeInfo -> UnboundEntityDef
+datatypeToEntityDef mps ps@PersistSettings{..} ded DatatypeInfo{..} = unbound' where
+    unbound = unbindEntityDef ent
+    unbound' = unbound {
+        unboundForeignDefs = foreigns,
+        unboundPrimarySpec = case entityIdField of
+            EntityIdNaturalKey _ -> unboundPrimarySpec unbound
+            -- unbindEntityDef never creates a DefaultKey, so we do it here
+            EntityIdField f -> DefaultKey $ fieldDB f
+    }
+    ent = EntityDef
+        { entityHaskell = EntityNameHS entName
+        , entityDB = EntityNameDB tableName
+        , entityId = entityIdField
+        , entityAttrs = []
+        , entityFields = map snd fields 
+        , entityUniques = entityUniques'
+        , entityForeigns = []
+        , entityDerives = []
+        , entityExtra = mempty
+        , entitySum = False 
+        , entityComments = Nothing
+    }
+    entName = pack $ nameBase datatypeName
+    tableName = fromMaybe (psToDBName entName) (fromOptionalText $ deriveEntityDB ded)
+
+    fields = fieldToFieldDefs mps ps ded $ case datatypeCons of
+        [c] -> c
+        _ -> error $ show entName <> ": data type must have a single constructor"
+
+    entityIdField = case primaryId ded of
+        Nothing -> EntityIdField $ mkAutoIdField' (FieldNameDB psIdName) (EntityNameHS entName) SqlInt64
+        Just (Right names) | null names -> error "No fields on primary composite key."
+        Just (Right names) -> EntityIdNaturalKey $ CompositeDef (getFieldByName <$> NEL.fromList names) []
+        Just (Left primaryOverride) ->
+            -- Only the id column name can be adjusted
+            EntityIdField $ mkAutoIdField' (FieldNameDB $ fromMaybe psIdName $ fromOptionalText $ sqlNameOverride primaryOverride) (EntityNameHS entName) SqlInt64
+
+    getFieldByName :: Name -> FieldDef
+    getFieldByName name = case lookup name fields of
+        Just field -> field
+        Nothing -> error $ "datatypeToEntityDef: entity " <> show entName <> "  does not have field " <> show name
+
+    entityUniques' = map mkUniqueDef (uniques ded)
+
+    mkUniqueDef :: DeriveUniqueDef -> UniqueDef
+    mkUniqueDef DeriveUniqueDef{..} = UniqueDef {..} where
+        uniqueError :: String -> a
+        uniqueError msg = error $ "Invalid unique constraint on table[" ++ unpack entName ++ "]: " ++ msg
+
+        uniqueFields = case NEL.nonEmpty deriveUniqueFields of
+            Just uniqueFields' -> fmap ((\f -> (fieldHaskell f, fieldDB f)) . getFieldByName) uniqueFields'
+            Nothing -> uniqueError "list of fields cannot be empty"
+        uniqueHaskell = if isCapitalizedText uniqueHaskellName
+            then ConstraintNameHS uniqueHaskellName
+            else uniqueError $ "expecting an uppercase constraint name, found =" ++ unpack uniqueHaskellName
+        uniqueDBName = ConstraintNameDB $ fromMaybe (psToDBName (tableName `T.append` uniqueHaskellName)) (fromOptionalText deriveUniqueDBName)
+        uniqueAttrs = ["!force" | forceNullableFields]
+
+    foreigns = map mkForeign (foreignKeys ded)
+
+    mkForeign :: DeriveForeignKey -> UnboundForeignDef
+    mkForeign DeriveForeignKey{..} = UnboundForeignDef foreignFields $ ForeignDef
+        { foreignRefTableHaskell = EntityNameHS $ pack $ nameBase otherEntity
+        , foreignRefTableDBName = EntityNameDB $ psToDBName $ pack $ nameBase otherEntity
+        , foreignConstraintNameHaskell = ConstraintNameHS constraintName
+        , foreignConstraintNameDBName =
+            ConstraintNameDB $ psToDBName (entName `T.append` constraintName)
+        , foreignFieldCascade = FieldCascade
+            { fcOnDelete = Nothing
+            , fcOnUpdate = Nothing
+            }
+        , foreignFields = []
+        , foreignAttrs = []
+        , foreignNullable = False
+        , foreignToPrimary = null parentFields
+        } where
+            foreignFields = FieldListImpliedId $ NEL.fromList $ map toFieldHaskell ourFields
+    toFieldHaskell name = FieldNameHS $
+        mpsRecordFieldToHaskellName mps entName (pack $ nameBase name)
+
+fieldToFieldDefs :: MkPersistSettings -> PersistSettings -> DeriveEntityDef -> ConstructorInfo -> [(Name, FieldDef)]
+fieldToFieldDefs mps PersistSettings{..} ded ConstructorInfo{..} = case constructorVariant of
+    RecordConstructor names -> zipWith3 (\name -> toFieldDef name (lookupFieldOverride name)) names constructorFields constructorStrictness
+    _ -> error "Data type must have a record constructor"
+    where
+    lookupFieldOverride :: Name -> Maybe DeriveFieldDef
+    lookupFieldOverride =
+        let fieldMap = M.fromList $ map (\f -> (fieldRecordName f, f)) $ deriveFields ded
+        in flip M.lookup fieldMap
+
+    toFieldDef :: Name -> Maybe DeriveFieldDef -> Type -> FieldStrictness -> (Name, FieldDef)
+    toFieldDef name maybeDef typ strictness = (name, FieldDef{
+          fieldHaskell = FieldNameHS fieldHaskell
+        , fieldDB = FieldNameDB $ fromMaybe (psToDBName fieldHaskell) (maybeDef >>= fromOptionalText . sqlNameOverride)
+        , fieldType = fieldType
+        , fieldSqlType = SqlOther $ "SqlType unset for " `mappend` pack (show name)
+        , fieldAttrs = recordNameAttr: sqlTypeAttr <> nullableAttr <> maybe [] fieldAttrOverride maybeDef
+        , fieldStrict = fieldStrictness strictness == THD.Strict
+        , fieldReference = NoReference
+        , fieldComments = Nothing
+        , fieldCascade = FieldCascade (maybeDef >>= fieldCascadeOverride >>= fcOnUpdate) (maybeDef >>= fieldCascadeOverride >>= fcOnDelete)
+        , fieldGenerated = maybeDef >>= fromOptionalText . generatedOverride
+        , fieldIsImplicitIdColumn = False
+        }) where
+        -- Save the field name for code generation. It cannot always be inferred from fieldHaskell.
+        recordNameAttr = FieldAttrOther $ "recordName=" <> pack (nameBase name)
+        entName = pack $ nameBase $ entityTypeName ded
+        fieldHaskell = mpsRecordFieldToHaskellName mps entName (pack $ nameBase name)
+        (fieldType, isNullable) = decomposeFieldType typ
+        sqlTypeAttr = maybe [] (\t -> [FieldAttrSqltype t]) (maybeDef >>= fromOptionalText . sqlTypeOverride)
+        nullableAttr = [FieldAttrMaybe | isNullable]
+
+decomposeFieldType :: Type -> (FieldType, Bool)
+decomposeFieldType = unwrapMaybe where
+    unwrapMaybe (AppT t1 t2) | t1 == ConT ''Maybe = (go t2, True)
+    unwrapMaybe t = (go t, False)
+
+    go (ConT name) = FTTypeCon Nothing (pack $ nameBase name)
+    go (ParensT t) = go t
+    go (AppT ListT t) = FTList (go t)
+    go (AppT t1 t2) | t1 == ConT ''Maybe = go t2
+    go (AppT t1 t2) = FTApp (go t1) (go t2)
+    go t = error $ "Cannot process type: " <> show t

--- a/persistent/Database/Persist/Quasi/Internal.hs
+++ b/persistent/Database/Persist/Quasi/Internal.hs
@@ -24,6 +24,7 @@ module Database.Persist.Quasi.Internal
     , Line (..)
     , preparse
     , parseLine
+    , isCapitalizedText
     , parseFieldType
     , associateLines
     , LinesWithComments(..)

--- a/persistent/Database/Persist/Quasi/Internal.hs
+++ b/persistent/Database/Persist/Quasi/Internal.hs
@@ -33,7 +33,6 @@ module Database.Persist.Quasi.Internal
     , UnboundEntityDef(..)
     , getUnboundEntityNameHS
     , unbindEntityDef
-    , unbindCompositeDef
     , getUnboundFieldDefs
     , UnboundForeignDef(..)
     , getSqlNameOr

--- a/persistent/Database/Persist/Quasi/Internal.hs
+++ b/persistent/Database/Persist/Quasi/Internal.hs
@@ -33,6 +33,7 @@ module Database.Persist.Quasi.Internal
     , UnboundEntityDef(..)
     , getUnboundEntityNameHS
     , unbindEntityDef
+    , unbindCompositeDef
     , getUnboundFieldDefs
     , UnboundForeignDef(..)
     , getSqlNameOr

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -312,6 +312,8 @@ mkAutoIdField ps entName idSqlType =
         , fieldIsImplicitIdColumn = True
         }
 
+-- | Helper data type for better ergonomics.
+-- Overriding a string with it does not need Just, which makes it easier to use than @Maybe Text@.
 data OptionalText = DefaultText | Override Text
 instance IsString OptionalText where
   fromString = Override . pack
@@ -333,6 +335,7 @@ data DeriveEntityDef = DeriveEntityDef
     { entityTypeName :: Name
     , primaryId :: Maybe (Either DeriveFieldDef [Name])
     , deriveEntityDB :: OptionalText
+    -- TODO: uniques are ignored now
     , uniques :: Maybe (Text, [Name])
     , deriveFields :: [DeriveFieldDef]
     , foreignKeys :: [DeriveForeignKey]
@@ -405,6 +408,7 @@ datatypeToEntityDef mps ps@PersistSettings{..} ded DatatypeInfo{..} = unbound' w
         Nothing -> EntityIdField $ mkAutoIdField' (FieldNameDB psIdName) (EntityNameHS entName) SqlInt64
         Just (Right names) | null names -> error "No fields on primary composite key."
         Just (Right names) -> EntityIdNaturalKey $ CompositeDef (getFieldByName <$> NEL.fromList names) []
+        -- TODO: override sql type and sql name
         Just (Left primaryOverride) -> error "Left entityIdField"
 
     getFieldByName :: Name -> FieldDef

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -363,9 +363,14 @@ stripEntityNamePrefix entName fieldName = if T.toLower entName `T.isPrefixOf` T.
     else fieldName
 
 datatypeToEntityDef :: MkPersistSettings -> PersistSettings -> DeriveEntityDef -> DatatypeInfo -> UnboundEntityDef
-datatypeToEntityDef mps ps@PersistSettings{..} ded DatatypeInfo{..} = unbound where
-    unbound = (unbindEntityDef ent) {
-        unboundForeignDefs = foreigns
+datatypeToEntityDef mps ps@PersistSettings{..} ded DatatypeInfo{..} = unbound' where
+    unbound = unbindEntityDef ent
+    unbound' = unbound {
+        unboundForeignDefs = foreigns,
+        unboundPrimarySpec = case primaryId ded of
+            -- unbindEntityDef never creates a DefaultKey
+            Nothing -> DefaultKey (FieldNameDB $ psIdName)
+            _ -> unboundPrimarySpec unbound
     }
     ent = EntityDef
         { entityHaskell = EntityNameHS entName

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -63,6 +63,7 @@ library
         Database.Persist.ImplicitIdDef
         Database.Persist.ImplicitIdDef.Internal
         Database.Persist.TH
+        Database.Persist.DerivePersist
 
         Database.Persist.Quasi
         Database.Persist.Quasi.Internal

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -37,6 +37,7 @@ library
       , template-haskell         >= 2.13 && < 2.18
       , text                     >= 1.2
       , th-lift-instances        >= 0.1.14    && < 0.2
+      , th-abstraction           >= 0.2.8
       , time                     >= 1.6
       , transformers             >= 0.5
       , unliftio
@@ -140,6 +141,7 @@ test-suite test
       , template-haskell         >= 2.4
       , text
       , th-lift-instances
+      , th-abstraction
       , time
       , transformers
       , unliftio


### PR DESCRIPTION
A declaration of a model with Persistent combines both the creation of the data type and the Persistent instances. If we could write a regular Haskell data type and separately define a persistent instance for it, they would be loosely coupled. The declarations would have less quasi-quotation magic but as a downside, they may be more verbose.

This is a draft PR. Before the final cleanup and adding the documentation, it would be helpful like to get a high-level review of the API and its integration with Persistent.

Here is an example:

```haskell
data DerivePrimary = DerivePrimary {
  derivePrimaryName :: String,
  derivePrimaryAge :: Int
} deriving (Eq, Show)

derivePersist persistSettings {mpsGeneric=False, mpsRecordFieldToHaskellName = stripEntityNamePrefix} lowerCaseSettings [
  (mkDeriveEntityDef 'DerivePrimary) {
    deriveFields = [(mkDeriveFieldDef 'derivePrimaryName) {
      sqlNameOverride="sql_name"
      }]
  }]
```