### PR TITLE
Add put function

### DIFF
--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -992,6 +992,7 @@ instance (PersistUniqueWrite b) => PersistUniqueWrite (RawSqlite b) where
     insertUnique = withReaderT _persistentBackend . insertUnique
     upsert rec = withReaderT _persistentBackend . upsert rec
     upsertBy uniq rec = withReaderT _persistentBackend . upsertBy uniq rec
+    put = withReaderT _persistentBackend . put
     putMany = withReaderT _persistentBackend . putMany
 #endif
 

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for persistent
 
+## 2.13.1.0
+* []()
+    * Add put that returns the repsert key
+
 ## 2.13.0.2
 
 * [#1265](https://github.com/yesodweb/persistent/pull/1265)

--- a/persistent/Database/Persist/Compatible/Types.hs
+++ b/persistent/Database/Persist/Compatible/Types.hs
@@ -124,6 +124,7 @@ instance (HasPersistBackend b, BackendCompatible b s, PersistUniqueWrite b) => P
     insertUnique = withReaderT (projectBackend @b @s . unCompatible) . insertUnique
     upsert rec = withReaderT (projectBackend @b @s . unCompatible) . upsert rec
     upsertBy uniq rec = withReaderT (projectBackend @b @s . unCompatible) . upsertBy uniq rec
+    put = withReaderT (projectBackend @b @s . unCompatible) . put
     putMany = withReaderT (projectBackend @b @s . unCompatible) . putMany
 
 deriving via (BackendKey b) instance (BackendCompatible b s, Show (BackendKey b)) => Show (BackendKey (Compatible b s))


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [X] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [X] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [ ] Ran `stylish-haskell` on any changed files.
- [X] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->


Saw a weird behavior when wanting to do a simple `repsert` but also get back the key. I wrote up a draft to see what people think. I tried to copy behavior as much as possible but I don't know the codebase enough to know if this is the right move or not. 

Other possible solutions I had thought of:
- make repsert return the key (may not always be possible)
- make upsert return the key
- make a different upsert/repsert within the non-unique namespace (not sure why they're split up)

Important note: There are multiple different ways to implement this to be performant on the sql/mongo/etc. side, is this something that I should attempt? I'm not a big expert on all of the different database structures.