### PR TITLE
Avoid unnecessary `REFERENCES` clause during table creation

### DIFF
--- a/persistent-mysql/persistent-mysql.cabal
+++ b/persistent-mysql/persistent-mysql.cabal
@@ -35,7 +35,7 @@ library
                    , conduit          >= 1.2.12
                    , containers       >= 0.5
                    , monad-logger
-                   , mysql            >= 0.1.4    && < 0.2
+                   , mysql            >= 0.1.4    && < 0.3
                    , mysql-simple     >= 0.4.4    && < 0.5
                    , resourcet        >= 1.1
                    , resource-pool


### PR DESCRIPTION
We ran into issue https://github.com/yesodweb/persistent/issues/1158 , which basically renders DB migrations unusable with MariaDB (at least since version 10.5). The solution proposed by Markus Linik (@mklinik) works as expected. In a nutshell, the `REFERENCES` part of a CREATE TABLE statement is suppressed for foreign keys and this specification is delayed until the subsequent ALTER TABLE which sets it up correctly (as it always has). 