### PR TITLE
Fix order of field comments

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog for persistent
 
+## 2.13.1.1
+
+* [#1294](https://github.com/yesodweb/persistent/pull/1294)
+    * Fix an issue where documentation comments on fields are in reverse line
+      order.
+
 ## 2.13.1.0
 
 * [#1264](https://github.com/yesodweb/persistent/pull/1264)

--- a/persistent/Database/Persist/Quasi/Internal.hs
+++ b/persistent/Database/Persist/Quasi/Internal.hs
@@ -789,7 +789,7 @@ associateComments ps x (!acc, !comments) =
         Just (DocComment comment) ->
             (acc, comment : comments)
         _ ->
-            case (setFieldComments comments <$> takeColsEx ps (tokenText <$> x)) of
+            case (setFieldComments (reverse comments) <$> takeColsEx ps (tokenText <$> x)) of
               Just sm ->
                   (sm : acc, [])
               Nothing ->

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:            persistent
-version:         2.13.1.0
+version:         2.13.1.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -167,6 +167,7 @@ test-suite test
         Database.Persist.TH.PersistWith.Model
         Database.Persist.TH.PersistWith.Model2
         Database.Persist.TH.PersistWithSpec
+        Database.Persist.TH.CommentSpec
         Database.Persist.TH.ImplicitIdColSpec
         Database.Persist.TH.JsonEncodingSpec
         Database.Persist.TH.KindEntitiesSpec

--- a/persistent/test/Database/Persist/TH/CommentSpec.hs
+++ b/persistent/test/Database/Persist/TH/CommentSpec.hs
@@ -33,8 +33,8 @@ mkPersist sqlSettings [persistLowerCase|
 -- | Doc comments work.
 -- | Has multiple lines.
 CommentModel
-    -- | First line of comment on column
-    -- | Second line of comment on column
+    -- | First line of comment on column.
+    -- | Second line of comment on column.
     name String
 
     deriving Eq Show

--- a/persistent/test/Database/Persist/TH/CommentSpec.hs
+++ b/persistent/test/Database/Persist/TH/CommentSpec.hs
@@ -16,15 +16,6 @@ module Database.Persist.TH.CommentSpec where
 
 import TemplateTestImports
 
-import Data.Text (Text)
-import qualified Data.Map as M
-import qualified Data.Text as T
-
-import Database.Persist.ImplicitIdDef
-import Database.Persist.ImplicitIdDef.Internal (fieldTypeFromTypeable)
-import Database.Persist.Types
-import Database.Persist.Types
-import Database.Persist.EntityDef
 import Database.Persist.EntityDef.Internal (EntityDef(..))
 import Database.Persist.FieldDef.Internal (FieldDef(..))
 
@@ -48,7 +39,7 @@ asIO :: IO a -> IO a
 asIO = id
 
 spec :: Spec
-spec = fdescribe "CommentSpec" $ do
+spec = describe "CommentSpec" $ do
     let
         ed =
             entityDef (Proxy @CommentModel)

--- a/persistent/test/Database/Persist/TH/CommentSpec.hs
+++ b/persistent/test/Database/Persist/TH/CommentSpec.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Database.Persist.TH.CommentSpec where
+
+import TemplateTestImports
+
+import Data.Text (Text)
+import qualified Data.Map as M
+import qualified Data.Text as T
+
+import Database.Persist.ImplicitIdDef
+import Database.Persist.ImplicitIdDef.Internal (fieldTypeFromTypeable)
+import Database.Persist.Types
+import Database.Persist.Types
+import Database.Persist.EntityDef
+import Database.Persist.EntityDef.Internal (EntityDef(..))
+import Database.Persist.FieldDef.Internal (FieldDef(..))
+
+mkPersist sqlSettings [persistLowerCase|
+
+-- | Doc comments work.
+-- | Has multiple lines.
+CommentModel
+    -- | First line of comment on column
+    -- | Second line of comment on column
+    name String
+
+    deriving Eq Show
+
+|]
+
+pass :: IO ()
+pass = pure ()
+
+asIO :: IO a -> IO a
+asIO = id
+
+spec :: Spec
+spec = fdescribe "CommentSpec" $ do
+    let
+        ed =
+            entityDef (Proxy @CommentModel)
+    it "has entity comments" $ do
+        entityComments ed
+            `shouldBe` do
+                Just $ mconcat
+                    [ "Doc comments work.\n"
+                    , "Has multiple lines.\n"
+                    ]
+
+    describe "fieldComments" $ do
+        let
+            [nameComments] =
+                map fieldComments $ entityFields ed
+        it "has the right name comments" $ do
+            nameComments
+                `shouldBe` do
+                    Just $ mconcat
+                        [ "First line of comment on column.\n"
+                        , "Second line of comment on column.\n"
+                        ]

--- a/persistent/test/Database/Persist/THSpec.hs
+++ b/persistent/test/Database/Persist/THSpec.hs
@@ -59,12 +59,12 @@ import qualified Database.Persist.TH.MultiBlockSpec as MultiBlockSpec
 import qualified Database.Persist.TH.OverloadedLabelSpec as OverloadedLabelSpec
 import qualified Database.Persist.TH.SharedPrimaryKeyImportedSpec as SharedPrimaryKeyImportedSpec
 import qualified Database.Persist.TH.SharedPrimaryKeySpec as SharedPrimaryKeySpec
-import qualified Database.Persist.TH.ToFromPersistValuesSpec as ToFromPersistValuesSpec
 import qualified Database.Persist.TH.KindEntitiesSpec as KindEntitiesSpec
 import qualified Database.Persist.TH.OverloadedLabelSpec as OverloadedLabelSpec
 import qualified Database.Persist.TH.SharedPrimaryKeyImportedSpec as SharedPrimaryKeyImportedSpec
 import qualified Database.Persist.TH.SharedPrimaryKeySpec as SharedPrimaryKeySpec
 import qualified Database.Persist.TH.ToFromPersistValuesSpec as ToFromPersistValuesSpec
+import qualified Database.Persist.TH.CommentSpec as CommentSpec
 
 -- test to ensure we can have types ending in Id that don't trash the TH
 -- machinery
@@ -189,6 +189,7 @@ spec = describe "THSpec" $ do
     ForeignRefSpec.spec
     ToFromPersistValuesSpec.spec
     JsonEncodingSpec.spec
+    CommentSpec.spec
     describe "TestDefaultKeyCol" $ do
         let EntityIdField FieldDef{..} =
                 entityId (entityDef (Proxy @TestDefaultKeyCol))

--- a/persistent/test/Database/Persist/THSpec.hs
+++ b/persistent/test/Database/Persist/THSpec.hs
@@ -59,10 +59,6 @@ import qualified Database.Persist.TH.MultiBlockSpec as MultiBlockSpec
 import qualified Database.Persist.TH.OverloadedLabelSpec as OverloadedLabelSpec
 import qualified Database.Persist.TH.SharedPrimaryKeyImportedSpec as SharedPrimaryKeyImportedSpec
 import qualified Database.Persist.TH.SharedPrimaryKeySpec as SharedPrimaryKeySpec
-import qualified Database.Persist.TH.KindEntitiesSpec as KindEntitiesSpec
-import qualified Database.Persist.TH.OverloadedLabelSpec as OverloadedLabelSpec
-import qualified Database.Persist.TH.SharedPrimaryKeyImportedSpec as SharedPrimaryKeyImportedSpec
-import qualified Database.Persist.TH.SharedPrimaryKeySpec as SharedPrimaryKeySpec
 import qualified Database.Persist.TH.ToFromPersistValuesSpec as ToFromPersistValuesSpec
 import qualified Database.Persist.TH.CommentSpec as CommentSpec
 

--- a/persistent/test/test/Database/Persist/THSpec.hs
+++ b/persistent/test/test/Database/Persist/THSpec.hs
@@ -1,6 +1,0 @@
-module Database.Persist.THSpec where
-
-spec :: Spec
-spec = do
-    it "passes" $ do
-        True `shouldBe` True


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [x] Ran `stylish-haskell` on any changed files.
- [x] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
