### PR TITLE
Refactor entity constraint parsing in Quasi module

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* [#1315](https://github.com/yesodweb/persistent/pull/1315)
+    * Refactor entity constraint parsing in Quasi module
 * [#1314](https://github.com/yesodweb/persistent/pull/1314)
     * Fix typos and minor documentation issues in Database.Persist and
       Database.Persist.Quasi.

--- a/persistent/Database/Persist/Quasi/Internal.hs
+++ b/persistent/Database/Persist/Quasi/Internal.hs
@@ -927,16 +927,21 @@ data EntityConstraintDefs = EntityConstraintDefs
 instance Semigroup EntityConstraintDefs where
     a <> b =
         EntityConstraintDefs
-            { entityConstraintDefsIdField = just1 (entityConstraintDefsIdField a) (entityConstraintDefsIdField b)
-            , entityConstraintDefsPrimaryComposite = just1 (entityConstraintDefsPrimaryComposite a) (entityConstraintDefsPrimaryComposite b)
+            { entityConstraintDefsIdField = justOneId (entityConstraintDefsIdField a) (entityConstraintDefsIdField b)
+            , entityConstraintDefsPrimaryComposite = justOneComposite (entityConstraintDefsPrimaryComposite a) (entityConstraintDefsPrimaryComposite b)
             , entityConstraintDefsUniques = entityConstraintDefsUniques a <> entityConstraintDefsUniques b
             , entityConstraintDefsForeigns = entityConstraintDefsForeigns a <> entityConstraintDefsForeigns b
             }
 
-just1 :: (Show x) => Maybe x -> Maybe x -> Maybe x
-just1 (Just x) (Just y) = error $ "expected only one of: "
+justOneId :: Maybe UnboundIdDef -> Maybe UnboundIdDef -> Maybe UnboundIdDef
+justOneId (Just x) (Just y) = error $ "expected only one of: "
   `mappend` show x `mappend` " " `mappend` show y
-just1 x y = x `mplus` y
+justOneId x y = x `mplus` y
+
+justOneComposite :: Maybe UnboundCompositeDef -> Maybe UnboundCompositeDef -> Maybe UnboundCompositeDef
+justOneComposite (Just x) (Just y) = error $ "expected only one of: "
+  `mappend` show x `mappend` " " `mappend` show y
+justOneComposite x y = x `mplus` y
 
 instance Monoid EntityConstraintDefs where
     mempty =

--- a/persistent/Database/Persist/Quasi/Internal.hs
+++ b/persistent/Database/Persist/Quasi/Internal.hs
@@ -835,20 +835,12 @@ parseEntityFields lns =
             case NEL.toList (tokens line) of
                 [Token name]
                   | isCapitalizedText name ->
-                    parseExtraBlock name (line :| rest)
+                    let (children, rest') = span ((> lineIndent line) . lineIndent) rest
+                        (x, y) = parseEntityFields rest'
+                     in (x, M.insert name (NEL.toList . lineText <$> children) y)
                 ts ->
                     let (x, y) = parseEntityFields rest
                      in (ts:x, y)
-
-parseExtraBlock :: Text -> NonEmpty Line -> ([[Token]], M.Map Text [ExtraLine])
-parseExtraBlock name (line :| rest) =
-    (x, M.insert name (NEL.toList . lineText <$> children) y)
-  where
-   (children, rest') =
-       span ((> lineIndent line) . lineIndent) rest
-
-   (x, y) =
-       parseEntityFields rest'
 
 isCapitalizedText :: Text -> Bool
 isCapitalizedText t =

--- a/persistent/test/Database/Persist/QuasiSpec.hs
+++ b/persistent/test/Database/Persist/QuasiSpec.hs
@@ -7,6 +7,7 @@ module Database.Persist.QuasiSpec where
 
 import Prelude hiding (lines)
 
+import Control.Exception
 import Data.List hiding (lines)
 import Data.List.NonEmpty (NonEmpty(..), (<|))
 import qualified Data.List.NonEmpty as NEL
@@ -338,6 +339,89 @@ Notification
             entityComments (unboundEntityDef bicycle) `shouldBe` Nothing
             entityComments (unboundEntityDef car) `shouldBe` Just "This is a Car\n"
             entityComments (unboundEntityDef vehicle) `shouldBe` Nothing
+
+        describe "custom Id column" $ do
+            it "parses custom Id column" $ do
+                let definitions = [st|
+User
+    Id   Text
+    name Text
+    age  Int
+|]
+                let [user] = parse lowerCaseSettings definitions
+                getUnboundEntityNameHS user `shouldBe` EntityNameHS "User"
+                entityDB (unboundEntityDef user) `shouldBe` EntityNameDB "user"
+                let idFields = NEL.toList (entitiesPrimary (unboundEntityDef user))
+                (fieldHaskell <$> idFields) `shouldBe` [FieldNameHS "Id"]
+                (fieldDB <$> idFields) `shouldBe` [FieldNameDB "id"]
+                (fieldType <$> idFields) `shouldBe` [FTTypeCon Nothing "Text"]
+                (unboundFieldNameHS <$> unboundEntityFields user) `shouldBe`
+                  [ FieldNameHS "name"
+                  , FieldNameHS "age"
+                  ]
+
+            it "errors on duplicate custom Id column" $ do
+                let definitions = [st|
+User
+    Id   Text
+    Id   Text
+    name Text
+    age  Int
+    |]
+                let [user] = parse lowerCaseSettings definitions
+                    errMsg = [st|expected only one of: UnboundIdDef {unboundIdEntityName = EntityNameHS {unEntityNameHS = "User"}, unboundIdDBName = FieldNameDB {unFieldNameDB = "id"}, unboundIdAttrs = [FieldAttrOther "Text"], unboundIdCascade = FieldCascade {fcOnUpdate = Nothing, fcOnDelete = Nothing}, unboundIdType = Just (FTTypeCon Nothing "Text")} UnboundIdDef {unboundIdEntityName = EntityNameHS {unEntityNameHS = "User"}, unboundIdDBName = FieldNameDB {unFieldNameDB = "id"}, unboundIdAttrs = [FieldAttrOther "Text"], unboundIdCascade = FieldCascade {fcOnUpdate = Nothing, fcOnDelete = Nothing}, unboundIdType = Just (FTTypeCon Nothing "Text")}|]
+                evaluate (unboundEntityDef user) `shouldThrow`
+                  errorCall (T.unpack errMsg)
+
+        describe "primary declaration" $ do
+            it "parses Primary declaration" $ do
+                let definitions = [st|
+User
+    ref Text
+    name Text
+    age  Int
+    Primary ref
+|]
+                let [user] = parse lowerCaseSettings definitions
+                getUnboundEntityNameHS user `shouldBe` EntityNameHS "User"
+                entityDB (unboundEntityDef user) `shouldBe` EntityNameDB "user"
+                let idFields = NEL.toList (entitiesPrimary (unboundEntityDef user))
+                (fieldHaskell <$> idFields) `shouldBe` [FieldNameHS "Id"]
+                (fieldDB <$> idFields) `shouldBe` [FieldNameDB "id"]
+                (fieldType <$> idFields) `shouldBe` [FTTypeCon Nothing "UserId"]
+                (unboundFieldNameHS <$> unboundEntityFields user) `shouldBe`
+                  [ FieldNameHS "ref"
+                  , FieldNameHS "name"
+                  , FieldNameHS "age"
+                  ]
+
+            it "errors on duplicate custom Primary declaration" $ do
+                let definitions = [st|
+User
+    ref Text
+    name Text
+    age  Int
+    Primary ref
+    Primary name
+    |]
+                let [user] = parse lowerCaseSettings definitions
+                    errMsg = [st|expected only one of: UnboundCompositeDef {unboundCompositeCols = [FieldNameHS {unFieldNameHS = "ref"}], unboundCompositeAttrs = []} UnboundCompositeDef {unboundCompositeCols = [FieldNameHS {unFieldNameHS = "name"}], unboundCompositeAttrs = []}|]
+                evaluate (unboundEntityDef user) `shouldThrow`
+                  errorCall (T.unpack errMsg)
+
+            it "errors on conflicting Primary/Id declarations" $ do
+                let definitions = [st|
+User
+    Id Text
+    ref Text
+    name Text
+    age  Int
+    Primary ref
+    |]
+                let [user] = parse lowerCaseSettings definitions
+                    errMsg = [st|Specified both an ID field and a Primary field|]
+                evaluate (unboundEntityDef user) `shouldThrow`
+                  errorCall (T.unpack errMsg)
 
         describe "foreign keys" $ do
             let definitions = [st|

--- a/persistent/test/Database/Persist/QuasiSpec.hs
+++ b/persistent/test/Database/Persist/QuasiSpec.hs
@@ -369,7 +369,7 @@ User
     age  Int
     |]
                 let [user] = parse lowerCaseSettings definitions
-                    errMsg = [st|expected only one of: UnboundIdDef {unboundIdEntityName = EntityNameHS {unEntityNameHS = "User"}, unboundIdDBName = FieldNameDB {unFieldNameDB = "id"}, unboundIdAttrs = [FieldAttrOther "Text"], unboundIdCascade = FieldCascade {fcOnUpdate = Nothing, fcOnDelete = Nothing}, unboundIdType = Just (FTTypeCon Nothing "Text")} UnboundIdDef {unboundIdEntityName = EntityNameHS {unEntityNameHS = "User"}, unboundIdDBName = FieldNameDB {unFieldNameDB = "id"}, unboundIdAttrs = [FieldAttrOther "Text"], unboundIdCascade = FieldCascade {fcOnUpdate = Nothing, fcOnDelete = Nothing}, unboundIdType = Just (FTTypeCon Nothing "Text")}|]
+                    errMsg = [st|expected only one Id declaration per entity|]
                 evaluate (unboundEntityDef user) `shouldThrow`
                   errorCall (T.unpack errMsg)
 
@@ -405,7 +405,7 @@ User
     Primary name
     |]
                 let [user] = parse lowerCaseSettings definitions
-                    errMsg = [st|expected only one of: UnboundCompositeDef {unboundCompositeCols = [FieldNameHS {unFieldNameHS = "ref"}], unboundCompositeAttrs = []} UnboundCompositeDef {unboundCompositeCols = [FieldNameHS {unFieldNameHS = "name"}], unboundCompositeAttrs = []}|]
+                    errMsg = [st|expected only one Primary declaration per entity|]
                 evaluate (unboundEntityDef user) `shouldThrow`
                   errorCall (T.unpack errMsg)
 

--- a/persistent/test/Database/Persist/QuasiSpec.hs
+++ b/persistent/test/Database/Persist/QuasiSpec.hs
@@ -23,28 +23,28 @@ import Text.Shakespeare.Text (st)
 
 spec :: Spec
 spec = describe "Quasi" $ do
-    describe "splitExtras" $ do
+    describe "parseEntityFields" $ do
         let helloWorldTokens = Token "hello" :| [Token "world"]
             foobarbazTokens = Token "foo" :| [Token "bar", Token "baz"]
         it "works" $ do
-            splitExtras []
+            parseEntityFields []
                 `shouldBe`
                     mempty
         it "works2" $ do
-            splitExtras
+            parseEntityFields
                 [ Line 0 helloWorldTokens
                 ]
                 `shouldBe`
                     ( [NEL.toList helloWorldTokens], mempty )
         it "works3" $ do
-            splitExtras
+            parseEntityFields
                 [ Line 0 helloWorldTokens
                 , Line 2 foobarbazTokens
                 ]
                 `shouldBe`
                     ( [NEL.toList helloWorldTokens, NEL.toList foobarbazTokens], mempty )
         it "works4" $ do
-            splitExtras
+            parseEntityFields
                 [ Line 0 [Token "Product"]
                 , Line 2 (Token <$> ["name", "Text"])
                 , Line 2 (Token <$> ["added", "UTCTime", "default=CURRENT_TIMESTAMP"])
@@ -59,7 +59,7 @@ spec = describe "Quasi" $ do
                         ) ]
                     )
         it "works5" $ do
-            splitExtras
+            parseEntityFields
                 [ Line 0 [Token "Product"]
                 , Line 2 (Token <$> ["name", "Text"])
                 , Line 4 [Token "ExtraBlock"]

--- a/persistent/test/Database/Persist/QuasiSpec.hs
+++ b/persistent/test/Database/Persist/QuasiSpec.hs
@@ -356,9 +356,9 @@ User
                 (fieldDB <$> idFields) `shouldBe` [FieldNameDB "id"]
                 (fieldType <$> idFields) `shouldBe` [FTTypeCon Nothing "Text"]
                 (unboundFieldNameHS <$> unboundEntityFields user) `shouldBe`
-                  [ FieldNameHS "name"
-                  , FieldNameHS "age"
-                  ]
+                    [ FieldNameHS "name"
+                    , FieldNameHS "age"
+                    ]
 
             it "errors on duplicate custom Id column" $ do
                 let definitions = [st|
@@ -367,11 +367,11 @@ User
     Id   Text
     name Text
     age  Int
-    |]
+|]
                 let [user] = parse lowerCaseSettings definitions
                     errMsg = [st|expected only one Id declaration per entity|]
                 evaluate (unboundEntityDef user) `shouldThrow`
-                  errorCall (T.unpack errMsg)
+                    errorCall (T.unpack errMsg)
 
         describe "primary declaration" $ do
             it "parses Primary declaration" $ do
@@ -390,10 +390,10 @@ User
                 (fieldDB <$> idFields) `shouldBe` [FieldNameDB "id"]
                 (fieldType <$> idFields) `shouldBe` [FTTypeCon Nothing "UserId"]
                 (unboundFieldNameHS <$> unboundEntityFields user) `shouldBe`
-                  [ FieldNameHS "ref"
-                  , FieldNameHS "name"
-                  , FieldNameHS "age"
-                  ]
+                    [ FieldNameHS "ref"
+                    , FieldNameHS "name"
+                    , FieldNameHS "age"
+                    ]
 
             it "errors on duplicate custom Primary declaration" $ do
                 let definitions = [st|
@@ -403,11 +403,11 @@ User
     age  Int
     Primary ref
     Primary name
-    |]
+|]
                 let [user] = parse lowerCaseSettings definitions
                     errMsg = [st|expected only one Primary declaration per entity|]
                 evaluate (unboundEntityDef user) `shouldThrow`
-                  errorCall (T.unpack errMsg)
+                    errorCall (T.unpack errMsg)
 
             it "errors on conflicting Primary/Id declarations" $ do
                 let definitions = [st|
@@ -417,11 +417,11 @@ User
     name Text
     age  Int
     Primary ref
-    |]
+|]
                 let [user] = parse lowerCaseSettings definitions
                     errMsg = [st|Specified both an ID field and a Primary field|]
                 evaluate (unboundEntityDef user) `shouldThrow`
-                  errorCall (T.unpack errMsg)
+                    errorCall (T.unpack errMsg)
 
         describe "foreign keys" $ do
             let definitions = [st|


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [x] Ran `stylish-haskell` on any changed files.
- [x] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->

-----

A further contribution towards https://github.com/yesodweb/persistent/issues/1156, addresses the fold referenced in that issue by creating a type that holds the various possible constraints, and can be built up and merged into one. I have used `Monoid`s / `Semigroup`s however the instances are not lawful. I will put some further detail about this as a comment in the relevant area in the PR.

I have also renamed `splitExtras` to `parseEntityFields` as this is more descriptive I think. This function is called when the fields of an entity are extracted, the first step being to split the `'extra'` tokens from the rest of the entity fields which are added to a value of type `M.Map Text [ExtraLine]`, where the key is the entity name and its `[ExtraLine]` values are the entity fields.