### PR TITLE
Expose orderClause from PersistQuery.hs

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,10 +1,13 @@
 # Changelog for persistent
 
-## Unreleased
+## 2.13.2.0
 
 * [#1314](https://github.com/yesodweb/persistent/pull/1314)
     * Fix typos and minor documentation issues in Database.Persist and
       Database.Persist.Quasi.
+* [#1317](https://github.com/yesodweb/persistent/pull/1317)
+    * Expose `orderClause` from the Persistent internals, which allows users
+      to produce well-formatted `ORDER BY` clauses.
 
 ## 2.13.1.2
 

--- a/persistent/Database/Persist/Sql.hs
+++ b/persistent/Database/Persist/Sql.hs
@@ -38,6 +38,7 @@ module Database.Persist.Sql
     , updateWhereCount
     , filterClause
     , filterClauseWithVals
+    , orderClause
     , FilterTablePrefix (..)
     -- * Transactions
     , transactionSave

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:            persistent
-version:         2.13.1.2
+version:         2.13.2.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
This is part of the followup to #1298.

This exposes `orderClause` in a similar manner to `filterClause`, to help third-party libraries which want to format their own SQL queries using Persistent's internal helpers.

It rewrites `orderClause` a bit to bring it in line with the other exposed functions, but there should be no functional changes as a result.

Before submitting your PR, check that you've:

- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [x] Ran `stylish-haskell` on any changed files.
- [x] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
