### PR TITLE
Add a Num instance for OverflowNatural

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -6,6 +6,9 @@
     * Fix typos and minor documentation issues in Database.Persist and
       Database.Persist.Quasi.
 
+* [#1319](https://github.com/yesodweb/persistent/pull/1319)
+    * Add a `Num` instance for `OverflowNatural`
+
 ## 2.13.1.2
 
 * [#1308](https://github.com/yesodweb/persistent/pull/1308)

--- a/persistent/Database/Persist/Class/PersistField.hs
+++ b/persistent/Database/Persist/Class/PersistField.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE PatternGuards, DataKinds, TypeOperators, UndecidableInstances #-}
+{-# LANGUAGE PatternGuards, DataKinds, TypeOperators, UndecidableInstances, GeneralizedNewtypeDeriving #-}
 module Database.Persist.Class.PersistField
     ( PersistField (..)
     , SomePersistField (..)
@@ -346,7 +346,7 @@ instance PersistField UTCTime where
 --
 -- @since 2.11.0
 newtype OverflowNatural = OverflowNatural { unOverflowNatural :: Natural }
-    deriving (Eq, Show, Ord)
+    deriving (Eq, Show, Ord, Num)
 
 instance
   TypeError


### PR DESCRIPTION
This is useful with things like castNum.

Didn't do these, since I'm not sure which ones are applicable:

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [ ] Ran `stylish-haskell` on any changed files.
- [ ] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
