### PR TITLE
Remove mysql simple as a dependency 

### DIFF
--- a/persistent-mysql/persistent-mysql.cabal
+++ b/persistent-mysql/persistent-mysql.cabal
@@ -36,7 +36,6 @@ library
                    , containers       >= 0.5
                    , monad-logger
                    , mysql            >= 0.1.4    && < 0.3
-                   , mysql-simple     >= 0.4.4    && < 0.5
                    , resourcet        >= 1.1
                    , resource-pool
                    , text             >= 1.2

--- a/persistent-mysql/persistent-mysql.cabal
+++ b/persistent-mysql/persistent-mysql.cabal
@@ -42,6 +42,7 @@ library
                    , text             >= 1.2
                    , transformers     >= 0.5
                    , unliftio-core
+                   , time >= 1.9.3
     exposed-modules: Database.Persist.MySQL
     ghc-options:     -Wall
     default-language: Haskell2010

--- a/stack-8.10.yaml
+++ b/stack-8.10.yaml
@@ -8,3 +8,7 @@ packages:
   - ./persistent-postgresql
   - ./persistent-redis
   - ./persistent-qq
+extra-deps: 
+    - ../mysql 
+    - ../mysql-simple
+    - lift-type-0.1.0.0

--- a/stack-8.10.yaml
+++ b/stack-8.10.yaml
@@ -9,6 +9,4 @@ packages:
   - ./persistent-redis
   - ./persistent-qq
 extra-deps: 
-    - ../mysql 
-    - ../mysql-simple
     - lift-type-0.1.0.0

--- a/stack-8.10.yaml.lock
+++ b/stack-8.10.yaml.lock
@@ -3,7 +3,14 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: lift-type-0.1.0.0@sha256:b52c172fc19635e53fa72874ac0e09b08b4bc2c711f57f883181f348799abd6f,1095
+    pantry-tree:
+      size: 360
+      sha256: 2ae816ebaef99ad169d95189cefa2113600ae2185e6af861984d91cbcd4bb3f0
+  original:
+    hackage: lift-type-0.1.0.0
 snapshots:
 - completed:
     size: 565720


### PR DESCRIPTION
It seems strange to rely on mysql-simple when we are the high level library. We are essentially just pushing a bunch of data around for little gain seemingly since we use almost none of the library. This PR inlines much of the code that was occurring in mysql-simple. 

Potential Issues:
   - Performance of parsing: I am not using any high performance parsing library, just Text.Read. From running the tests I didnt see any obvious degredation in performance. 
   - Do we have a specific version of time that we are targeting? I only tested with 1.9.3 and may need to try with a lower version to ensure this works still.

Before submitting your PR, check that you've:

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [ ] Ran `stylish-haskell` on any changed files.
- [ ] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
