### PR TITLE
Replace (IORef (Map Text Statement)) with StatementCache interface

### DIFF
--- a/persistent-mysql/ChangeLog.md
+++ b/persistent-mysql/ChangeLog.md
@@ -1,6 +1,6 @@
 # Changelog for persistent-mysql
 
-## 2.14.0.0
+## 2.14.0.0 (unreleased)
 
 * [#XXXX]()
     * Update backend to support new `StatementCache` interface

--- a/persistent-mysql/ChangeLog.md
+++ b/persistent-mysql/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for persistent-mysql
 
+## 2.14.0.0
+
+* [#XXXX]()
+    * Update backend to support new `StatementCache` interface
+
 ## 2.13.0.2
 
 * Bugfix: prevent fetching constraint info from other databases during migrations [#1301](https://github.com/yesodweb/persistent/pull/1301)

--- a/persistent-mysql/ChangeLog.md
+++ b/persistent-mysql/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 2.14.0.0 (unreleased)
 
-* [#XXXX]()
+* [#1327](https://github.com/yesodweb/persistent/pull/1327)
     * Update backend to support new `StatementCache` interface
 
 ## 2.13.0.2

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -46,7 +46,6 @@ import Control.Monad.Trans.Except (ExceptT, runExceptT)
 import Control.Monad.Trans.Reader (ReaderT, runReaderT)
 import Control.Monad.Trans.Writer (runWriterT)
 
-import qualified Data.List.NonEmpty as NEL
 import Data.Acquire (Acquire, mkAcquire, with)
 import Data.Aeson
 import Data.Aeson.Types (modifyFailure)
@@ -58,6 +57,7 @@ import Data.Fixed (Pico)
 import Data.Function (on)
 import Data.Int (Int64)
 import Data.List (find, groupBy, intercalate, sort)
+import qualified Data.List.NonEmpty as NEL
 import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
 import Data.Monoid ((<>))
 import qualified Data.Monoid as Monoid
@@ -70,10 +70,10 @@ import GHC.Stack
 import System.Environment (getEnvironment)
 
 import Database.Persist.Sql
-import Database.Persist.SqlBackend
-import Database.Persist.SqlBackend.StatementCache
 import Database.Persist.Sql.Types.Internal (makeIsolationLevelStatement)
 import qualified Database.Persist.Sql.Util as Util
+import Database.Persist.SqlBackend
+import Database.Persist.SqlBackend.StatementCache
 
 import qualified Database.MySQL.Base as MySQLBase
 import qualified Database.MySQL.Base.Types as MySQLBase

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -1278,7 +1278,7 @@ mockMigrate _connectInfo allDefs _getter val = do
 -- the actual database isn't already present in the system.
 mockMigration :: Migration -> IO ()
 mockMigration mig = do
-    smap <- mkStatemeentCache <$> mkSimpleStatementCache
+    smap <- mkStatementCache <$> mkSimpleStatementCache
     let sqlbackend =
             mkSqlBackend MkSqlBackendArgs
                 { connPrepare = \_ -> do

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -59,6 +59,7 @@ import Data.Int (Int64)
 import Data.List (find, groupBy, intercalate, sort)
 import qualified Data.List.NonEmpty as NEL
 import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
+import qualified Data.Map as Map
 import Data.Monoid ((<>))
 import qualified Data.Monoid as Monoid
 import Data.Pool (Pool)

--- a/persistent-mysql/persistent-mysql.cabal
+++ b/persistent-mysql/persistent-mysql.cabal
@@ -1,5 +1,5 @@
 name:            persistent-mysql
-version:         2.13.0.2
+version:         2.14.0.0
 license:         MIT
 license-file:    LICENSE
 author:          Felipe Lessa <felipe.lessa@gmail.com>, Michael Snoyman
@@ -28,7 +28,7 @@ extra-source-files: ChangeLog.md
 
 library
     build-depends:   base             >= 4.9      && < 5
-                   , persistent       >= 2.13   && < 3
+                   , persistent       >= 2.14   && < 3
                    , aeson            >= 1.0
                    , blaze-builder
                    , bytestring       >= 0.10.8

--- a/persistent-postgresql/ChangeLog.md
+++ b/persistent-postgresql/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for persistent-postgresql
 
+## 2.14.0.0
+
+* [#XXXX]()
+    * Update backend to support new `StatementCache` interface
+
 ## 2.13.2.0
 * [#1316](https://github.com/yesodweb/persistent/pull/1316)
   * Expose some internals in the new `Database.Persist.Postgresql.Internal` module.

--- a/persistent-postgresql/ChangeLog.md
+++ b/persistent-postgresql/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 2.14.0.0 (unreleased)
 
-* [#XXXX]()
+* [#1327](https://github.com/yesodweb/persistent/pull/1327)
     * Update backend to support new `StatementCache` interface
 
 ## 2.13.2.0

--- a/persistent-postgresql/ChangeLog.md
+++ b/persistent-postgresql/ChangeLog.md
@@ -1,6 +1,6 @@
 # Changelog for persistent-postgresql
 
-## 2.14.0.0
+## 2.14.0.0 (unreleased)
 
 * [#XXXX]()
     * Update backend to support new `StatementCache` interface

--- a/persistent-postgresql/persistent-postgresql.cabal
+++ b/persistent-postgresql/persistent-postgresql.cabal
@@ -1,5 +1,5 @@
 name:            persistent-postgresql
-version:         2.13.2.0
+version:         2.14.0.0
 license:         MIT
 license-file:    LICENSE
 author:          Felipe Lessa, Michael Snoyman <michael@snoyman.com>
@@ -16,7 +16,7 @@ extra-source-files: ChangeLog.md
 
 library
     build-depends:   base                  >= 4.9      && < 5
-                   , persistent            >= 2.13     && < 3
+                   , persistent            >= 2.14     && < 3
                    , aeson                 >= 1.0
                    , attoparsec
                    , blaze-builder

--- a/persistent-sqlite/ChangeLog.md
+++ b/persistent-sqlite/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 2.14.0.0 (unreleased)
 
-* [#XXXX]()
+* [#1327](https://github.com/yesodweb/persistent/pull/1327)
     * Update backend to support new `StatementCache` interface
 
 ## 2.13.0.3

--- a/persistent-sqlite/ChangeLog.md
+++ b/persistent-sqlite/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for persistent-sqlite
 
+## 2.14.0.0
+
+* [#XXXX]()
+    * Update backend to support new `StatementCache` interface
+
 ## 2.13.0.3
 
 * Somehow failed to properly release the safe-to-remove changes.

--- a/persistent-sqlite/ChangeLog.md
+++ b/persistent-sqlite/ChangeLog.md
@@ -1,6 +1,6 @@
 # Changelog for persistent-sqlite
 
-## 2.14.0.0
+## 2.14.0.0 (unreleased)
 
 * [#XXXX]()
     * Update backend to support new `StatementCache` interface

--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -78,8 +78,6 @@ import qualified Data.Conduit.Combinators as C
 import qualified Data.Conduit.List as CL
 import qualified Data.HashMap.Lazy as HashMap
 import Data.Int (Int64)
-import Data.IORef
-import qualified Data.Map as Map
 import Data.Pool (Pool)
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -95,6 +93,7 @@ import Database.Persist.Sql
 import Database.Persist.SqlBackend
 import qualified Database.Persist.Sql.Util as Util
 import qualified Database.Sqlite as Sqlite
+import Database.Persist.SqlBackend.StatementCache
 
 
 -- | Create a pool of SQLite connections.
@@ -269,7 +268,7 @@ wrapConnectionInfo connInfo conn logFunc = do
         Sqlite.reset conn stmt
         Sqlite.finalize stmt
 
-    smap <- newIORef $ Map.empty
+    smap <- mkStatementCache <$> mkSimpleStatementCache
     return $
         setConnMaxParams 999 $
         setConnPutManySql putManySql $
@@ -456,7 +455,7 @@ migrate' allDefs getter val = do
 -- with the difference that an actual database isn't needed for it.
 mockMigration :: Migration -> IO ()
 mockMigration mig = do
-    smap <- newIORef $ Map.empty
+    smap <- mkStatementCache <$> mkSimpleStatementCache
     let sqlbackend =
             setConnMaxParams 999 $
             mkSqlBackend MkSqlBackendArgs

--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -60,40 +60,54 @@ module Database.Persist.Sqlite
 import Control.Concurrent (threadDelay)
 import qualified Control.Exception as E
 import Control.Monad (forM_)
-import Control.Monad.IO.Unlift (MonadIO (..), MonadUnliftIO, askRunInIO, withRunInIO, withUnliftIO, unliftIO, withRunInIO)
-import Control.Monad.Logger (NoLoggingT, runNoLoggingT, MonadLoggerIO, logWarn, runLoggingT, askLoggerIO)
+import Control.Monad.IO.Unlift
+       ( MonadIO(..)
+       , MonadUnliftIO
+       , askRunInIO
+       , unliftIO
+       , withRunInIO
+       , withUnliftIO
+       )
+import Control.Monad.Logger
+       ( MonadLoggerIO
+       , NoLoggingT
+       , askLoggerIO
+       , logWarn
+       , runLoggingT
+       , runNoLoggingT
+       )
 import Control.Monad.Reader (MonadReader)
-import Control.Monad.Trans.Resource (MonadResource)
 import Control.Monad.Trans.Reader (ReaderT, runReaderT)
+import Control.Monad.Trans.Resource (MonadResource)
 #if !MIN_VERSION_base(4,12,0)
 import Control.Monad.Trans.Reader (withReaderT)
 #endif
 import Control.Monad.Trans.Writer (runWriterT)
 import Data.Acquire (Acquire, mkAcquire, with)
-import Data.Maybe
 import Data.Aeson
 import Data.Aeson.Types (modifyFailure)
 import Data.Conduit
 import qualified Data.Conduit.Combinators as C
 import qualified Data.Conduit.List as CL
+import Data.Foldable (toList)
 import qualified Data.HashMap.Lazy as HashMap
 import Data.Int (Int64)
+import Data.Maybe
 import Data.Pool (Pool)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
 import Lens.Micro.TH (makeLenses)
 import UnliftIO.Resource (ResourceT, runResourceT)
-import Data.Foldable (toList)
 
 #if MIN_VERSION_base(4,12,0)
 import Database.Persist.Compatible
 #endif
 import Database.Persist.Sql
-import Database.Persist.SqlBackend
 import qualified Database.Persist.Sql.Util as Util
-import qualified Database.Sqlite as Sqlite
+import Database.Persist.SqlBackend
 import Database.Persist.SqlBackend.StatementCache
+import qualified Database.Sqlite as Sqlite
 
 
 -- | Create a pool of SQLite connections.

--- a/persistent-sqlite/persistent-sqlite.cabal
+++ b/persistent-sqlite/persistent-sqlite.cabal
@@ -1,5 +1,5 @@
 name:            persistent-sqlite
-version:         2.13.0.3
+version:         2.14.0.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -44,7 +44,7 @@ flag use-stat4
 
 library
     build-depends:   base                    >= 4.9         && < 5
-                   , persistent              >= 2.13        && < 3
+                   , persistent              >= 2.14        && < 3
                    , aeson                   >= 1.0
                    , bytestring              >= 0.10
                    , conduit                 >= 1.2.12

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -1,5 +1,5 @@
 name:            persistent-test
-version:         2.13.0.3
+version:         2.14.0.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -75,7 +75,7 @@ library
       , monad-logger             >= 0.3.25
       , mtl
       , path-pieces              >= 0.2
-      , persistent               >= 2.13      && < 2.14
+      , persistent               >= 2.14      && < 2.15
       , QuickCheck               >= 2.9
       , quickcheck-instances     >= 0.3
       , random                   >= 1.1

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog for persistent
 
+## 2.14.0.0
+
+* [#XXXX]()
+    * Update `SqlBackend` to use new `StatementCache` interface
+      instead of `IORef (Map Text Statement)`
+
 ## 2.13.2.0
 
 * [#1314](https://github.com/yesodweb/persistent/pull/1314)

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 2.14.0.0 (unreleased)
 
-* [#XXXX]()
+* [#1327](https://github.com/yesodweb/persistent/pull/1327)
     * Update `SqlBackend` to use new `StatementCache` interface
       instead of `IORef (Map Text Statement)`
 

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,6 +1,6 @@
 # Changelog for persistent
 
-## 2.14.0.0
+## 2.14.0.0 (unreleased)
 
 * [#XXXX]()
     * Update `SqlBackend` to use new `StatementCache` interface

--- a/persistent/Database/Persist/Sql/Raw.hs
+++ b/persistent/Database/Persist/Sql/Raw.hs
@@ -1,22 +1,22 @@
 module Database.Persist.Sql.Raw where
 
 import Control.Exception (throwIO)
-import Control.Monad (when, liftM)
+import Control.Monad (liftM, when)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Logger (logDebugNS, runLoggingT)
-import Control.Monad.Reader (ReaderT, ask, MonadReader)
-import Control.Monad.Trans.Resource (MonadResource,release)
-import Data.Acquire (allocateAcquire, Acquire, mkAcquire, with)
+import Control.Monad.Reader (MonadReader, ReaderT, ask)
+import Control.Monad.Trans.Resource (MonadResource, release)
+import Data.Acquire (Acquire, allocateAcquire, mkAcquire, with)
 import Data.Conduit
-import Data.IORef (writeIORef, readIORef, newIORef)
+import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Int (Int64)
 import Data.Text (Text, pack)
 import qualified Data.Text as T
 
 import Database.Persist
+import Database.Persist.Sql.Class
 import Database.Persist.Sql.Types
 import Database.Persist.Sql.Types.Internal
-import Database.Persist.Sql.Class
 import Database.Persist.SqlBackend.Internal.StatementCache
 
 rawQuery :: (MonadResource m, MonadReader env m, BackendCompatible SqlBackend env)

--- a/persistent/Database/Persist/Sql/Run.hs
+++ b/persistent/Database/Persist/Sql/Run.hs
@@ -2,7 +2,6 @@
 module Database.Persist.Sql.Run where
 
 import Control.Monad.IO.Unlift
-import qualified UnliftIO.Exception as UE
 import Control.Monad.Logger.CallStack
 import Control.Monad.Reader (MonadReader)
 import qualified Control.Monad.Reader as MonadReader
@@ -11,13 +10,14 @@ import Control.Monad.Trans.Resource
 import Data.Acquire (Acquire, ReleaseType(..), mkAcquireType, with)
 import Data.Pool as P
 import qualified Data.Text as T
+import qualified UnliftIO.Exception as UE
 
 import Database.Persist.Class.PersistStore
+import Database.Persist.Sql.Raw
 import Database.Persist.Sql.Types
 import Database.Persist.Sql.Types.Internal
-import Database.Persist.Sql.Raw
 import Database.Persist.SqlBackend.Internal.StatementCache
-    ( StatementCache(statementCacheClear) )
+       (StatementCache(statementCacheClear))
 
 -- | Get a connection from the pool, run the given action, and then return the
 -- connection to the pool.

--- a/persistent/Database/Persist/SqlBackend/Internal.hs
+++ b/persistent/Database/Persist/SqlBackend/Internal.hs
@@ -14,6 +14,7 @@ import Database.Persist.SqlBackend.Internal.MkSqlBackend
 import Database.Persist.SqlBackend.Internal.Statement
 import Database.Persist.SqlBackend.Internal.InsertSqlResult
 import Database.Persist.SqlBackend.Internal.IsolationLevel
+import Database.Persist.SqlBackend.Internal.StatementCache (StatementCache)
 
 -- | A 'SqlBackend' represents a handle or connection to a database. It
 -- contains functions and values that allow databases to have more
@@ -69,7 +70,7 @@ data SqlBackend = SqlBackend
     -- When left as 'Nothing', we default to using 'defaultPutMany'.
     --
     -- @since 2.8.1
-    , connStmtMap :: IORef (Map Text Statement)
+    , connStmtMap :: StatementCache
     -- ^ A reference to the cache of statements. 'Statement's are keyed by
     -- the 'Text' queries that generated them.
     , connClose :: IO ()

--- a/persistent/Database/Persist/SqlBackend/Internal.hs
+++ b/persistent/Database/Persist/SqlBackend/Internal.hs
@@ -1,20 +1,20 @@
-{-# language RecordWildCards #-}
-{-# language RankNTypes #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Database.Persist.SqlBackend.Internal where
 
-import Data.Map (Map)
+import Data.IORef
 import Data.List.NonEmpty (NonEmpty)
+import Data.Map (Map)
 import Data.Text (Text)
 import Database.Persist.Class.PersistStore
-import Database.Persist.Types.Base
 import Database.Persist.Names
-import Data.IORef
-import Database.Persist.SqlBackend.Internal.MkSqlBackend
-import Database.Persist.SqlBackend.Internal.Statement
 import Database.Persist.SqlBackend.Internal.InsertSqlResult
 import Database.Persist.SqlBackend.Internal.IsolationLevel
+import Database.Persist.SqlBackend.Internal.MkSqlBackend
+import Database.Persist.SqlBackend.Internal.Statement
 import Database.Persist.SqlBackend.Internal.StatementCache (StatementCache)
+import Database.Persist.Types.Base
 
 -- | A 'SqlBackend' represents a handle or connection to a database. It
 -- contains functions and values that allow databases to have more

--- a/persistent/Database/Persist/SqlBackend/Internal/MkSqlBackend.hs
+++ b/persistent/Database/Persist/SqlBackend/Internal/MkSqlBackend.hs
@@ -3,14 +3,13 @@
 module Database.Persist.SqlBackend.Internal.MkSqlBackend where
 
 import Control.Monad.Logger (Loc, LogLevel, LogSource, LogStr)
-import Data.IORef
-import Data.Map (Map)
 import Data.Text (Text)
 import Database.Persist.SqlBackend.Internal.Statement
 import Database.Persist.SqlBackend.Internal.InsertSqlResult
 import Database.Persist.SqlBackend.Internal.IsolationLevel
 import Database.Persist.Types.Base
 import Database.Persist.Names
+import Database.Persist.SqlBackend.Internal.StatementCache
 
 -- | This type shares many of the same field names as the 'SqlBackend' type.
 -- It's useful for library authors to use this when migrating from using the
@@ -28,7 +27,7 @@ data MkSqlBackendArgs = MkSqlBackendArgs
     , connInsertSql :: EntityDef -> [PersistValue] -> InsertSqlResult
     -- ^ This function generates the SQL and values necessary for
     -- performing an insert against the database.
-    , connStmtMap :: IORef (Map Text Statement)
+    , connStmtMap :: StatementCache
     -- ^ A reference to the cache of statements. 'Statement's are keyed by
     -- the 'Text' queries that generated them.
     , connClose :: IO ()

--- a/persistent/Database/Persist/SqlBackend/Internal/MkSqlBackend.hs
+++ b/persistent/Database/Persist/SqlBackend/Internal/MkSqlBackend.hs
@@ -4,12 +4,12 @@ module Database.Persist.SqlBackend.Internal.MkSqlBackend where
 
 import Control.Monad.Logger (Loc, LogLevel, LogSource, LogStr)
 import Data.Text (Text)
-import Database.Persist.SqlBackend.Internal.Statement
+import Database.Persist.Names
 import Database.Persist.SqlBackend.Internal.InsertSqlResult
 import Database.Persist.SqlBackend.Internal.IsolationLevel
-import Database.Persist.Types.Base
-import Database.Persist.Names
+import Database.Persist.SqlBackend.Internal.Statement
 import Database.Persist.SqlBackend.Internal.StatementCache
+import Database.Persist.Types.Base
 
 -- | This type shares many of the same field names as the 'SqlBackend' type.
 -- It's useful for library authors to use this when migrating from using the

--- a/persistent/Database/Persist/SqlBackend/Internal/StatementCache.hs
+++ b/persistent/Database/Persist/SqlBackend/Internal/StatementCache.hs
@@ -1,0 +1,23 @@
+module Database.Persist.SqlBackend.Internal.StatementCache where
+
+import Data.Text (Text)
+import Database.Persist.SqlBackend.Internal.Statement
+
+-- | A statement cache used to lookup statements that have already been prepared
+-- for a given query.
+--
+-- @since 2.14.0
+data StatementCache = StatementCache
+    { statementCacheLookup :: StatementCacheKey -> IO (Maybe Statement)
+    , statementCacheInsert :: StatementCacheKey -> Statement -> IO ()
+    , statementCacheClear :: IO ()
+    , statementCacheSize :: IO Int
+    }
+
+newtype StatementCacheKey = StatementCacheKey { cacheKey :: Text }
+-- Wrapping around this to allow for more efficient keying mechanisms
+-- in the future, perhaps.
+
+-- | Construct a `StatementCacheKey` from a raw SQL query.
+mkCacheKeyFromQuery :: Text -> StatementCacheKey
+mkCacheKeyFromQuery = StatementCacheKey

--- a/persistent/Database/Persist/SqlBackend/StatementCache.hs
+++ b/persistent/Database/Persist/SqlBackend/StatementCache.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE RecordWildCards #-}
+module Database.Persist.SqlBackend.StatementCache
+  ( StatementCache
+  , StatementCacheKey
+  , mkCacheKeyFromQuery
+  , MkStatementCache(..)
+  , mkSimpleStatementCache
+  , mkStatementCache
+  ) where
+
+import Data.Foldable
+import Data.IORef
+import qualified Data.Map as Map
+import Database.Persist.SqlBackend.Internal.Statement
+import Database.Persist.SqlBackend.Internal.StatementCache
+
+-- | Configuration parameters for creating a custom statement cache
+--
+-- @since 2.14.0
+data MkStatementCache = MkStatementCache
+  { statementCacheLookup :: StatementCacheKey -> IO (Maybe Statement)
+  -- ^ Retrieve a statement from the cache, or return nothing if it is not found.
+  --
+  -- @since 2.14.0
+  , statementCacheInsert :: StatementCacheKey -> Statement -> IO ()
+  -- ^ Put a new statement into the cache. An immediate lookup of
+  -- the statement MUST return the inserted statement for the given
+  -- cache key. Depending on the implementation, the statement cache MAY
+  -- choose to evict other statements from the cache within this function.
+  --
+  -- @since 2.14.0
+  , statementCacheClear :: IO ()
+  -- ^ Remove all statements from the cache. Implementations of this
+  -- should be sure to call `stmtFinalize` on all statements removed
+  -- from the cache.
+  --
+  -- @since 2.14.0
+  , statementCacheSize :: IO Int
+  -- ^ Get the current size of the cache.
+  --
+  -- @since 2.14.0
+  }
+
+
+-- | Make a simple statement cache that will cache statements if they are not currently cached.
+--
+-- @since 2.14.0
+mkSimpleStatementCache :: IO MkStatementCache
+mkSimpleStatementCache = do
+    stmtMap <- newIORef Map.empty
+    pure $ MkStatementCache
+        { statementCacheLookup = \sql -> Map.lookup (cacheKey sql) <$> readIORef stmtMap
+        , statementCacheInsert = \sql stmt ->
+            modifyIORef' stmtMap (Map.insert (cacheKey sql) stmt)
+        , statementCacheClear = do
+            oldStatements <- atomicModifyIORef' stmtMap (\oldStatements -> (Map.empty, oldStatements))
+            traverse_ stmtFinalize oldStatements
+        , statementCacheSize = Map.size <$> readIORef stmtMap
+        }
+
+-- | Create a statement cache.
+--
+-- @since 2.13.0
+mkStatementCache :: MkStatementCache -> StatementCache
+mkStatementCache MkStatementCache{..} = StatementCache { .. }

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:            persistent
-version:         2.13.2.0
+version:         2.14.0.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -72,10 +72,12 @@ library
         Database.Persist.Sql.Util
 
         Database.Persist.SqlBackend
+        Database.Persist.SqlBackend.StatementCache
         Database.Persist.SqlBackend.Internal
         Database.Persist.SqlBackend.Internal.InsertSqlResult
         Database.Persist.SqlBackend.Internal.IsolationLevel
         Database.Persist.SqlBackend.Internal.Statement
+        Database.Persist.SqlBackend.Internal.StatementCache
         Database.Persist.SqlBackend.Internal.MkSqlBackend
 
         Database.Persist.Class


### PR DESCRIPTION
In some cases, I've observed that the existing statement cache can leak memory, since it never clears statements from the cache. This PR adds support for providing alternative implementations of the statement cache & monitoring size in order to handle/discover these potential memory leaks.

Before submitting your PR, check that you've:

- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [x] Ran `stylish-haskell` on any changed files.
- [x] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
