### PR TITLE
Don't discover constrained instances

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,5 +1,12 @@
 # Changelog for persistent
 
+## 2.13.2.1
+
+* [#1329](https://github.com/yesodweb/persistent/pull/1329)
+    * Prevent discovery of constrained `PersistEntity` instances in
+      `discoverEntities` (since the discovered instances won't work without
+      constraints anyway).
+
 ## 2.13.2.0
 
 * [#1314](https://github.com/yesodweb/persistent/pull/1314)

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -3104,7 +3104,7 @@ discoverEntities = do
             mapMaybe getDecType instances
         getDecType dec =
             case dec of
-                InstanceD _moverlap _cxt typ _decs ->
+                InstanceD _moverlap [] typ _decs ->
                     stripPersistEntity typ
                 _ ->
                     Nothing

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:            persistent
-version:         2.13.2.0
+version:         2.13.2.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
The big idea here is that if a user or something besides `Database.Persist.TH` writes a `C a => PersistEntity (Foo a)` instance, we don't want `discoverEntities` to find it and include a `entityDef (Proxy :: Proxy (Foo a))` in the list, because there's no way that's going to work (unless `C` is a trivial typeclass).

---

Before submitting your PR, check that you've:

- [ ] ~Documented new APIs with [Haddock
      markup](https://www.haskell.org/haddock/doc/html/index.html)~
- [ ] ~Added [`@since`
      declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since)
      to the Haddock~
- [x] Ran `stylish-haskell` on any changed files.
- [ ] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->