### PR TITLE
Add mysql json field support

### DIFF
--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -45,12 +45,13 @@ import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except (ExceptT, runExceptT)
 import Control.Monad.Trans.Reader (ReaderT, runReaderT)
 import Control.Monad.Trans.Writer (runWriterT)
+import Data.Proxy (Proxy(..))
 
-import qualified Data.List.NonEmpty as NEL
 import Data.Acquire (Acquire, mkAcquire, with)
 import Data.Aeson
 import Data.Aeson.Types (modifyFailure)
 import Data.ByteString (ByteString)
+import qualified Data.ByteString.Lazy as BSL
 import Data.Conduit
 import qualified Data.Conduit.List as CL
 import Data.Either (partitionEithers)
@@ -59,6 +60,7 @@ import Data.Function (on)
 import Data.IORef
 import Data.Int (Int64)
 import Data.List (find, groupBy, intercalate, sort)
+import qualified Data.List.NonEmpty as NEL
 import qualified Data.Map as Map
 import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
 import Data.Monoid ((<>))
@@ -72,9 +74,9 @@ import GHC.Stack
 import System.Environment (getEnvironment)
 
 import Database.Persist.Sql
-import Database.Persist.SqlBackend
 import Database.Persist.Sql.Types.Internal (makeIsolationLevelStatement)
 import qualified Database.Persist.Sql.Util as Util
+import Database.Persist.SqlBackend
 
 import qualified Database.MySQL.Base as MySQLBase
 import qualified Database.MySQL.Base.Types as MySQLBase
@@ -335,6 +337,7 @@ getGetter field = go (MySQLBase.fieldType field)
       case m of
         Just g -> PersistLiteral g
         Nothing -> error "Unexpected null in database specific value"
+    go MySQLBase.Json       _ _  = convertPV PersistByteString
     -- Unsupported
     go other _ _ = error $ "MySQL.getGetter: type " ++
                       show other ++ " not supported."

--- a/persistent-mysql/persistent-mysql.cabal
+++ b/persistent-mysql/persistent-mysql.cabal
@@ -35,8 +35,8 @@ library
                    , conduit          >= 1.2.12
                    , containers       >= 0.5
                    , monad-logger
-                   , mysql            >= 0.1.4    && < 0.3
-                   , mysql-simple     >= 0.4.4    && < 0.5
+                   , mysql            >= 0.2.1    && < 0.3
+                   , mysql-simple     >= 0.4.7    && < 0.5
                    , resourcet        >= 1.1
                    , resource-pool
                    , text             >= 1.2
@@ -59,6 +59,7 @@ test-suite test
         InsertDuplicateUpdate
         CustomConstraintTest
         ImplicitUuidSpec
+        JSONTest
     ghc-options:     -Wall
 
     build-depends:   
@@ -66,6 +67,7 @@ test-suite test
       , aeson
       , bytestring
       , containers
+      , conduit
       , fast-logger
       , hspec            >= 2.4
       , http-api-data

--- a/persistent-mysql/test/JSONTest.hs
+++ b/persistent-mysql/test/JSONTest.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module JSONTest where
+
+import Data.Aeson
+import Test.HUnit (assertBool)
+
+import qualified Data.ByteString.Lazy as BSL
+import Data.Conduit (runConduit, (.|))
+import qualified Data.Conduit.List as CL
+import Database.Persist.MySQL
+import MyInit
+
+specs :: Spec
+specs = describe "JSONTest" $ do
+    it "can select json with rawsql" $ db $ do
+        let testJSON = toJSON $ [object [ "test" .= ("value" :: Text) ]]
+        [[PersistByteString value]] <- runConduit $ rawQuery "select JSON_ARRAY(JSON_OBJECT('test', 'value'))" [] .| CL.consume
+        liftIO $ Just testJSON `shouldBe` (decode $ BSL.fromStrict value)

--- a/persistent-mysql/test/main.hs
+++ b/persistent-mysql/test/main.hs
@@ -54,6 +54,7 @@ import qualified CustomConstraintTest
 import qualified ForeignKey
 import qualified GeneratedColumnTestSQL
 import qualified ImplicitUuidSpec
+import qualified JSONTest
 import qualified LongIdentifierTest
 import qualified RenameTest
 import qualified SumTypeTest
@@ -212,6 +213,7 @@ main = do
         xdescribe "The migration for this test currently fails because of MySQL's 64 character limit for identifiers. See https://github.com/yesodweb/persistent/issues/1000 for details" $
             LongIdentifierTest.specsWith db
         GeneratedColumnTestSQL.specsWith db
+        JSONTest.specs
 
 roundFn :: RealFrac a => a -> Integer
 roundFn = round

--- a/stack-8.10.yaml
+++ b/stack-8.10.yaml
@@ -8,3 +8,8 @@ packages:
   - ./persistent-postgresql
   - ./persistent-redis
   - ./persistent-qq
+
+extra-deps:
+    - lift-type-0.1.0.0
+    - mysql-0.2.1
+    - mysql-simple-0.4.7

--- a/stack-8.10.yaml.lock
+++ b/stack-8.10.yaml.lock
@@ -3,7 +3,28 @@
 # For more information, please see the documentation at:
 #   https://docs.haskellstack.org/en/stable/lock_files
 
-packages: []
+packages:
+- completed:
+    hackage: lift-type-0.1.0.0@sha256:b52c172fc19635e53fa72874ac0e09b08b4bc2c711f57f883181f348799abd6f,1095
+    pantry-tree:
+      size: 360
+      sha256: 2ae816ebaef99ad169d95189cefa2113600ae2185e6af861984d91cbcd4bb3f0
+  original:
+    hackage: lift-type-0.1.0.0
+- completed:
+    hackage: mysql-0.2.1@sha256:156061d432d29b3a56037e8a67e16589b1d370fb9ad0dd71a81ea2c4b0b195bb,2188
+    pantry-tree:
+      size: 640
+      sha256: 567eaea9d842f5ece8702d3d895b7573c168faa986ad9071019877bf8edacf39
+  original:
+    hackage: mysql-0.2.1
+- completed:
+    hackage: mysql-simple-0.4.7@sha256:bf7c4a1ed0971d11c21f14796c3850a623a43ea83d158877f05380c52abad4a9,2581
+    pantry-tree:
+      size: 877
+      sha256: e1e868b577503a0e414de3172d09284596b070519806d1de2721daa0b33f1a82
+  original:
+    hackage: mysql-simple-0.4.7
 snapshots:
 - completed:
     size: 565720

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,3 +11,5 @@ packages:
 
 extra-deps:
     - lift-type-0.1.0.0
+    - mysql-0.2.1
+    - mysql-simple-0.4.7

--- a/stack_lts-12.yaml
+++ b/stack_lts-12.yaml
@@ -15,3 +15,5 @@ extra-deps:
 - th-lift-0.8.0.1
 - th-lift-instances-0.1.14
 - lift-type-0.1.0.1
+- mysql-0.2.1
+- mysql-simple-0.4.7


### PR DESCRIPTION
Now that mysql-simple and mysql have been updated to properly handle JSON values coming out of a mysql db (supported since mysql 5.7.8) this PR adds support to the MySQL backend to read these values. It does not add a PersistField instance for Value's. It is probably not great that Postgres has an orphan instance for Value. Would rather there be a Json newtype and JsonB newtype. 

Before submitting your PR, check that you've:

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [ ] Ran `stylish-haskell` on any changed files.
- [ ] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
