### PR TITLE
Support ghc-9.2.1 (aeson-2, template-haskell-2.18)

### DIFF
--- a/persistent/Database/Persist/Class/PersistConfig.hs
+++ b/persistent/Database/Persist/Class/PersistConfig.hs
@@ -4,7 +4,7 @@ module Database.Persist.Class.PersistConfig
 
 import Control.Monad.IO.Unlift (MonadUnliftIO)
 import Data.Aeson (Value (Object))
-import Data.Aeson.KeyMap
+import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Aeson.Types (Parser)
 import qualified Data.HashMap.Strict as HashMap
 import Data.Kind (Type)

--- a/persistent/Database/Persist/Class/PersistConfig.hs
+++ b/persistent/Database/Persist/Class/PersistConfig.hs
@@ -8,7 +8,7 @@ import Control.Monad.IO.Unlift (MonadUnliftIO)
 import Data.Aeson (Value (Object))
 import Data.Aeson.Types (Parser)
 
-#if MIN_VERSION_template_haskell(2,18,0)
+#if MIN_VERSION_aeson(2,0,0)
 import qualified Data.Aeson.KeyMap as AM
 #else
 import qualified Data.HashMap.Strict as AM

--- a/persistent/Database/Persist/Class/PersistConfig.hs
+++ b/persistent/Database/Persist/Class/PersistConfig.hs
@@ -6,7 +6,6 @@ import Control.Monad.IO.Unlift (MonadUnliftIO)
 import Data.Aeson (Value (Object))
 import qualified Data.Aeson.KeyMap as KeyMap
 import Data.Aeson.Types (Parser)
-import qualified Data.HashMap.Strict as HashMap
 import Data.Kind (Type)
 
 -- | Represents a value containing all the configuration options for a specific

--- a/persistent/Database/Persist/Class/PersistConfig.hs
+++ b/persistent/Database/Persist/Class/PersistConfig.hs
@@ -4,6 +4,7 @@ module Database.Persist.Class.PersistConfig
 
 import Control.Monad.IO.Unlift (MonadUnliftIO)
 import Data.Aeson (Value (Object))
+import Data.Aeson.KeyMap
 import Data.Aeson.Types (Parser)
 import qualified Data.HashMap.Strict as HashMap
 import Data.Kind (Type)
@@ -43,10 +44,10 @@ instance
     type PersistConfigPool (Either c1 c2) = PersistConfigPool c1
 
     loadConfig (Object o) =
-        case HashMap.lookup "left" o of
+        case KeyMap.lookup "left" o of
             Just v -> Left <$> loadConfig v
             Nothing ->
-                case HashMap.lookup "right" o of
+                case KeyMap.lookup "right" o of
                     Just v -> Right <$> loadConfig v
                     Nothing -> fail "PersistConfig for Either: need either a left or right"
     loadConfig _ = fail "PersistConfig for Either: need an object"

--- a/persistent/Database/Persist/Class/PersistConfig.hs
+++ b/persistent/Database/Persist/Class/PersistConfig.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Database.Persist.Class.PersistConfig
     ( PersistConfig (..)
     ) where

--- a/persistent/Database/Persist/Class/PersistConfig.hs
+++ b/persistent/Database/Persist/Class/PersistConfig.hs
@@ -4,7 +4,13 @@ module Database.Persist.Class.PersistConfig
 
 import Control.Monad.IO.Unlift (MonadUnliftIO)
 import Data.Aeson (Value (Object))
-import qualified Data.Aeson.KeyMap as KeyMap
+
+#if MIN_VERSION_template_haskell(2,18,0)
+import qualified Data.Aeson.KeyMap as AM
+#else
+import qualified Data.HashMap.Strict as AM
+#endif
+
 import Data.Aeson.Types (Parser)
 import Data.Kind (Type)
 
@@ -43,10 +49,10 @@ instance
     type PersistConfigPool (Either c1 c2) = PersistConfigPool c1
 
     loadConfig (Object o) =
-        case KeyMap.lookup "left" o of
+        case AM.lookup "left" o of
             Just v -> Left <$> loadConfig v
             Nothing ->
-                case KeyMap.lookup "right" o of
+                case AM.lookup "right" o of
                     Just v -> Right <$> loadConfig v
                     Nothing -> fail "PersistConfig for Either: need either a left or right"
     loadConfig _ = fail "PersistConfig for Either: need an object"

--- a/persistent/Database/Persist/Class/PersistConfig.hs
+++ b/persistent/Database/Persist/Class/PersistConfig.hs
@@ -4,6 +4,7 @@ module Database.Persist.Class.PersistConfig
 
 import Control.Monad.IO.Unlift (MonadUnliftIO)
 import Data.Aeson (Value (Object))
+import Data.Aeson.Types (Parser)
 
 #if MIN_VERSION_template_haskell(2,18,0)
 import qualified Data.Aeson.KeyMap as AM
@@ -11,7 +12,6 @@ import qualified Data.Aeson.KeyMap as AM
 import qualified Data.HashMap.Strict as AM
 #endif
 
-import Data.Aeson.Types (Parser)
 import Data.Kind (Type)
 
 -- | Represents a value containing all the configuration options for a specific

--- a/persistent/Database/Persist/Class/PersistEntity.hs
+++ b/persistent/Database/Persist/Class/PersistEntity.hs
@@ -46,7 +46,7 @@ import qualified Data.Aeson.Parser as AP
 import Data.Aeson.Text (encodeToTextBuilder)
 import Data.Aeson.Types (Parser, Result(Error, Success))
 import Data.Attoparsec.ByteString (parseOnly)
-import qualified Data.HashMap.Strict as HM
+import qualified Data.Aeson.KeyMap as KM
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.Maybe (isJust)
 import Data.Text (Text)
@@ -288,7 +288,7 @@ keyValueEntityFromJSON _ = fail "keyValueEntityFromJSON: not an object"
 -- @
 entityIdToJSON :: (PersistEntity record, ToJSON record) => Entity record -> Value
 entityIdToJSON (Entity key value) = case toJSON value of
-        Object o -> Object $ HM.insert "id" (toJSON key) o
+        Object o -> Object $ KM.insert "id" (toJSON key) o
         x -> x
 
 -- | Predefined @parseJSON@. The input JSON looks like

--- a/persistent/Database/Persist/Class/PersistEntity.hs
+++ b/persistent/Database/Persist/Class/PersistEntity.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE CPP #-}
 
 module Database.Persist.Class.PersistEntity
     ( PersistEntity (..)

--- a/persistent/Database/Persist/Class/PersistEntity.hs
+++ b/persistent/Database/Persist/Class/PersistEntity.hs
@@ -48,7 +48,7 @@ import Data.Aeson.Text (encodeToTextBuilder)
 import Data.Aeson.Types (Parser, Result(Error, Success))
 import Data.Attoparsec.ByteString (parseOnly)
 
-#if MIN_VERSION_template_haskell(2,18,0)
+#if MIN_VERSION_aeson(2,0,0)
 import qualified Data.Aeson.KeyMap as AM
 #else
 import qualified Data.HashMap.Strict as AM

--- a/persistent/Database/Persist/Class/PersistEntity.hs
+++ b/persistent/Database/Persist/Class/PersistEntity.hs
@@ -46,7 +46,13 @@ import qualified Data.Aeson.Parser as AP
 import Data.Aeson.Text (encodeToTextBuilder)
 import Data.Aeson.Types (Parser, Result(Error, Success))
 import Data.Attoparsec.ByteString (parseOnly)
-import qualified Data.Aeson.KeyMap as KM
+
+#if MIN_VERSION_template_haskell(2,18,0)
+import qualified Data.Aeson.KeyMap as AM
+#else
+import qualified Data.HashMap.Strict as AM
+#endif
+
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.Maybe (isJust)
 import Data.Text (Text)
@@ -288,7 +294,7 @@ keyValueEntityFromJSON _ = fail "keyValueEntityFromJSON: not an object"
 -- @
 entityIdToJSON :: (PersistEntity record, ToJSON record) => Entity record -> Value
 entityIdToJSON (Entity key value) = case toJSON value of
-        Object o -> Object $ KM.insert "id" (toJSON key) o
+        Object o -> Object $ AM.insert "id" (toJSON key) o
         x -> x
 
 -- | Predefined @parseJSON@. The input JSON looks like

--- a/persistent/Database/Persist/PersistValue.hs
+++ b/persistent/Database/Persist/PersistValue.hs
@@ -176,7 +176,7 @@ instance A.ToJSON PersistValue where
     toJSON PersistNull = A.Null
     toJSON (PersistList l) = A.Array $ V.fromList $ map A.toJSON l
     toJSON (PersistMap m) = A.object $ map go m
-        where go (k, v) = (K.toText k, A.toJSON v)
+        where go (k, v) = (K.fromText k, A.toJSON v)
     toJSON (PersistLiteral_ litTy b) =
         let encoded = TE.decodeUtf8 $ B64.encode b
             prefix =

--- a/persistent/Database/Persist/PersistValue.hs
+++ b/persistent/Database/Persist/PersistValue.hs
@@ -251,5 +251,5 @@ instance A.FromJSON PersistValue where
     parseJSON (A.Object o) =
         fmap PersistMap $ mapM go $ KM.toList o
       where
-        go (k, v) = (,) K.toText k <$> A.parseJSON v
+        go (k, v) = (,) (K.toText k) <$> A.parseJSON v
 

--- a/persistent/Database/Persist/PersistValue.hs
+++ b/persistent/Database/Persist/PersistValue.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE CPP #-}
 
 -- | This module contains an intermediate representation of values before the
 -- backends serialize them into explicit database types.

--- a/persistent/Database/Persist/PersistValue.hs
+++ b/persistent/Database/Persist/PersistValue.hs
@@ -26,7 +26,8 @@ import Data.Time (Day, TimeOfDay, UTCTime)
 import Web.PathPieces (PathPiece(..))
 import qualified Data.Aeson as A
 import qualified Data.ByteString as BS
-import qualified Data.HashMap.Strict as HM
+#import qualified Data.HashMap.Strict as HM
+import qualified Data.Aeson.KeyMap as HM
 import Web.HttpApiData
        ( FromHttpApiData(..)
        , ToHttpApiData(..)

--- a/persistent/Database/Persist/PersistValue.hs
+++ b/persistent/Database/Persist/PersistValue.hs
@@ -27,7 +27,7 @@ import Web.PathPieces (PathPiece(..))
 import qualified Data.Aeson as A
 import qualified Data.ByteString as BS
 
-#if MIN_VERSION_template_haskell(2,18,0)
+#if MIN_VERSION_aeson(2,0,0)
 import qualified Data.Aeson.Key as K
 import qualified Data.Aeson.KeyMap as AM
 #else
@@ -131,7 +131,7 @@ pattern PersistLiteral bs <- PersistLiteral_ _ bs where
 
 {-# DEPRECATED PersistDbSpecific "Deprecated since 2.11 because of inconsistent escaping behavior across backends. The Postgres backend escapes these values, while the MySQL backend does not. If you are using this, please switch to 'PersistLiteral_' and provide a relevant 'LiteralType' for your conversion." #-}
 
-#if MIN_VERSION_template_haskell(2,18,0)
+#if MIN_VERSION_aeson(2,0,0)
 keyToText = AK.toText
 keyFromText = AK.fromText
 #else

--- a/persistent/Database/Persist/PersistValue.hs
+++ b/persistent/Database/Persist/PersistValue.hs
@@ -132,8 +132,8 @@ pattern PersistLiteral bs <- PersistLiteral_ _ bs where
 {-# DEPRECATED PersistDbSpecific "Deprecated since 2.11 because of inconsistent escaping behavior across backends. The Postgres backend escapes these values, while the MySQL backend does not. If you are using this, please switch to 'PersistLiteral_' and provide a relevant 'LiteralType' for your conversion." #-}
 
 #if MIN_VERSION_aeson(2,0,0)
-keyToText = AM.toText
-keyFromText = AM.fromText
+keyToText = K.toText
+keyFromText = K.fromText
 #else
 keyToText = id
 keyFromText = id

--- a/persistent/Database/Persist/PersistValue.hs
+++ b/persistent/Database/Persist/PersistValue.hs
@@ -250,5 +250,5 @@ instance A.FromJSON PersistValue where
     parseJSON (A.Object o) =
         fmap PersistMap $ mapM go $ HM.toList o
       where
-        go (k, v) = (,) k <$> A.parseJSON v
+        go (k, v) = (,) A.unkey k <$> A.parseJSON v
 

--- a/persistent/Database/Persist/PersistValue.hs
+++ b/persistent/Database/Persist/PersistValue.hs
@@ -176,8 +176,7 @@ instance A.ToJSON PersistValue where
     toJSON (PersistDay d) = A.String $ Text.pack $ 'd' : show d
     toJSON PersistNull = A.Null
     toJSON (PersistList l) = A.Array $ V.fromList $ map A.toJSON l
-    --toJSON (PersistMap m) = A.object $ map (second A.toJSON) m
-    toJSON (PersistMap m) = A.object $ map A.toJSON m
+    toJSON (PersistMap m) = A.object $ mapKeys A.toJSONKey $ map (second A.toJSON) m
     toJSON (PersistLiteral_ litTy b) =
         let encoded = TE.decodeUtf8 $ B64.encode b
             prefix =

--- a/persistent/Database/Persist/PersistValue.hs
+++ b/persistent/Database/Persist/PersistValue.hs
@@ -176,7 +176,8 @@ instance A.ToJSON PersistValue where
     toJSON (PersistDay d) = A.String $ Text.pack $ 'd' : show d
     toJSON PersistNull = A.Null
     toJSON (PersistList l) = A.Array $ V.fromList $ map A.toJSON l
-    toJSON (PersistMap m) = A.object $ mapKeys A.toJSONKey $ map (second A.toJSON) m
+    --toJSON (PersistMap m) = A.object $ map (second A.toJSON) m
+    toJSON (PersistMap m) = A.object $ map go m where go (a, b) = (A.toJSONKey a, A.toJSON b)
     toJSON (PersistLiteral_ litTy b) =
         let encoded = TE.decodeUtf8 $ B64.encode b
             prefix =

--- a/persistent/Database/Persist/PersistValue.hs
+++ b/persistent/Database/Persist/PersistValue.hs
@@ -26,7 +26,6 @@ import Data.Time (Day, TimeOfDay, UTCTime)
 import Web.PathPieces (PathPiece(..))
 import qualified Data.Aeson as A
 import qualified Data.ByteString as BS
---import qualified Data.HashMap.Strict as HM
 import qualified Data.Aeson.Key as K
 import qualified Data.Aeson.KeyMap as KM
 import Web.HttpApiData
@@ -176,8 +175,8 @@ instance A.ToJSON PersistValue where
     toJSON (PersistDay d) = A.String $ Text.pack $ 'd' : show d
     toJSON PersistNull = A.Null
     toJSON (PersistList l) = A.Array $ V.fromList $ map A.toJSON l
-    --toJSON (PersistMap m) = A.object $ map (second A.toJSON) m
-    toJSON (PersistMap m) = A.object $ map go m where go (a, b) = (A.toJSONKey a, A.toJSON b)
+    toJSON (PersistMap m) = A.object $ map go m
+        where go (k, v) = (K.toText k, A.toJSON v)
     toJSON (PersistLiteral_ litTy b) =
         let encoded = TE.decodeUtf8 $ B64.encode b
             prefix =

--- a/persistent/Database/Persist/PersistValue.hs
+++ b/persistent/Database/Persist/PersistValue.hs
@@ -27,7 +27,8 @@ import Web.PathPieces (PathPiece(..))
 import qualified Data.Aeson as A
 import qualified Data.ByteString as BS
 --import qualified Data.HashMap.Strict as HM
-import qualified Data.Aeson.KeyMap as HM
+import qualified Data.Aeson.Key as K
+import qualified Data.Aeson.KeyMap as KM
 import Web.HttpApiData
        ( FromHttpApiData(..)
        , ToHttpApiData(..)
@@ -248,7 +249,7 @@ instance A.FromJSON PersistValue where
     parseJSON A.Null = return PersistNull
     parseJSON (A.Array a) = fmap PersistList (mapM A.parseJSON $ V.toList a)
     parseJSON (A.Object o) =
-        fmap PersistMap $ mapM go $ HM.toList o
+        fmap PersistMap $ mapM go $ KM.toList o
       where
-        go (k, v) = (,) A.unkey k <$> A.parseJSON v
+        go (k, v) = (,) K.toText k <$> A.parseJSON v
 

--- a/persistent/Database/Persist/PersistValue.hs
+++ b/persistent/Database/Persist/PersistValue.hs
@@ -132,8 +132,8 @@ pattern PersistLiteral bs <- PersistLiteral_ _ bs where
 {-# DEPRECATED PersistDbSpecific "Deprecated since 2.11 because of inconsistent escaping behavior across backends. The Postgres backend escapes these values, while the MySQL backend does not. If you are using this, please switch to 'PersistLiteral_' and provide a relevant 'LiteralType' for your conversion." #-}
 
 #if MIN_VERSION_aeson(2,0,0)
-keyToText = AK.toText
-keyFromText = AK.fromText
+keyToText = AM.toText
+keyFromText = AM.fromText
 #else
 keyToText = id
 keyFromText = id

--- a/persistent/Database/Persist/PersistValue.hs
+++ b/persistent/Database/Persist/PersistValue.hs
@@ -33,8 +33,6 @@ import qualified Data.Aeson.KeyMap as AM
 import qualified Data.HashMap.Strict as AM
 #endif
 
-import qualified Data.Aeson.Key as K
-import qualified Data.Aeson.KeyMap as KM
 import Web.HttpApiData
        ( FromHttpApiData(..)
        , ToHttpApiData(..)

--- a/persistent/Database/Persist/PersistValue.hs
+++ b/persistent/Database/Persist/PersistValue.hs
@@ -26,7 +26,7 @@ import Data.Time (Day, TimeOfDay, UTCTime)
 import Web.PathPieces (PathPiece(..))
 import qualified Data.Aeson as A
 import qualified Data.ByteString as BS
-#import qualified Data.HashMap.Strict as HM
+--import qualified Data.HashMap.Strict as HM
 import qualified Data.Aeson.KeyMap as HM
 import Web.HttpApiData
        ( FromHttpApiData(..)

--- a/persistent/Database/Persist/PersistValue.hs
+++ b/persistent/Database/Persist/PersistValue.hs
@@ -17,7 +17,6 @@ import Data.Int (Int64)
 import qualified Data.Scientific
 import Data.Text.Encoding.Error (lenientDecode)
 import Data.Bits (shiftL, shiftR)
-import Control.Arrow (second)
 import Numeric (readHex, showHex)
 import qualified Data.Text as Text
 import Data.Text (Text)

--- a/persistent/Database/Persist/PersistValue.hs
+++ b/persistent/Database/Persist/PersistValue.hs
@@ -176,7 +176,8 @@ instance A.ToJSON PersistValue where
     toJSON (PersistDay d) = A.String $ Text.pack $ 'd' : show d
     toJSON PersistNull = A.Null
     toJSON (PersistList l) = A.Array $ V.fromList $ map A.toJSON l
-    toJSON (PersistMap m) = A.object $ map (second A.toJSON) m
+    --toJSON (PersistMap m) = A.object $ map (second A.toJSON) m
+    toJSON (PersistMap m) = A.object $ map A.toJSON m
     toJSON (PersistLiteral_ litTy b) =
         let encoded = TE.decodeUtf8 $ B64.encode b
             prefix =

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -127,6 +127,13 @@ import Database.Persist.EntityDef.Internal (EntityDef(..))
 import Database.Persist.ImplicitIdDef (autoIncrementingInteger)
 import Database.Persist.ImplicitIdDef.Internal
 
+#if MIN_VERSION_template_haskell(2,18,0)
+conp :: Name -> [Pat] -> Pat
+conp name pats = ConP name [] pats
+#else
+conp = ConP
+#endif
+
 -- | Converts a quasi-quoted syntax into a list of entity definitions, to be
 -- used as input to the template haskell generation code (mkPersist).
 persistWith :: PersistSettings -> QuasiQuoter
@@ -1284,7 +1291,7 @@ mkToPersistFields mps ed = do
     go = do
         xs <- sequence $ replicate fieldCount $ newName "x"
         let name = mkEntityDefName ed
-            pat = ConP name [] $ fmap VarP xs
+            pat = conp name $ fmap VarP xs
         sp <- [|SomePersistField|]
         let bod = ListE $ fmap (AppE sp . VarE) xs
         return $ normalClause [pat] bod
@@ -1306,7 +1313,7 @@ mkToPersistFields mps ed = do
                 , [sp `AppE` VarE x]
                 , after
                 ]
-        return $ normalClause [ConP name [] [VarP x]] body
+        return $ normalClause [conp name [VarP x]] body
 
 mkToFieldNames :: [UniqueDef] -> Q Dec
 mkToFieldNames pairs = do
@@ -1328,7 +1335,7 @@ mkUniqueToValues pairs = do
     go :: UniqueDef -> Q Clause
     go (UniqueDef constr _ names _) = do
         xs <- mapM (const $ newName "x") names
-        let pat = ConP (mkConstraintName constr) [] $ fmap VarP $ toList xs
+        let pat = conp (mkConstraintName constr) $ fmap VarP $ toList xs
         tpv <- [|toPersistValue|]
         let bod = ListE $ fmap (AppE tpv . VarE) $ toList xs
         return $ normalClause [pat] bod
@@ -1367,7 +1374,7 @@ mkFromPersistValues mps entDef
     mkClauses _ [] = return []
     mkClauses before (field:after) = do
         x <- newName "x"
-        let null' = ConP 'PersistNull [] []
+        let null' = conp 'PersistNull []
             pat = ListP $ mconcat
                 [ fmap (const null') before
                 , [VarP x]
@@ -1404,20 +1411,20 @@ mkLensClauses mps entDef = do
     valName <- newName "value"
     xName <- newName "x"
     let idClause = normalClause
-            [ConP (keyIdName entDef) [] []]
+            [conp (keyIdName entDef) []]
             (lens' `AppE` getId `AppE` setId)
     return $ idClause : if unboundEntitySum entDef
         then fmap (toSumClause lens' keyVar valName xName) (getUnboundFieldDefs entDef)
         else fmap (toClause lens' getVal dot keyVar valName xName) (getUnboundFieldDefs entDef)
   where
     toClause lens' getVal dot keyVar valName xName fieldDef = normalClause
-        [ConP (filterConName mps entDef fieldDef) [] []]
+        [conp (filterConName mps entDef fieldDef) []]
         (lens' `AppE` getter `AppE` setter)
       where
         fieldName = fieldDefToRecordName mps entDef fieldDef
         getter = InfixE (Just $ VarE fieldName) dot (Just getVal)
         setter = LamE
-            [ ConP 'Entity [] [VarP keyVar, VarP valName]
+            [ conp 'Entity [VarP keyVar, VarP valName]
             , VarP xName
             ]
             $ ConE 'Entity `AppE` VarE keyVar `AppE` RecUpdE
@@ -1425,12 +1432,12 @@ mkLensClauses mps entDef = do
                 [(fieldName, VarE xName)]
 
     toSumClause lens' keyVar valName xName fieldDef = normalClause
-        [ConP (filterConName mps entDef fieldDef) [] []]
+        [conp (filterConName mps entDef fieldDef) []]
         (lens' `AppE` getter `AppE` setter)
       where
         emptyMatch = Match WildP (NormalB $ VarE 'error `AppE` LitE (StringL "Tried to use fieldLens on a Sum type")) []
         getter = LamE
-            [ ConP 'Entity [] [WildP, VarP valName]
+            [ conp 'Entity [WildP, VarP valName]
             ] $ CaseE (VarE valName)
             $ Match (ConP (sumConstrName mps entDef fieldDef) [] [VarP xName]) (NormalB $ VarE xName) []
 
@@ -1438,7 +1445,7 @@ mkLensClauses mps entDef = do
             -- a sum type and therefore could result in Maybe.
             : if length (getUnboundFieldDefs entDef) > 1 then [emptyMatch] else []
         setter = LamE
-            [ ConP 'Entity [] [VarP keyVar, WildP]
+            [ conp 'Entity [VarP keyVar, WildP]
             , VarP xName
             ]
             $ ConE 'Entity `AppE` VarE keyVar `AppE` (ConE (sumConstrName mps entDef fieldDef) `AppE` VarE xName)
@@ -2360,8 +2367,8 @@ mkUniqueKeys def = do
             x' <- newName $ '_' : unpack (unFieldNameHS x)
             return (x, x')
         let pcs = fmap (go xs) $ entityUniques $ unboundEntityDef def
-        let pat = ConP
-                (mkEntityDefName def) []
+        let pat = conp
+                (mkEntityDefName def)
                 (fmap (VarP . snd) xs)
         return $ normalClause [pat] (ListE pcs)
 
@@ -2549,7 +2556,7 @@ mkField mps entityMap et fieldDef = do
             maybeIdType mps entityMap fieldDef Nothing Nothing
     bod <- mkLookupEntityField et (unboundFieldNameHS fieldDef)
     let cla = normalClause
-                [ConP name [] []]
+                [conp name []]
                 bod
     return $ EntityFieldTH con cla
   where
@@ -2579,7 +2586,7 @@ mkIdField mps ued = do
                 [mkEqualP (VarT $ mkName "typ") entityIdType]
                 $ NormalC name []
         , entityFieldTHClause =
-            normalClause [ConP name [] []] clause
+            normalClause [conp name []] clause
         }
 
 lookupEntityField
@@ -2658,7 +2665,7 @@ mkJSON mps (fixEntityDef -> def) = do
             typeInstanceD ''ToJSON (mpsGeneric mps) typ [toJSON']
           where
             toJSON' = FunD 'toJSON $ return $ normalClause
-                [ConP conName [] $ fmap VarP xs]
+                [conp conName $ fmap VarP xs]
                 (objectE `AppE` ListE pairs)
               where
                 pairs = zipWith toPair fields xs
@@ -2670,7 +2677,7 @@ mkJSON mps (fixEntityDef -> def) = do
             typeInstanceD ''FromJSON (mpsGeneric mps) typ [parseJSON']
           where
             parseJSON' = FunD 'parseJSON
-                [ normalClause [ConP 'Object [] [VarP obj]]
+                [ normalClause [conp 'Object [VarP obj]]
                     (foldl'
                         (\x y -> InfixE (Just x) apE' (Just y))
                         (pureE `AppE` ConE conName)

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -2549,7 +2549,7 @@ mkField mps entityMap et fieldDef = do
             maybeIdType mps entityMap fieldDef Nothing Nothing
     bod <- mkLookupEntityField et (unboundFieldNameHS fieldDef)
     let cla = normalClause
-                [ConP name []]
+                [ConP name [] []]
                 bod
     return $ EntityFieldTH con cla
   where
@@ -2579,7 +2579,7 @@ mkIdField mps ued = do
                 [mkEqualP (VarT $ mkName "typ") entityIdType]
                 $ NormalC name []
         , entityFieldTHClause =
-            normalClause [ConP name []] clause
+            normalClause [ConP name [] []] clause
         }
 
 lookupEntityField
@@ -2658,7 +2658,7 @@ mkJSON mps (fixEntityDef -> def) = do
             typeInstanceD ''ToJSON (mpsGeneric mps) typ [toJSON']
           where
             toJSON' = FunD 'toJSON $ return $ normalClause
-                [ConP conName $ fmap VarP xs]
+                [ConP conName [] $ fmap VarP xs]
                 (objectE `AppE` ListE pairs)
               where
                 pairs = zipWith toPair fields xs
@@ -2670,7 +2670,7 @@ mkJSON mps (fixEntityDef -> def) = do
             typeInstanceD ''FromJSON (mpsGeneric mps) typ [parseJSON']
           where
             parseJSON' = FunD 'parseJSON
-                [ normalClause [ConP 'Object [VarP obj]]
+                [ normalClause [ConP 'Object [] [VarP obj]]
                     (foldl'
                         (\x y -> InfixE (Just x) apE' (Just y))
                         (pureE `AppE` ConE conName)

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -1284,7 +1284,7 @@ mkToPersistFields mps ed = do
     go = do
         xs <- sequence $ replicate fieldCount $ newName "x"
         let name = mkEntityDefName ed
-            pat = ConP name $ fmap VarP xs
+            pat = ConP name [] $ fmap VarP xs
         sp <- [|SomePersistField|]
         let bod = ListE $ fmap (AppE sp . VarE) xs
         return $ normalClause [pat] bod
@@ -1306,7 +1306,7 @@ mkToPersistFields mps ed = do
                 , [sp `AppE` VarE x]
                 , after
                 ]
-        return $ normalClause [ConP name [VarP x]] body
+        return $ normalClause [ConP name [] [VarP x]] body
 
 mkToFieldNames :: [UniqueDef] -> Q Dec
 mkToFieldNames pairs = do

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -2361,7 +2361,7 @@ mkUniqueKeys def = do
             return (x, x')
         let pcs = fmap (go xs) $ entityUniques $ unboundEntityDef def
         let pat = ConP
-                (mkEntityDefName def)
+                (mkEntityDefName def) []
                 (fmap (VarP . snd) xs)
         return $ normalClause [pat] (ListE pcs)
 


### PR DESCRIPTION
Tentative patch to
- support  aeson-2 (introducing Key/KeyMap as an abstraction in replacement to HashMap Text Value)
- support template-haskell-2.18.0 (changes the type of some functions, esp. ConP)
which makes it possible to compile with ghc-9.2.1