### PR TITLE
Add SQL Connection & Statement hooks

### DIFF
--- a/persistent-mysql/ChangeLog.md
+++ b/persistent-mysql/ChangeLog.md
@@ -1,6 +1,6 @@
 # Changelog for persistent-mysql
 
-## 2.14.0.0
+## 2.14.0.0 (unreleased)
 
 * [#XXXX]()
     * Update backend to support new `StatementCache` interface

--- a/persistent-mysql/ChangeLog.md
+++ b/persistent-mysql/ChangeLog.md
@@ -2,6 +2,9 @@
 
 ## 2.14.0.0 (unreleased)
 
+* [#1341](https://github.com/yesodweb/persistent/pull/1341)
+    * Add `SqlBackendHooks` to allow for instrumentation of queries.
+
 * [#1327](https://github.com/yesodweb/persistent/pull/1327)
     * Update backend to support new `StatementCache` interface
 

--- a/persistent-mysql/ChangeLog.md
+++ b/persistent-mysql/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for persistent-mysql
 
+## 2.14.0.0
+
+* [#XXXX]()
+    * Update backend to support new `StatementCache` interface
+
 ## 2.13.0.2
 
 * Bugfix: prevent fetching constraint info from other databases during migrations [#1301](https://github.com/yesodweb/persistent/pull/1301)

--- a/persistent-mysql/ChangeLog.md
+++ b/persistent-mysql/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 2.14.0.0 (unreleased)
 
-* [#XXXX]()
+* [#1327](https://github.com/yesodweb/persistent/pull/1327)
     * Update backend to support new `StatementCache` interface
 
 ## 2.13.0.2

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -46,7 +46,6 @@ import Control.Monad.Trans.Except (ExceptT, runExceptT)
 import Control.Monad.Trans.Reader (ReaderT, runReaderT)
 import Control.Monad.Trans.Writer (runWriterT)
 
-import qualified Data.List.NonEmpty as NEL
 import Data.Acquire (Acquire, mkAcquire, with)
 import Data.Aeson
 import Data.Aeson.Types (modifyFailure)
@@ -58,6 +57,7 @@ import Data.Fixed (Pico)
 import Data.Function (on)
 import Data.Int (Int64)
 import Data.List (find, groupBy, intercalate, sort)
+import qualified Data.List.NonEmpty as NEL
 import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
 import Data.Monoid ((<>))
 import qualified Data.Monoid as Monoid
@@ -70,10 +70,10 @@ import GHC.Stack
 import System.Environment (getEnvironment)
 
 import Database.Persist.Sql
-import Database.Persist.SqlBackend
-import Database.Persist.SqlBackend.StatementCache
 import Database.Persist.Sql.Types.Internal (makeIsolationLevelStatement)
 import qualified Database.Persist.Sql.Util as Util
+import Database.Persist.SqlBackend
+import Database.Persist.SqlBackend.StatementCache
 
 import qualified Database.MySQL.Base as MySQLBase
 import qualified Database.MySQL.Base.Types as MySQLBase

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -1278,7 +1278,7 @@ mockMigrate _connectInfo allDefs _getter val = do
 -- the actual database isn't already present in the system.
 mockMigration :: Migration -> IO ()
 mockMigration mig = do
-    smap <- mkStatemeentCache <$> mkSimpleStatementCache
+    smap <- mkStatementCache <$> mkSimpleStatementCache
     let sqlbackend =
             mkSqlBackend MkSqlBackendArgs
                 { connPrepare = \_ -> do

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -45,6 +45,7 @@ import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except (ExceptT, runExceptT)
 import Control.Monad.Trans.Reader (ReaderT, runReaderT)
 import Control.Monad.Trans.Writer (runWriterT)
+import Data.IORef (newIORef)
 import Data.Proxy (Proxy(..))
 
 import Data.Acquire (Acquire, mkAcquire, with)
@@ -132,7 +133,7 @@ openMySQLConn :: MySQL.ConnectInfo -> LogFunc -> IO (MySQL.Connection, SqlBacken
 openMySQLConn ci logFunc = do
     conn <- MySQL.connect ci
     MySQLBase.autocommit conn False -- disable autocommit!
-    smap <- mkStatementCache <$> mkSimpleStatementCache
+    smap <- newIORef mempty
     let
         backend =
             setConnPutManySql putManySql $
@@ -1298,7 +1299,7 @@ mockMigrate _connectInfo allDefs _getter val = do
 -- the actual database isn't already present in the system.
 mockMigration :: Migration -> IO ()
 mockMigration mig = do
-    smap <- mkStatementCache <$> mkSimpleStatementCache
+    smap <- newIORef mempty
     let sqlbackend =
             mkSqlBackend MkSqlBackendArgs
                 { connPrepare = \_ -> do

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -59,6 +59,7 @@ import Data.Int (Int64)
 import Data.List (find, groupBy, intercalate, sort)
 import qualified Data.List.NonEmpty as NEL
 import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
+import qualified Data.Map as Map
 import Data.Monoid ((<>))
 import qualified Data.Monoid as Monoid
 import Data.Pool (Pool)

--- a/persistent-mysql/persistent-mysql.cabal
+++ b/persistent-mysql/persistent-mysql.cabal
@@ -1,5 +1,5 @@
 name:            persistent-mysql
-version:         2.13.0.2
+version:         2.14.0.0
 license:         MIT
 license-file:    LICENSE
 author:          Felipe Lessa <felipe.lessa@gmail.com>, Michael Snoyman
@@ -28,7 +28,7 @@ extra-source-files: ChangeLog.md
 
 library
     build-depends:   base             >= 4.9      && < 5
-                   , persistent       >= 2.13   && < 3
+                   , persistent       >= 2.14   && < 3
                    , aeson            >= 1.0
                    , blaze-builder
                    , bytestring       >= 0.10.8

--- a/persistent-postgresql/ChangeLog.md
+++ b/persistent-postgresql/ChangeLog.md
@@ -2,6 +2,9 @@
 
 ## 2.14.0.0 (unreleased)
 
+* [#1341](https://github.com/yesodweb/persistent/pull/1341)
+    * Add `SqlBackendHooks` to allow for instrumentation of queries.
+
 * [#1327](https://github.com/yesodweb/persistent/pull/1327)
     * Update backend to support new `StatementCache` interface
 

--- a/persistent-postgresql/ChangeLog.md
+++ b/persistent-postgresql/ChangeLog.md
@@ -1,6 +1,6 @@
 # Changelog for persistent-postgresql
 
-## 2.14.0.0
+## 2.14.0.0 (unreleased)
 
 * [#XXXX]()
     * Update backend to support new `StatementCache` interface

--- a/persistent-postgresql/ChangeLog.md
+++ b/persistent-postgresql/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 2.14.0.0 (unreleased)
 
-* [#XXXX]()
+* [#1327](https://github.com/yesodweb/persistent/pull/1327)
     * Update backend to support new `StatementCache` interface
 
 ## 2.13.2.1

--- a/persistent-postgresql/ChangeLog.md
+++ b/persistent-postgresql/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for persistent-postgresql
 
+## 2.14.0.0
+
+* [#XXXX]()
+    * Update backend to support new `StatementCache` interface
+
 ## 2.13.2.1
 
 * [#1331](https://github.com/yesodweb/persistent/pull/1331)

--- a/persistent-postgresql/persistent-postgresql.cabal
+++ b/persistent-postgresql/persistent-postgresql.cabal
@@ -34,6 +34,7 @@ library
                    , time                  >= 1.6
                    , transformers          >= 0.5
                    , unliftio-core
+                   , vault
     exposed-modules: Database.Persist.Postgresql
                    , Database.Persist.Postgresql.Internal
                    , Database.Persist.Postgresql.JSON

--- a/persistent-postgresql/persistent-postgresql.cabal
+++ b/persistent-postgresql/persistent-postgresql.cabal
@@ -1,5 +1,5 @@
 name:            persistent-postgresql
-version:         2.13.2.1
+version:         2.14.0.0
 license:         MIT
 license-file:    LICENSE
 author:          Felipe Lessa, Michael Snoyman <michael@snoyman.com>
@@ -16,7 +16,7 @@ extra-source-files: ChangeLog.md
 
 library
     build-depends:   base                  >= 4.9      && < 5
-                   , persistent            >= 2.13     && < 3
+                   , persistent            >= 2.14     && < 3
                    , aeson                 >= 1.0
                    , attoparsec
                    , blaze-builder

--- a/persistent-sqlite/ChangeLog.md
+++ b/persistent-sqlite/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 2.14.0.0 (unreleased)
 
-* [#XXXX]()
+* [#1327](https://github.com/yesodweb/persistent/pull/1327)
     * Update backend to support new `StatementCache` interface
 
 ## 2.13.0.3

--- a/persistent-sqlite/ChangeLog.md
+++ b/persistent-sqlite/ChangeLog.md
@@ -2,6 +2,9 @@
 
 ## 2.14.0.0 (unreleased)
 
+* [#1341](https://github.com/yesodweb/persistent/pull/1341)
+    * Add `SqlBackendHooks` to allow for instrumentation of queries.
+
 * [#1327](https://github.com/yesodweb/persistent/pull/1327)
     * Update backend to support new `StatementCache` interface
 

--- a/persistent-sqlite/ChangeLog.md
+++ b/persistent-sqlite/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for persistent-sqlite
 
+## 2.14.0.0
+
+* [#XXXX]()
+    * Update backend to support new `StatementCache` interface
+
 ## 2.13.0.3
 
 * Somehow failed to properly release the safe-to-remove changes.

--- a/persistent-sqlite/ChangeLog.md
+++ b/persistent-sqlite/ChangeLog.md
@@ -1,6 +1,6 @@
 # Changelog for persistent-sqlite
 
-## 2.14.0.0
+## 2.14.0.0 (unreleased)
 
 * [#XXXX]()
     * Update backend to support new `StatementCache` interface

--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -78,8 +78,6 @@ import qualified Data.Conduit.Combinators as C
 import qualified Data.Conduit.List as CL
 import qualified Data.HashMap.Lazy as HashMap
 import Data.Int (Int64)
-import Data.IORef
-import qualified Data.Map as Map
 import Data.Pool (Pool)
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -95,6 +93,7 @@ import Database.Persist.Sql
 import Database.Persist.SqlBackend
 import qualified Database.Persist.Sql.Util as Util
 import qualified Database.Sqlite as Sqlite
+import Database.Persist.SqlBackend.StatementCache
 
 
 -- | Create a pool of SQLite connections.
@@ -269,7 +268,7 @@ wrapConnectionInfo connInfo conn logFunc = do
         Sqlite.reset conn stmt
         Sqlite.finalize stmt
 
-    smap <- newIORef $ Map.empty
+    smap <- mkStatementCache <$> mkSimpleStatementCache
     return $
         setConnMaxParams 999 $
         setConnPutManySql putManySql $
@@ -456,7 +455,7 @@ migrate' allDefs getter val = do
 -- with the difference that an actual database isn't needed for it.
 mockMigration :: Migration -> IO ()
 mockMigration mig = do
-    smap <- newIORef $ Map.empty
+    smap <- mkStatementCache <$> mkSimpleStatementCache
     let sqlbackend =
             setConnMaxParams 999 $
             mkSqlBackend MkSqlBackendArgs

--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -95,6 +95,7 @@ import qualified Data.Conduit.List as CL
 import Data.Foldable (toList)
 import qualified Data.HashMap.Lazy as HashMap
 import Data.Int (Int64)
+import Data.IORef (newIORef)
 import Data.Maybe
 import Data.Pool (Pool)
 import Data.Text (Text)
@@ -109,7 +110,6 @@ import Database.Persist.Compatible
 import Database.Persist.Sql
 import qualified Database.Persist.Sql.Util as Util
 import Database.Persist.SqlBackend
-import Database.Persist.SqlBackend.StatementCache
 import qualified Database.Sqlite as Sqlite
 
 
@@ -285,7 +285,7 @@ wrapConnectionInfo connInfo conn logFunc = do
         Sqlite.reset conn stmt
         Sqlite.finalize stmt
 
-    smap <- mkStatementCache <$> mkSimpleStatementCache
+    smap <- newIORef mempty
     return $
         setConnMaxParams 999 $
         setConnPutManySql putManySql $
@@ -472,7 +472,7 @@ migrate' allDefs getter val = do
 -- with the difference that an actual database isn't needed for it.
 mockMigration :: Migration -> IO ()
 mockMigration mig = do
-    smap <- mkStatementCache <$> mkSimpleStatementCache
+    smap <- newIORef mempty
     let sqlbackend =
             setConnMaxParams 999 $
             mkSqlBackend MkSqlBackendArgs

--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -60,40 +60,54 @@ module Database.Persist.Sqlite
 import Control.Concurrent (threadDelay)
 import qualified Control.Exception as E
 import Control.Monad (forM_)
-import Control.Monad.IO.Unlift (MonadIO (..), MonadUnliftIO, askRunInIO, withRunInIO, withUnliftIO, unliftIO, withRunInIO)
-import Control.Monad.Logger (NoLoggingT, runNoLoggingT, MonadLoggerIO, logWarn, runLoggingT, askLoggerIO)
+import Control.Monad.IO.Unlift
+       ( MonadIO(..)
+       , MonadUnliftIO
+       , askRunInIO
+       , unliftIO
+       , withRunInIO
+       , withUnliftIO
+       )
+import Control.Monad.Logger
+       ( MonadLoggerIO
+       , NoLoggingT
+       , askLoggerIO
+       , logWarn
+       , runLoggingT
+       , runNoLoggingT
+       )
 import Control.Monad.Reader (MonadReader)
-import Control.Monad.Trans.Resource (MonadResource)
 import Control.Monad.Trans.Reader (ReaderT, runReaderT)
+import Control.Monad.Trans.Resource (MonadResource)
 #if !MIN_VERSION_base(4,12,0)
 import Control.Monad.Trans.Reader (withReaderT)
 #endif
 import Control.Monad.Trans.Writer (runWriterT)
 import Data.Acquire (Acquire, mkAcquire, with)
-import Data.Maybe
 import Data.Aeson
 import Data.Aeson.Types (modifyFailure)
 import Data.Conduit
 import qualified Data.Conduit.Combinators as C
 import qualified Data.Conduit.List as CL
+import Data.Foldable (toList)
 import qualified Data.HashMap.Lazy as HashMap
 import Data.Int (Int64)
+import Data.Maybe
 import Data.Pool (Pool)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
 import Lens.Micro.TH (makeLenses)
 import UnliftIO.Resource (ResourceT, runResourceT)
-import Data.Foldable (toList)
 
 #if MIN_VERSION_base(4,12,0)
 import Database.Persist.Compatible
 #endif
 import Database.Persist.Sql
-import Database.Persist.SqlBackend
 import qualified Database.Persist.Sql.Util as Util
-import qualified Database.Sqlite as Sqlite
+import Database.Persist.SqlBackend
 import Database.Persist.SqlBackend.StatementCache
+import qualified Database.Sqlite as Sqlite
 
 
 -- | Create a pool of SQLite connections.

--- a/persistent-sqlite/persistent-sqlite.cabal
+++ b/persistent-sqlite/persistent-sqlite.cabal
@@ -1,5 +1,5 @@
 name:            persistent-sqlite
-version:         2.13.0.3
+version:         2.14.0.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -44,7 +44,7 @@ flag use-stat4
 
 library
     build-depends:   base                    >= 4.9         && < 5
-                   , persistent              >= 2.13        && < 3
+                   , persistent              >= 2.14        && < 3
                    , aeson                   >= 1.0
                    , bytestring              >= 0.10
                    , conduit                 >= 1.2.12

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -1,5 +1,5 @@
 name:            persistent-test
-version:         2.13.0.3
+version:         2.14.0.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -75,7 +75,7 @@ library
       , monad-logger             >= 0.3.25
       , mtl
       , path-pieces              >= 0.2
-      , persistent               >= 2.13      && < 2.14
+      , persistent               >= 2.14      && < 2.15
       , QuickCheck               >= 2.9
       , quickcheck-instances     >= 0.3
       , random                   >= 1.1

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -2,6 +2,9 @@
 
 ## 2.14.0.0 (unreleased)
 
+* [#XXXX]()
+    * Add `SqlBackendHooks` to allow for instrumentation of queries.
+
 * [#1327](https://github.com/yesodweb/persistent/pull/1327)
     * Update `SqlBackend` to use new `StatementCache` interface
       instead of `IORef (Map Text Statement)`

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 2.14.0.0 (unreleased)
 
-* [#XXXX]()
+* [#1327](https://github.com/yesodweb/persistent/pull/1327)
     * Update `SqlBackend` to use new `StatementCache` interface
       instead of `IORef (Map Text Statement)`
 

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,6 +1,6 @@
 # Changelog for persistent
 
-## 2.14.0.0
+## 2.14.0.0 (unreleased)
 
 * [#XXXX]()
     * Update `SqlBackend` to use new `StatementCache` interface

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog for persistent
 
+## 2.14.0.0
+
+* [#XXXX]()
+    * Update `SqlBackend` to use new `StatementCache` interface
+      instead of `IORef (Map Text Statement)`
+
 ## 2.13.2.1
 
 * [#1329](https://github.com/yesodweb/persistent/pull/1329)

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 2.14.0.0 (unreleased)
 
-* [#XXXX]()
+* [#1341](https://github.com/yesodweb/persistent/pull/1341)
     * Add `SqlBackendHooks` to allow for instrumentation of queries.
 
 * [#1327](https://github.com/yesodweb/persistent/pull/1327)

--- a/persistent/Database/Persist/Sql/Raw.hs
+++ b/persistent/Database/Persist/Sql/Raw.hs
@@ -1,22 +1,22 @@
 module Database.Persist.Sql.Raw where
 
 import Control.Exception (throwIO)
-import Control.Monad (when, liftM)
+import Control.Monad (liftM, when)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Logger (logDebugNS, runLoggingT)
-import Control.Monad.Reader (ReaderT, ask, MonadReader)
-import Control.Monad.Trans.Resource (MonadResource,release)
-import Data.Acquire (allocateAcquire, Acquire, mkAcquire, with)
+import Control.Monad.Reader (MonadReader, ReaderT, ask)
+import Control.Monad.Trans.Resource (MonadResource, release)
+import Data.Acquire (Acquire, allocateAcquire, mkAcquire, with)
 import Data.Conduit
-import Data.IORef (writeIORef, readIORef, newIORef)
+import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Int (Int64)
 import Data.Text (Text, pack)
 import qualified Data.Text as T
 
 import Database.Persist
+import Database.Persist.Sql.Class
 import Database.Persist.Sql.Types
 import Database.Persist.Sql.Types.Internal
-import Database.Persist.Sql.Class
 import Database.Persist.SqlBackend.Internal.StatementCache
 
 rawQuery :: (MonadResource m, MonadReader env m, BackendCompatible SqlBackend env)

--- a/persistent/Database/Persist/Sql/Raw.hs
+++ b/persistent/Database/Persist/Sql/Raw.hs
@@ -76,7 +76,7 @@ getStmt sql = do
 getStmtConn :: SqlBackend -> Text -> IO Statement
 getStmtConn conn sql = do
     let cacheK = mkCacheKeyFromQuery sql
-    mstmt <- liftIO $ statementCacheLookup (connStmtMap conn) cacheK
+    mstmt <- statementCacheLookup (connStmtMap conn) cacheK
     stmt <- case mstmt of
         Just stmt -> pure stmt
         Nothing -> do

--- a/persistent/Database/Persist/Sql/Raw.hs
+++ b/persistent/Database/Persist/Sql/Raw.hs
@@ -77,8 +77,8 @@ getStmtConn :: SqlBackend -> Text -> IO Statement
 getStmtConn conn sql = do
     let cacheK = mkCacheKeyFromQuery sql
     mstmt <- liftIO $ statementCacheLookup (connStmtMap conn) cacheK
-    case mstmt of
-        Just stmt -> return stmt
+    stmt <- case mstmt of
+        Just stmt -> pure stmt
         Nothing -> do
             stmt' <- liftIO $ connPrepare conn sql
             iactive <- liftIO $ newIORef True
@@ -103,7 +103,8 @@ getStmtConn conn sql = do
                     }
 
             liftIO $ statementCacheInsert (connStmtMap conn) cacheK stmt
-            return stmt
+            pure stmt
+    (hookGetStatement $ connHooks conn) conn sql stmt
 
 -- | Execute a raw SQL statement and return its results as a
 -- list. If you do not expect a return value, use of

--- a/persistent/Database/Persist/Sql/Run.hs
+++ b/persistent/Database/Persist/Sql/Run.hs
@@ -2,7 +2,6 @@
 module Database.Persist.Sql.Run where
 
 import Control.Monad.IO.Unlift
-import qualified UnliftIO.Exception as UE
 import Control.Monad.Logger.CallStack
 import Control.Monad.Reader (MonadReader)
 import qualified Control.Monad.Reader as MonadReader
@@ -11,13 +10,14 @@ import Control.Monad.Trans.Resource
 import Data.Acquire (Acquire, ReleaseType(..), mkAcquireType, with)
 import Data.Pool as P
 import qualified Data.Text as T
+import qualified UnliftIO.Exception as UE
 
 import Database.Persist.Class.PersistStore
+import Database.Persist.Sql.Raw
 import Database.Persist.Sql.Types
 import Database.Persist.Sql.Types.Internal
-import Database.Persist.Sql.Raw
 import Database.Persist.SqlBackend.Internal.StatementCache
-    ( StatementCache(statementCacheClear) )
+       (StatementCache(statementCacheClear))
 
 -- | Get a connection from the pool, run the given action, and then return the
 -- connection to the pool.

--- a/persistent/Database/Persist/Sql/Types.hs
+++ b/persistent/Database/Persist/Sql/Types.hs
@@ -12,9 +12,8 @@ import Control.Exception (Exception(..))
 import Control.Monad.Logger (NoLoggingT)
 import Control.Monad.Trans.Reader (ReaderT(..))
 import Control.Monad.Trans.Resource (ResourceT)
-import Control.Monad.Trans.Writer (WriterT)
 import Data.Pool (Pool)
-import Data.Text (Text, unpack)
+import Data.Text (Text)
 
 import Data.Time (NominalDiffTime)
 import Database.Persist.Sql.Types.Internal

--- a/persistent/Database/Persist/Sql/Types/Internal.hs
+++ b/persistent/Database/Persist/Sql/Types/Internal.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE RankNTypes #-}
-{-# language RecordWildCards #-}
-{-# language DuplicateRecordFields #-}
+{-# LANGUAGE RecordWildCards #-}
 
 -- | Breaking changes to this module are not reflected in the major version
 -- number. Prefer to import from "Database.Persist.Sql" instead. If you neeed
@@ -25,24 +25,28 @@ module Database.Persist.Sql.Types.Internal
     , SqlReadT
     , SqlWriteT
     , IsSqlBackend
+    , SqlBackendHooks (..)
     ) where
 
 import Control.Monad.Trans.Class (lift)
-import Control.Monad.Trans.Reader (ReaderT, runReaderT, ask)
+import Control.Monad.Trans.Reader (ReaderT, ask, runReaderT)
 
 import Database.Persist.Class
-    ( HasPersistBackend (..)
-    , PersistQueryRead, PersistQueryWrite
-    , PersistStoreRead, PersistStoreWrite
-    , PersistUniqueRead, PersistUniqueWrite
-    , BackendCompatible(..)
-    )
-import Database.Persist.Class.PersistStore (IsPersistBackend (..))
+       ( BackendCompatible(..)
+       , HasPersistBackend(..)
+       , PersistQueryRead
+       , PersistQueryWrite
+       , PersistStoreRead
+       , PersistStoreWrite
+       , PersistUniqueRead
+       , PersistUniqueWrite
+       )
+import Database.Persist.Class.PersistStore (IsPersistBackend(..))
 import Database.Persist.SqlBackend.Internal
 import Database.Persist.SqlBackend.Internal.InsertSqlResult
+import Database.Persist.SqlBackend.Internal.IsolationLevel
 import Database.Persist.SqlBackend.Internal.MkSqlBackend
 import Database.Persist.SqlBackend.Internal.Statement
-import Database.Persist.SqlBackend.Internal.IsolationLevel
 
 -- | An SQL backend which can only handle read queries
 --

--- a/persistent/Database/Persist/SqlBackend.hs
+++ b/persistent/Database/Persist/SqlBackend.hs
@@ -13,6 +13,7 @@ module Database.Persist.SqlBackend
     -- $utilities
 
     -- ** SqlBackend Getters
+    , getRDBMS
     , getEscapedFieldName
     , getEscapedRawName
     , getEscapeRawNameFunction
@@ -155,6 +156,17 @@ getConnHooks
     => m SqlBackendHooks
 getConnHooks = do
     asks (SqlBackend.connHooks . projectBackend)
+
+-- | Get a tag displaying what database the 'SqlBackend' is for. Can be
+-- used to differentiate features in downstream libraries for different
+-- database backends.
+-- @since 2.14.0.0
+getRDBMS
+    :: (BackendCompatible SqlBackend backend, MonadReader backend m)
+    => m Text
+getRDBMS = do
+    asks (SqlBackend.connRDBMS . projectBackend)
+
 
 -- | Set the maximum parameters that may be issued in a given SQL query. This
 -- should be used only if the database backend have this limitation.

--- a/persistent/Database/Persist/SqlBackend.hs
+++ b/persistent/Database/Persist/SqlBackend.hs
@@ -142,7 +142,7 @@ getConnUpsertSql = do
 
 -- | Retrieve the vault from the provided database backend.
 --
--- @since 2.13.X.0
+-- @since 2.13.3.0
 getConnVault
     ::  (BackendCompatible SqlBackend backend, MonadReader backend m)
     => m Vault
@@ -151,7 +151,7 @@ getConnVault = do
 
 -- | Retrieve instrumentation hooks from the provided database backend.
 --
--- @since 2.13.X.0
+-- @since 2.13.3.0
 getConnHooks
     ::  (BackendCompatible SqlBackend backend, MonadReader backend m)
     => m SqlBackendHooks
@@ -161,7 +161,7 @@ getConnHooks = do
 -- | Get a tag displaying what database the 'SqlBackend' is for. Can be
 -- used to differentiate features in downstream libraries for different
 -- database backends.
--- @since 2.13.X.0
+-- @since 2.13.3.0
 getRDBMS
     :: (BackendCompatible SqlBackend backend, MonadReader backend m)
     => m Text

--- a/persistent/Database/Persist/SqlBackend.hs
+++ b/persistent/Database/Persist/SqlBackend.hs
@@ -7,6 +7,7 @@ module Database.Persist.SqlBackend
     , mkSqlBackend
     , MkSqlBackendArgs(..)
     , SqlBackendHooks(..)
+    , emptySqlBackendHooks
     -- * Utilities
 
     -- $utilities

--- a/persistent/Database/Persist/SqlBackend.hs
+++ b/persistent/Database/Persist/SqlBackend.hs
@@ -6,7 +6,7 @@ module Database.Persist.SqlBackend
       SqlBackend
     , mkSqlBackend
     , MkSqlBackendArgs(..)
-    , SqlBackendHooks(..)
+    , SqlBackendHooks
     , emptySqlBackendHooks
     -- * Utilities
 
@@ -30,6 +30,7 @@ module Database.Persist.SqlBackend
     , setConnVault
     , modifyConnVault
     , setConnHooks
+    -- ** SqlBackendHooks
     ) where
 
 import Control.Monad.Reader
@@ -141,7 +142,7 @@ getConnUpsertSql = do
 
 -- | Retrieve the vault from the provided database backend.
 --
--- @since 2.14.0.0
+-- @since 2.13.X.0
 getConnVault
     ::  (BackendCompatible SqlBackend backend, MonadReader backend m)
     => m Vault
@@ -150,7 +151,7 @@ getConnVault = do
 
 -- | Retrieve instrumentation hooks from the provided database backend.
 --
--- @since 2.14.0.0
+-- @since 2.13.X.0
 getConnHooks
     ::  (BackendCompatible SqlBackend backend, MonadReader backend m)
     => m SqlBackendHooks
@@ -160,7 +161,7 @@ getConnHooks = do
 -- | Get a tag displaying what database the 'SqlBackend' is for. Can be
 -- used to differentiate features in downstream libraries for different
 -- database backends.
--- @since 2.14.0.0
+-- @since 2.13.X.0
 getRDBMS
     :: (BackendCompatible SqlBackend backend, MonadReader backend m)
     => m Text
@@ -229,21 +230,21 @@ setConnPutManySql  mkQuery sb =
 
 -- | Set the vault on the provided database backend.
 --
--- @since 2.14.0
+-- @since 2.13.0
 setConnVault :: Vault -> SqlBackend -> SqlBackend
 setConnVault vault sb =
     sb { connVault = vault }
 
 -- | Modify the vault on the provided database backend.
 --
--- @since 2.14.0
+-- @since 2.13.0
 modifyConnVault :: (Vault -> Vault) -> SqlBackend  -> SqlBackend
 modifyConnVault f sb =
     sb { connVault = f $ connVault sb }
 
 -- | Set hooks on the provided database backend.
 --
--- @since 2.14.0
+-- @since 2.13.0
 setConnHooks :: SqlBackendHooks -> SqlBackend -> SqlBackend
 setConnHooks hooks sb =
     sb { connHooks = hooks }

--- a/persistent/Database/Persist/SqlBackend/Internal.hs
+++ b/persistent/Database/Persist/SqlBackend/Internal.hs
@@ -14,6 +14,7 @@ import Database.Persist.SqlBackend.Internal.IsolationLevel
 import Database.Persist.SqlBackend.Internal.MkSqlBackend
 import Database.Persist.SqlBackend.Internal.Statement
 import Database.Persist.SqlBackend.Internal.StatementCache (StatementCache)
+import Database.Persist.SqlBackend.StatementCache
 import Database.Persist.Types.Base
 
 -- | A 'SqlBackend' represents a handle or connection to a database. It
@@ -166,6 +167,7 @@ mkSqlBackend MkSqlBackendArgs {..} =
         , connInsertManySql = Nothing
         , connVault = Vault.empty
         , connHooks = emptySqlBackendHooks
+        , connStmtMap = mkStatementCache $ mkSimpleStatementCache connStmtMap
         , ..
         }
 

--- a/persistent/Database/Persist/SqlBackend/Internal.hs
+++ b/persistent/Database/Persist/SqlBackend/Internal.hs
@@ -14,6 +14,7 @@ import Database.Persist.SqlBackend.Internal.MkSqlBackend
 import Database.Persist.SqlBackend.Internal.Statement
 import Database.Persist.SqlBackend.Internal.InsertSqlResult
 import Database.Persist.SqlBackend.Internal.IsolationLevel
+import Database.Persist.SqlBackend.Internal.StatementCache (StatementCache)
 
 -- | A 'SqlBackend' represents a handle or connection to a database. It
 -- contains functions and values that allow databases to have more
@@ -69,7 +70,7 @@ data SqlBackend = SqlBackend
     -- When left as 'Nothing', we default to using 'defaultPutMany'.
     --
     -- @since 2.8.1
-    , connStmtMap :: IORef (Map Text Statement)
+    , connStmtMap :: StatementCache
     -- ^ A reference to the cache of statements. 'Statement's are keyed by
     -- the 'Text' queries that generated them.
     , connClose :: IO ()

--- a/persistent/Database/Persist/SqlBackend/Internal.hs
+++ b/persistent/Database/Persist/SqlBackend/Internal.hs
@@ -1,20 +1,20 @@
-{-# language RecordWildCards #-}
-{-# language RankNTypes #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Database.Persist.SqlBackend.Internal where
 
-import Data.Map (Map)
+import Data.IORef
 import Data.List.NonEmpty (NonEmpty)
+import Data.Map (Map)
 import Data.Text (Text)
 import Database.Persist.Class.PersistStore
-import Database.Persist.Types.Base
 import Database.Persist.Names
-import Data.IORef
-import Database.Persist.SqlBackend.Internal.MkSqlBackend
-import Database.Persist.SqlBackend.Internal.Statement
 import Database.Persist.SqlBackend.Internal.InsertSqlResult
 import Database.Persist.SqlBackend.Internal.IsolationLevel
+import Database.Persist.SqlBackend.Internal.MkSqlBackend
+import Database.Persist.SqlBackend.Internal.Statement
 import Database.Persist.SqlBackend.Internal.StatementCache (StatementCache)
+import Database.Persist.Types.Base
 
 -- | A 'SqlBackend' represents a handle or connection to a database. It
 -- contains functions and values that allow databases to have more

--- a/persistent/Database/Persist/SqlBackend/Internal/MkSqlBackend.hs
+++ b/persistent/Database/Persist/SqlBackend/Internal/MkSqlBackend.hs
@@ -3,14 +3,13 @@
 module Database.Persist.SqlBackend.Internal.MkSqlBackend where
 
 import Control.Monad.Logger (Loc, LogLevel, LogSource, LogStr)
-import Data.IORef
-import Data.Map (Map)
 import Data.Text (Text)
 import Database.Persist.SqlBackend.Internal.Statement
 import Database.Persist.SqlBackend.Internal.InsertSqlResult
 import Database.Persist.SqlBackend.Internal.IsolationLevel
 import Database.Persist.Types.Base
 import Database.Persist.Names
+import Database.Persist.SqlBackend.Internal.StatementCache
 
 -- | This type shares many of the same field names as the 'SqlBackend' type.
 -- It's useful for library authors to use this when migrating from using the
@@ -28,7 +27,7 @@ data MkSqlBackendArgs = MkSqlBackendArgs
     , connInsertSql :: EntityDef -> [PersistValue] -> InsertSqlResult
     -- ^ This function generates the SQL and values necessary for
     -- performing an insert against the database.
-    , connStmtMap :: IORef (Map Text Statement)
+    , connStmtMap :: StatementCache
     -- ^ A reference to the cache of statements. 'Statement's are keyed by
     -- the 'Text' queries that generated them.
     , connClose :: IO ()

--- a/persistent/Database/Persist/SqlBackend/Internal/MkSqlBackend.hs
+++ b/persistent/Database/Persist/SqlBackend/Internal/MkSqlBackend.hs
@@ -4,12 +4,12 @@ module Database.Persist.SqlBackend.Internal.MkSqlBackend where
 
 import Control.Monad.Logger (Loc, LogLevel, LogSource, LogStr)
 import Data.Text (Text)
-import Database.Persist.SqlBackend.Internal.Statement
+import Database.Persist.Names
 import Database.Persist.SqlBackend.Internal.InsertSqlResult
 import Database.Persist.SqlBackend.Internal.IsolationLevel
-import Database.Persist.Types.Base
-import Database.Persist.Names
+import Database.Persist.SqlBackend.Internal.Statement
 import Database.Persist.SqlBackend.Internal.StatementCache
+import Database.Persist.Types.Base
 
 -- | This type shares many of the same field names as the 'SqlBackend' type.
 -- It's useful for library authors to use this when migrating from using the

--- a/persistent/Database/Persist/SqlBackend/Internal/MkSqlBackend.hs
+++ b/persistent/Database/Persist/SqlBackend/Internal/MkSqlBackend.hs
@@ -8,8 +8,9 @@ import Database.Persist.Names
 import Database.Persist.SqlBackend.Internal.InsertSqlResult
 import Database.Persist.SqlBackend.Internal.IsolationLevel
 import Database.Persist.SqlBackend.Internal.Statement
-import Database.Persist.SqlBackend.Internal.StatementCache
 import Database.Persist.Types.Base
+import Data.Map (Map)
+import Data.IORef (IORef)
 
 -- | This type shares many of the same field names as the 'SqlBackend' type.
 -- It's useful for library authors to use this when migrating from using the
@@ -27,7 +28,7 @@ data MkSqlBackendArgs = MkSqlBackendArgs
     , connInsertSql :: EntityDef -> [PersistValue] -> InsertSqlResult
     -- ^ This function generates the SQL and values necessary for
     -- performing an insert against the database.
-    , connStmtMap :: StatementCache
+    , connStmtMap :: IORef (Map Text Statement)
     -- ^ A reference to the cache of statements. 'Statement's are keyed by
     -- the 'Text' queries that generated them.
     , connClose :: IO ()

--- a/persistent/Database/Persist/SqlBackend/Internal/SqlPoolHooks.hs
+++ b/persistent/Database/Persist/SqlBackend/Internal/SqlPoolHooks.hs
@@ -1,0 +1,21 @@
+module Database.Persist.SqlBackend.Internal.SqlPoolHooks
+  ( SqlPoolHooks(..)
+  ) where
+import Control.Exception (SomeException)
+import Database.Persist.SqlBackend.Internal.IsolationLevel
+
+-- | A set of hooks that may be used to alter the behaviour
+-- of @runSqlPoolWithExtensibleHooks@ in a backwards-compatible
+-- fashion.
+data SqlPoolHooks m backend = SqlPoolHooks
+    { alterBackend :: backend -> m backend
+    -- ^ Alter the backend prior to executing any actions with it.
+    , runBefore :: backend -> Maybe IsolationLevel -> m ()
+    -- ^ Run this action immediately before the action is performed.
+    , runAfter :: backend -> Maybe IsolationLevel -> m ()
+    -- ^ Run this action immediately after the action is completed.
+    , runOnException :: backend -> Maybe IsolationLevel -> SomeException -> m ()
+    -- ^ This action is performed when an exception is received. The
+    -- exception is provided as a convenience - it is rethrown once this
+    -- cleanup function is complete.
+    }

--- a/persistent/Database/Persist/SqlBackend/Internal/StatementCache.hs
+++ b/persistent/Database/Persist/SqlBackend/Internal/StatementCache.hs
@@ -1,0 +1,23 @@
+module Database.Persist.SqlBackend.Internal.StatementCache where
+
+import Data.Text (Text)
+import Database.Persist.SqlBackend.Internal.Statement
+
+-- | A statement cache used to lookup statements that have already been prepared
+-- for a given query.
+--
+-- @since 2.14.0
+data StatementCache = StatementCache
+    { statementCacheLookup :: StatementCacheKey -> IO (Maybe Statement)
+    , statementCacheInsert :: StatementCacheKey -> Statement -> IO ()
+    , statementCacheClear :: IO ()
+    , statementCacheSize :: IO Int
+    }
+
+newtype StatementCacheKey = StatementCacheKey { cacheKey :: Text }
+-- Wrapping around this to allow for more efficient keying mechanisms
+-- in the future, perhaps.
+
+-- | Construct a `StatementCacheKey` from a raw SQL query.
+mkCacheKeyFromQuery :: Text -> StatementCacheKey
+mkCacheKeyFromQuery = StatementCacheKey

--- a/persistent/Database/Persist/SqlBackend/Internal/StatementCache.hs
+++ b/persistent/Database/Persist/SqlBackend/Internal/StatementCache.hs
@@ -6,7 +6,7 @@ import Database.Persist.SqlBackend.Internal.Statement
 -- | A statement cache used to lookup statements that have already been prepared
 -- for a given query.
 --
--- @since 2.14.0
+-- @since 2.13.X
 data StatementCache = StatementCache
     { statementCacheLookup :: StatementCacheKey -> IO (Maybe Statement)
     , statementCacheInsert :: StatementCacheKey -> Statement -> IO ()

--- a/persistent/Database/Persist/SqlBackend/Internal/StatementCache.hs
+++ b/persistent/Database/Persist/SqlBackend/Internal/StatementCache.hs
@@ -6,7 +6,7 @@ import Database.Persist.SqlBackend.Internal.Statement
 -- | A statement cache used to lookup statements that have already been prepared
 -- for a given query.
 --
--- @since 2.13.X
+-- @since 2.13.3
 data StatementCache = StatementCache
     { statementCacheLookup :: StatementCacheKey -> IO (Maybe Statement)
     , statementCacheInsert :: StatementCacheKey -> Statement -> IO ()

--- a/persistent/Database/Persist/SqlBackend/SqlPoolHooks.hs
+++ b/persistent/Database/Persist/SqlBackend/SqlPoolHooks.hs
@@ -1,0 +1,92 @@
+module Database.Persist.SqlBackend.SqlPoolHooks
+  ( SqlPoolHooks
+  , defaultSqlPoolHooks
+  , getAlterBackend
+  , modifyAlterBackend
+  , setAlterBackend
+  , getRunBefore
+  , modifyRunBefore
+  , setRunBefore
+  , getRunAfter
+  , modifyRunAfter
+  , setRunAfter
+  , getRunOnException
+  )
+  where
+
+import Control.Exception
+import Control.Monad.IO.Class
+import Database.Persist.Sql.Raw
+import Database.Persist.SqlBackend.Internal
+import Database.Persist.SqlBackend.Internal.SqlPoolHooks
+import Database.Persist.SqlBackend.Internal.IsolationLevel
+import Database.Persist.Class.PersistStore
+
+-- | Lifecycle hooks that may be altered to extend SQL pool behavior
+-- in a backwards compatible fashion.
+--
+-- By default, the hooks have the following semantics:
+--
+-- - 'alterBackend' has no effect
+-- - 'runBefore' begins a transaction
+-- - 'runAfter' commits the current transaction
+-- - 'runOnException' rolls back the current transaction
+--
+-- @since 2.13.X.0
+defaultSqlPoolHooks :: (MonadIO m, BackendCompatible SqlBackend backend) => SqlPoolHooks m backend
+defaultSqlPoolHooks = SqlPoolHooks
+    { alterBackend = pure
+    , runBefore = \conn mi -> do
+        let sqlBackend = projectBackend conn
+        let getter = getStmtConn sqlBackend
+        liftIO $ connBegin sqlBackend getter mi
+    , runAfter = \conn _ -> do
+        let sqlBackend = projectBackend conn
+        let getter = getStmtConn sqlBackend
+        liftIO $ connCommit sqlBackend getter
+    , runOnException = \conn _ _ -> do
+        let sqlBackend = projectBackend conn
+        let getter = getStmtConn sqlBackend
+        liftIO $ connRollback sqlBackend getter
+    }
+
+getAlterBackend :: SqlPoolHooks m backend -> (backend -> m backend)
+getAlterBackend = alterBackend
+
+modifyAlterBackend :: SqlPoolHooks m backend -> ((backend -> m backend) -> (backend -> m backend)) -> SqlPoolHooks m backend
+modifyAlterBackend hooks f = hooks { alterBackend = f $ alterBackend hooks }
+
+setAlterBackend :: SqlPoolHooks m backend -> (backend -> m backend) -> SqlPoolHooks m backend
+setAlterBackend hooks f = hooks { alterBackend = f }
+
+
+getRunBefore :: SqlPoolHooks m backend -> (backend -> Maybe IsolationLevel -> m ())
+getRunBefore = runBefore
+
+modifyRunBefore :: SqlPoolHooks m backend -> ((backend -> Maybe IsolationLevel -> m ()) -> (backend -> Maybe IsolationLevel -> m ())) -> SqlPoolHooks m backend
+modifyRunBefore hooks f = hooks { runBefore = f $ runBefore hooks }
+
+setRunBefore :: SqlPoolHooks m backend -> (backend -> Maybe IsolationLevel -> m ()) -> SqlPoolHooks m backend
+setRunBefore h f = h { runBefore = f }
+
+
+getRunAfter :: SqlPoolHooks m backend -> (backend -> Maybe IsolationLevel -> m ())
+getRunAfter = runAfter
+
+modifyRunAfter :: SqlPoolHooks m backend -> ((backend -> Maybe IsolationLevel -> m ()) -> (backend -> Maybe IsolationLevel -> m ())) -> SqlPoolHooks m backend
+modifyRunAfter hooks f = hooks { runAfter = f $ runAfter hooks }
+
+setRunAfter :: SqlPoolHooks m backend -> (backend -> Maybe IsolationLevel -> m ()) -> SqlPoolHooks m backend
+setRunAfter hooks f = hooks { runAfter = f }
+
+
+getRunOnException :: SqlPoolHooks m backend -> (backend -> Maybe IsolationLevel -> SomeException -> m ())
+getRunOnException = runOnException
+
+modifyRunOnException :: SqlPoolHooks m backend -> ((backend -> Maybe IsolationLevel -> SomeException -> m ()) -> (backend -> Maybe IsolationLevel -> SomeException -> m ())) -> SqlPoolHooks m backend
+modifyRunOnException hooks f = hooks { runOnException = f $ runOnException hooks }
+
+setRunOnException :: SqlPoolHooks m backend -> (backend -> Maybe IsolationLevel -> SomeException -> m ()) -> SqlPoolHooks m backend
+setRunOnException hooks f = hooks { runOnException = f }
+
+

--- a/persistent/Database/Persist/SqlBackend/SqlPoolHooks.hs
+++ b/persistent/Database/Persist/SqlBackend/SqlPoolHooks.hs
@@ -32,7 +32,7 @@ import Database.Persist.Class.PersistStore
 -- - 'runAfter' commits the current transaction
 -- - 'runOnException' rolls back the current transaction
 --
--- @since 2.13.X.0
+-- @since 2.13.3.0
 defaultSqlPoolHooks :: (MonadIO m, BackendCompatible SqlBackend backend) => SqlPoolHooks m backend
 defaultSqlPoolHooks = SqlPoolHooks
     { alterBackend = pure

--- a/persistent/Database/Persist/SqlBackend/StatementCache.hs
+++ b/persistent/Database/Persist/SqlBackend/StatementCache.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE RecordWildCards #-}
+module Database.Persist.SqlBackend.StatementCache
+  ( StatementCache
+  , StatementCacheKey
+  , mkCacheKeyFromQuery
+  , MkStatementCache(..)
+  , mkSimpleStatementCache
+  , mkStatementCache
+  ) where
+
+import Data.Foldable
+import Data.IORef
+import qualified Data.Map as Map
+import Database.Persist.SqlBackend.Internal.Statement
+import Database.Persist.SqlBackend.Internal.StatementCache
+
+-- | Configuration parameters for creating a custom statement cache
+--
+-- @since 2.14.0
+data MkStatementCache = MkStatementCache
+  { statementCacheLookup :: StatementCacheKey -> IO (Maybe Statement)
+  -- ^ Retrieve a statement from the cache, or return nothing if it is not found.
+  --
+  -- @since 2.14.0
+  , statementCacheInsert :: StatementCacheKey -> Statement -> IO ()
+  -- ^ Put a new statement into the cache. An immediate lookup of
+  -- the statement MUST return the inserted statement for the given
+  -- cache key. Depending on the implementation, the statement cache MAY
+  -- choose to evict other statements from the cache within this function.
+  --
+  -- @since 2.14.0
+  , statementCacheClear :: IO ()
+  -- ^ Remove all statements from the cache. Implementations of this
+  -- should be sure to call `stmtFinalize` on all statements removed
+  -- from the cache.
+  --
+  -- @since 2.14.0
+  , statementCacheSize :: IO Int
+  -- ^ Get the current size of the cache.
+  --
+  -- @since 2.14.0
+  }
+
+
+-- | Make a simple statement cache that will cache statements if they are not currently cached.
+--
+-- @since 2.14.0
+mkSimpleStatementCache :: IO MkStatementCache
+mkSimpleStatementCache = do
+    stmtMap <- newIORef Map.empty
+    pure $ MkStatementCache
+        { statementCacheLookup = \sql -> Map.lookup (cacheKey sql) <$> readIORef stmtMap
+        , statementCacheInsert = \sql stmt ->
+            modifyIORef' stmtMap (Map.insert (cacheKey sql) stmt)
+        , statementCacheClear = do
+            oldStatements <- atomicModifyIORef' stmtMap (\oldStatements -> (Map.empty, oldStatements))
+            traverse_ stmtFinalize oldStatements
+        , statementCacheSize = Map.size <$> readIORef stmtMap
+        }
+
+-- | Create a statement cache.
+--
+-- @since 2.13.0
+mkStatementCache :: MkStatementCache -> StatementCache
+mkStatementCache MkStatementCache{..} = StatementCache { .. }

--- a/persistent/Database/Persist/SqlBackend/StatementCache.hs
+++ b/persistent/Database/Persist/SqlBackend/StatementCache.hs
@@ -18,35 +18,35 @@ import Data.Text (Text)
 
 -- | Configuration parameters for creating a custom statement cache
 --
--- @since 2.13.X
+-- @since 2.13.3
 data MkStatementCache = MkStatementCache
     { statementCacheLookup :: StatementCacheKey -> IO (Maybe Statement)
     -- ^ Retrieve a statement from the cache, or return nothing if it is not found.
     --
-    -- @since 2.13.X
+    -- @since 2.13.3
     , statementCacheInsert :: StatementCacheKey -> Statement -> IO ()
     -- ^ Put a new statement into the cache. An immediate lookup of
     -- the statement MUST return the inserted statement for the given
     -- cache key. Depending on the implementation, the statement cache MAY
     -- choose to evict other statements from the cache within this function.
     --
-    -- @since 2.13.X
+    -- @since 2.13.3
     , statementCacheClear :: IO ()
     -- ^ Remove all statements from the cache. Implementations of this
     -- should be sure to call `stmtFinalize` on all statements removed
     -- from the cache.
     --
-    -- @since 2.13.X
+    -- @since 2.13.3
     , statementCacheSize :: IO Int
     -- ^ Get the current size of the cache.
     --
-    -- @since 2.13.X
+    -- @since 2.13.3
     }
 
 
 -- | Make a simple statement cache that will cache statements if they are not currently cached.
 --
--- @since 2.13.X
+-- @since 2.13.3
 mkSimpleStatementCache :: IORef (Map Text Statement) -> MkStatementCache
 mkSimpleStatementCache stmtMap =
     MkStatementCache

--- a/persistent/Database/Persist/SqlBackend/StatementCache.hs
+++ b/persistent/Database/Persist/SqlBackend/StatementCache.hs
@@ -13,42 +13,43 @@ import Data.IORef
 import qualified Data.Map as Map
 import Database.Persist.SqlBackend.Internal.Statement
 import Database.Persist.SqlBackend.Internal.StatementCache
+import Data.Map (Map)
+import Data.Text (Text)
 
 -- | Configuration parameters for creating a custom statement cache
 --
--- @since 2.14.0
+-- @since 2.13.X
 data MkStatementCache = MkStatementCache
-  { statementCacheLookup :: StatementCacheKey -> IO (Maybe Statement)
-  -- ^ Retrieve a statement from the cache, or return nothing if it is not found.
-  --
-  -- @since 2.14.0
-  , statementCacheInsert :: StatementCacheKey -> Statement -> IO ()
-  -- ^ Put a new statement into the cache. An immediate lookup of
-  -- the statement MUST return the inserted statement for the given
-  -- cache key. Depending on the implementation, the statement cache MAY
-  -- choose to evict other statements from the cache within this function.
-  --
-  -- @since 2.14.0
-  , statementCacheClear :: IO ()
-  -- ^ Remove all statements from the cache. Implementations of this
-  -- should be sure to call `stmtFinalize` on all statements removed
-  -- from the cache.
-  --
-  -- @since 2.14.0
-  , statementCacheSize :: IO Int
-  -- ^ Get the current size of the cache.
-  --
-  -- @since 2.14.0
-  }
+    { statementCacheLookup :: StatementCacheKey -> IO (Maybe Statement)
+    -- ^ Retrieve a statement from the cache, or return nothing if it is not found.
+    --
+    -- @since 2.13.X
+    , statementCacheInsert :: StatementCacheKey -> Statement -> IO ()
+    -- ^ Put a new statement into the cache. An immediate lookup of
+    -- the statement MUST return the inserted statement for the given
+    -- cache key. Depending on the implementation, the statement cache MAY
+    -- choose to evict other statements from the cache within this function.
+    --
+    -- @since 2.13.X
+    , statementCacheClear :: IO ()
+    -- ^ Remove all statements from the cache. Implementations of this
+    -- should be sure to call `stmtFinalize` on all statements removed
+    -- from the cache.
+    --
+    -- @since 2.13.X
+    , statementCacheSize :: IO Int
+    -- ^ Get the current size of the cache.
+    --
+    -- @since 2.13.X
+    }
 
 
 -- | Make a simple statement cache that will cache statements if they are not currently cached.
 --
--- @since 2.14.0
-mkSimpleStatementCache :: IO MkStatementCache
-mkSimpleStatementCache = do
-    stmtMap <- newIORef Map.empty
-    pure $ MkStatementCache
+-- @since 2.13.X
+mkSimpleStatementCache :: IORef (Map Text Statement) -> MkStatementCache
+mkSimpleStatementCache stmtMap =
+    MkStatementCache
         { statementCacheLookup = \sql -> Map.lookup (cacheKey sql) <$> readIORef stmtMap
         , statementCacheInsert = \sql stmt ->
             modifyIORef' stmtMap (Map.insert (cacheKey sql) stmt)

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -74,9 +74,11 @@ library
 
         Database.Persist.SqlBackend
         Database.Persist.SqlBackend.StatementCache
+        Database.Persist.SqlBackend.SqlPoolHooks
         Database.Persist.SqlBackend.Internal
         Database.Persist.SqlBackend.Internal.InsertSqlResult
         Database.Persist.SqlBackend.Internal.IsolationLevel
+        Database.Persist.SqlBackend.Internal.SqlPoolHooks
         Database.Persist.SqlBackend.Internal.Statement
         Database.Persist.SqlBackend.Internal.StatementCache
         Database.Persist.SqlBackend.Internal.MkSqlBackend

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -42,6 +42,7 @@ library
       , unliftio
       , unliftio-core
       , unordered-containers
+      , vault
       , vector
 
     default-extensions: 

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -72,10 +72,12 @@ library
         Database.Persist.Sql.Util
 
         Database.Persist.SqlBackend
+        Database.Persist.SqlBackend.StatementCache
         Database.Persist.SqlBackend.Internal
         Database.Persist.SqlBackend.Internal.InsertSqlResult
         Database.Persist.SqlBackend.Internal.IsolationLevel
         Database.Persist.SqlBackend.Internal.Statement
+        Database.Persist.SqlBackend.Internal.StatementCache
         Database.Persist.SqlBackend.Internal.MkSqlBackend
 
         Database.Persist.Class

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:            persistent
-version:         2.13.3.2
+version:         2.13.3.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:            persistent
-version:         2.13.2.1
+version:         2.14.0.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
This PR builds on top of https://github.com/yesodweb/persistent/pull/1327

It adds support for hooking into various aspects of the lifecycle of a connection / statements. This functionality opens up support for tracing queries within the context of a larger chunk of code: 
![image](https://user-images.githubusercontent.com/69209/142637348-f8922d4b-1e3d-43ef-8ec5-88614d5c2187.png)

To see how this is being used, see the hs-opentelemetry project: https://github.com/iand675/hs-opentelemetry/blob/main/instrumentation/persistent/src/OpenTelemetry/Instrumentation/Persistent.hs

Before submitting your PR, check that you've:

- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [x] Ran `stylish-haskell` on any changed files.
- [x] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
