### PR TITLE
Remove SomePersistField

### DIFF
--- a/persistent/Database/Persist/Class/PersistEntity.hs
+++ b/persistent/Database/Persist/Class/PersistEntity.hs
@@ -106,7 +106,7 @@ class ( PersistField (Key record), ToJSON (Key record), FromJSON (Key record)
     -- | Return meta-data for a given 'EntityField'.
     persistFieldDef :: EntityField record typ -> FieldDef
     -- | A meta-operation to get the database fields of a record.
-    toPersistFields :: record -> [SomePersistField]
+    toPersistFields :: record -> [PersistValue]
     -- | A lower-level operation to convert from database values to a Haskell record.
     fromPersistValues :: [PersistValue] -> Either Text record
 

--- a/persistent/Database/Persist/Class/PersistField.hs
+++ b/persistent/Database/Persist/Class/PersistField.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE PatternGuards, DataKinds, TypeOperators, UndecidableInstances, GeneralizedNewtypeDeriving #-}
 module Database.Persist.Class.PersistField
     ( PersistField (..)
-    , SomePersistField (..)
     , getPersistMap
     , OverflowNatural(..)
     ) where
@@ -446,11 +445,6 @@ getPersistMap (PersistByteString bs)
     | Just pairs <- A.decode' (L.fromChunks [bs]) = Right pairs
 getPersistMap PersistNull = Right []
 getPersistMap x = Left $ fromPersistValueError "[(Text, PersistValue)]" "map, string, bytestring or null" x
-
-data SomePersistField = forall a. (PersistField a) => SomePersistField a
-instance PersistField SomePersistField where
-    toPersistValue (SomePersistField a) = toPersistValue a
-    fromPersistValue x = fmap SomePersistField (fromPersistValue x :: Either Text Text)
 
 instance PersistField Checkmark where
     toPersistValue Active   = PersistBool True

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -1285,7 +1285,7 @@ mkToPersistFields mps ed = do
         xs <- sequence $ replicate fieldCount $ newName "x"
         let name = mkEntityDefName ed
             pat = ConP name $ fmap VarP xs
-        sp <- [|SomePersistField|]
+        sp <- [|toPersistValue|]
         let bod = ListE $ fmap (AppE sp . VarE) xs
         return $ normalClause [pat] bod
 
@@ -1294,13 +1294,13 @@ mkToPersistFields mps ed = do
     goSum :: UnboundFieldDef -> Int -> Q Clause
     goSum fieldDef idx = do
         let name = sumConstrName mps ed fieldDef
-        enull <- [|SomePersistField PersistNull|]
+        enull <- [|PersistNull|]
         let beforeCount = idx - 1
             afterCount = fieldCount - idx
             before = replicate beforeCount enull
             after = replicate afterCount enull
         x <- newName "x"
-        sp <- [|SomePersistField|]
+        sp <- [|toPersistValue|]
         let body = ListE $ mconcat
                 [ before
                 , [sp `AppE` VarE x]

--- a/persistent/Database/Persist/Types.hs
+++ b/persistent/Database/Persist/Types.hs
@@ -24,7 +24,6 @@ module Database.Persist.Types
     -- database and Haskell types.
     , module Database.Persist.PersistValue
     -- * Other Useful Stuff
-    , SomePersistField (..)
     , Update (..)
     , BackendSpecificUpdate
     , SelectOpt (..)

--- a/persistent/test/Database/Persist/TH/MigrationOnlySpec.hs
+++ b/persistent/test/Database/Persist/TH/MigrationOnlySpec.hs
@@ -55,7 +55,7 @@ spec = describe "MigrationOnlySpec" $ do
             it "should have one field" $ do
                 map toPersistValue (toPersistFields (HasMigrationOnly "asdf"))
                     `shouldBe`
-                        map toPersistValue [SomePersistField ("asdf" :: Text)]
+                        [PersistText ("asdf" :: Text)]
         describe "fromPersistValues" $ do
             it "should work with only item in list" $ do
                 fromPersistValues [PersistText "Hello"]


### PR DESCRIPTION
# Issue

`SomePersistField` exists only to convert to `PersistValue`. Furthermore, we end up with a type-class instance with unexpected behavior due to how `fromPersistValue` works. 

# Solution

We can replace `SomePersistValue` with `PersistValue` directly.

After submitting your PR:

# TODO For Author

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)