### PR TITLE
Add `BackendCompatible (RawPostgresql b) (RawPostgresql b)` instance.

### DIFF
--- a/persistent-postgresql/ChangeLog.md
+++ b/persistent-postgresql/ChangeLog.md
@@ -1,6 +1,6 @@
 # Changelog for persistent-postgresql
 
-## 2.13.2.2
+## 2.13.3.0
 
 * [#1349](https://github.com/yesodweb/persistent/pull/1349)
     * Add `BackendCompatible (RawPostgresql b) (RawPostgresql b)` instance.

--- a/persistent-postgresql/ChangeLog.md
+++ b/persistent-postgresql/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for persistent-postgresql
 
+## 2.13.2.2
+
+* [#1349](https://github.com/yesodweb/persistent/pull/1349)
+    * Add `BackendCompatible (RawPostgresql b) (RawPostgresql b)` instance.
+
 ## 2.13.2.1
 
 * [#1331](https://github.com/yesodweb/persistent/pull/1331)

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -1838,6 +1838,9 @@ data RawPostgresql backend = RawPostgresql
     -- @since 2.13.1.0
     }
 
+instance BackendCompatible (RawPostgresql b) (RawPostgresql b) where
+    projectBackend = id
+
 instance BackendCompatible b (RawPostgresql b) where
     projectBackend = persistentBackend
 

--- a/persistent-postgresql/persistent-postgresql.cabal
+++ b/persistent-postgresql/persistent-postgresql.cabal
@@ -1,5 +1,5 @@
 name:            persistent-postgresql
-version:         2.13.2.2
+version:         2.13.3.0
 license:         MIT
 license-file:    LICENSE
 author:          Felipe Lessa, Michael Snoyman <michael@snoyman.com>

--- a/persistent-postgresql/persistent-postgresql.cabal
+++ b/persistent-postgresql/persistent-postgresql.cabal
@@ -1,5 +1,5 @@
 name:            persistent-postgresql
-version:         2.13.2.1
+version:         2.13.2.2
 license:         MIT
 license-file:    LICENSE
 author:          Felipe Lessa, Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
Similar to like we have `BackendCompatible SqlBackend SqlBackend`. I had to add this one as an orphan in a project using `persistent-postgresql-streaming`, so thought it might be useful here.