### PR TITLE
aeson 2.0 support (only)

### DIFF
--- a/persistent-postgresql/test/JSONTest.hs
+++ b/persistent-postgresql/test/JSONTest.hs
@@ -16,7 +16,7 @@
 module JSONTest where
 
 import Control.Monad.IO.Class (MonadIO)
-import Data.Aeson
+import Data.Aeson hiding (Key)
 import qualified Data.Vector as V (fromList)
 import Test.HUnit (assertBool)
 import Test.Hspec.Expectations ()

--- a/persistent-postgresql/test/PgInit.hs
+++ b/persistent-postgresql/test/PgInit.hs
@@ -68,7 +68,7 @@ import Init
 import Control.Exception (SomeException)
 import Control.Monad (forM_, liftM, replicateM, void, when)
 import Control.Monad.Trans.Reader
-import Data.Aeson (ToJSON, FromJSON, Value(..))
+import Data.Aeson (ToJSON, FromJSON, Value(..), object)
 import Database.Persist.Postgresql.JSON ()
 import Database.Persist.Sql.Raw.QQ
 import Database.Persist.SqlBackend
@@ -210,13 +210,12 @@ instance Arbitrary Value where
                         , (2, Number <$> arbitrary)
                         , (2, String <$> arbText)
                         , (3, Array <$> limitIt 4 arbitrary)
-                        , (3, Object <$> arbObject)
+                        , (3, object <$> arbObject)
                         ]
     where limitIt i x = sized $ \n -> do
             let m = if n > i then i else n
             resize m x
           arbObject = limitIt 4 -- Recursion can make execution divergent
-                    $ fmap HM.fromList -- HashMap -> [(,)]
-                    . listOf -- [(,)] -> (,)
+                    $ listOf -- [(,)] -> (,)
                     . liftA2 (,) arbText -- (,) -> Text and Value
                     $ limitIt 4 arbitrary -- Again, precaution against divergent recursion.

--- a/persistent-postgresql/test/PgInit.hs
+++ b/persistent-postgresql/test/PgInit.hs
@@ -27,6 +27,7 @@ module PgInit
     , module Test.Hspec
     , module Test.Hspec.Expectations.Lifted
     , module Test.HUnit
+    , AValue (..)
     , BS.ByteString
     , Int32, Int64
     , liftIO
@@ -117,6 +118,7 @@ import Data.Int (Int32, Int64)
 import Data.Maybe (fromMaybe)
 import Data.Monoid ((<>))
 import Data.Text (Text)
+import Data.Vector (Vector)
 import System.Environment (getEnvironment)
 import System.Log.FastLogger (fromLogStr)
 
@@ -204,18 +206,24 @@ runConnAssertUseConf :: SqlPersistT (LoggingT (ResourceT IO)) () -> Assertion
 runConnAssertUseConf actions = do
   runResourceT $ runConnInternal RunConnConf (actions >> transactionUndo)
 
-instance Arbitrary Value where
-  arbitrary = frequency [ (1, pure Null)
+newtype AValue = AValue { getValue :: Value }
+
+-- Need a specialized Arbitrary instance
+instance Arbitrary AValue where
+  arbitrary = AValue <$>
+              frequency [ (1, pure Null)
                         , (1, Bool <$> arbitrary)
                         , (2, Number <$> arbitrary)
                         , (2, String <$> arbText)
-                        , (3, Array <$> limitIt 4 arbitrary)
+                        , (3, Array <$> limitIt 4 (fmap (fmap getValue) arbitrary))
                         , (3, object <$> arbObject)
                         ]
-    where limitIt i x = sized $ \n -> do
-            let m = if n > i then i else n
-            resize m x
-          arbObject = limitIt 4 -- Recursion can make execution divergent
-                    $ listOf -- [(,)] -> (,)
-                    . liftA2 (,) arbText -- (,) -> Text and Value
-                    $ limitIt 4 arbitrary -- Again, precaution against divergent recursion.
+    where
+      limitIt :: Int -> Gen a -> Gen a
+      limitIt i x = sized $ \n -> do
+          let m = if n > i then i else n
+          resize m x
+      arbObject = limitIt 4 -- Recursion can make execution divergent
+                $ listOf -- [(,)] -> (,)
+                . liftA2 (,) arbText -- (,) -> Text and Value
+                $ limitIt 4 (fmap getValue arbitrary) -- Again, precaution against divergent recursion.

--- a/persistent-postgresql/test/main.hs
+++ b/persistent-postgresql/test/main.hs
@@ -99,7 +99,7 @@ instance Arbitrary DataTypeTable where
      <*> arbitrary              -- pico
      <*> (arbitrary) -- utc
      <*> (truncateUTCTime   =<< arbitrary) -- utc
-     <*> arbitrary              -- value
+     <*> fmap getValue arbitrary -- value
 
 setup :: MonadIO m => Migration -> ReaderT SqlBackend m ()
 setup migration = do

--- a/persistent-qq/test/PersistentTestModels.hs
+++ b/persistent-qq/test/PersistentTestModels.hs
@@ -15,7 +15,7 @@
 module PersistentTestModels where
 
 import Control.Monad.Reader
-import Data.Aeson
+import Data.Aeson hiding (Key)
 import Data.Proxy
 import Data.Text (Text)
 

--- a/persistent-test/src/Init.hs
+++ b/persistent-test/src/Init.hs
@@ -74,6 +74,7 @@ import Control.Monad.Reader
 import Data.Char (GeneralCategory(..), generalCategory)
 import Data.Fixed (Micro, Pico)
 import Data.Proxy
+import Data.String (IsString, fromString)
 import qualified Data.Text as T
 import Data.Time
 import Test.Hspec
@@ -213,9 +214,9 @@ truncateUTCTime (UTCTime d dift) = do
       d' = max d $ fromGregorian 1950 1 1
   return $ UTCTime d' $ picosecondsToDiffTime picoi
 
-arbText :: Gen Text
+arbText :: IsString s => Gen s
 arbText =
-     T.pack
+     fromString
   .  filter ((`notElem` forbidden) . generalCategory)
   .  filter (<= '\xFFFF') -- only BMP
   .  filter (/= '\0')     -- no nulls

--- a/persistent-test/src/PersistentTest.hs
+++ b/persistent-test/src/PersistentTest.hs
@@ -17,7 +17,6 @@ import Data.Conduit
 import qualified Data.Conduit.List as CL
 import Data.Functor.Constant
 import Data.Functor.Identity
-import qualified Data.HashMap.Lazy as M
 import qualified Data.Map as Map
 import Data.Maybe (fromJust)
 import Test.Hspec.QuickCheck(prop)
@@ -632,7 +631,7 @@ specsWith runDb = describe "persistent" $ do
       let p = Person "D" 0 Nothing
       k <- insert p
       liftIO $ toJSON (Entity k p) @?=
-        Object (M.fromList [("id", toJSON k), ("color",Null),("name",String "D"),("age",Number 0)])
+        object [("id", toJSON k), ("color",Null),("name",String "D"),("age",Number 0)]
 
 {- FIXME
     prop "fromJSON . toJSON $ key" $ \(person :: Key Person) ->

--- a/persistent-test/src/PersistentTestModels.hs
+++ b/persistent-test/src/PersistentTestModels.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE UndecidableInstances #-} -- FIXME
 module PersistentTestModels where
 
-import Data.Aeson
+import Data.Aeson hiding (Key)
 
 import qualified Data.List.NonEmpty as NEL
 import Data.Proxy

--- a/persistent/Database/Persist/Class/PersistConfig.hs
+++ b/persistent/Database/Persist/Class/PersistConfig.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 module Database.Persist.Class.PersistConfig
     ( PersistConfig (..)
     ) where
@@ -5,7 +7,13 @@ module Database.Persist.Class.PersistConfig
 import Control.Monad.IO.Unlift (MonadUnliftIO)
 import Data.Aeson (Value (Object))
 import Data.Aeson.Types (Parser)
-import qualified Data.HashMap.Strict as HashMap
+
+#if MIN_VERSION_aeson(2,0,0)
+import qualified Data.Aeson.KeyMap as AM
+#else
+import qualified Data.HashMap.Strict as AM
+#endif
+
 import Data.Kind (Type)
 
 -- | Represents a value containing all the configuration options for a specific
@@ -43,10 +51,10 @@ instance
     type PersistConfigPool (Either c1 c2) = PersistConfigPool c1
 
     loadConfig (Object o) =
-        case HashMap.lookup "left" o of
+        case AM.lookup "left" o of
             Just v -> Left <$> loadConfig v
             Nothing ->
-                case HashMap.lookup "right" o of
+                case AM.lookup "right" o of
                     Just v -> Right <$> loadConfig v
                     Nothing -> fail "PersistConfig for Either: need either a left or right"
     loadConfig _ = fail "PersistConfig for Either: need an object"

--- a/persistent/Database/Persist/Class/PersistEntity.hs
+++ b/persistent/Database/Persist/Class/PersistEntity.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE CPP #-}
 
 module Database.Persist.Class.PersistEntity
     ( PersistEntity (..)
@@ -46,7 +47,13 @@ import qualified Data.Aeson.Parser as AP
 import Data.Aeson.Text (encodeToTextBuilder)
 import Data.Aeson.Types (Parser, Result(Error, Success))
 import Data.Attoparsec.ByteString (parseOnly)
-import qualified Data.HashMap.Strict as HM
+
+#if MIN_VERSION_aeson(2,0,0)
+import qualified Data.Aeson.KeyMap as AM
+#else
+import qualified Data.HashMap.Strict as AM
+#endif
+
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.Maybe (isJust)
 import Data.Text (Text)
@@ -288,7 +295,7 @@ keyValueEntityFromJSON _ = fail "keyValueEntityFromJSON: not an object"
 -- @
 entityIdToJSON :: (PersistEntity record, ToJSON record) => Entity record -> Value
 entityIdToJSON (Entity key value) = case toJSON value of
-        Object o -> Object $ HM.insert "id" (toJSON key) o
+        Object o -> Object $ AM.insert "id" (toJSON key) o
         x -> x
 
 -- | Predefined @parseJSON@. The input JSON looks like

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -17,7 +17,7 @@ extra-source-files: ChangeLog.md README.md
 library
     build-depends:   
         base                     >= 4.11.1.0     && < 5
-      , aeson                    >= 1.0 && < 1.6
+      , aeson                    >= 1.0 && < 2.1
       , attoparsec
       , base64-bytestring
       , blaze-html               >= 0.9

--- a/persistent/test/Database/Persist/TH/JsonEncodingSpec.hs
+++ b/persistent/test/Database/Persist/TH/JsonEncodingSpec.hs
@@ -19,7 +19,6 @@ module Database.Persist.TH.JsonEncodingSpec where
 import TemplateTestImports
 
 import Data.Aeson
-import qualified Data.HashMap.Lazy as M
 import Data.Text (Text)
 import Test.QuickCheck.Instances ()
 import Test.Hspec.QuickCheck
@@ -73,15 +72,15 @@ spec = describe "JsonEncodingSpec" $ do
     it "encodes without an ID field" $ do
         toJSON subjectEntity
             `shouldBe`
-                Object (M.fromList
+                object
                     [ ("name", String "Bob")
                     , ("age", toJSON (32 :: Int))
                     , ("id", String "Bob")
-                    ])
+                    ]
 
     it "decodes without an ID field" $ do
         let
-            json_ = encode . Object . M.fromList $
+            json_ = encode . object $
                 [ ("name", String "Bob")
                 , ("age", toJSON (32 :: Int))
                 ]
@@ -103,11 +102,11 @@ spec = describe "JsonEncodingSpec" $ do
                 Entity (JsonEncodingKey jsonEncodingName) j
         toJSON ent
             `shouldBe`
-                Object (M.fromList
+                object
                     [ ("name", toJSON jsonEncodingName)
                     , ("age", toJSON jsonEncodingAge)
                     , ("id", toJSON jsonEncodingName)
-                    ])
+                    ]
 
     prop "round trip works with composite key" $ \j@JsonEncoding2{..} -> do
         let
@@ -125,9 +124,9 @@ spec = describe "JsonEncodingSpec" $ do
                 Entity key j
         toJSON ent
             `shouldBe`
-                Object (M.fromList
+                object
                   [ ("name", toJSON jsonEncoding2Name)
                   , ("age", toJSON jsonEncoding2Age)
                   , ("blood", toJSON jsonEncoding2Blood)
                   , ("id", toJSON key)
-                  ])
+                  ]

--- a/persistent/test/Database/Persist/THSpec.hs
+++ b/persistent/test/Database/Persist/THSpec.hs
@@ -24,7 +24,7 @@
 module Database.Persist.THSpec where
 
 import Control.Applicative (Const(..))
-import Data.Aeson
+import Data.Aeson hiding (Key)
 import Data.ByteString.Lazy.Char8 ()
 import Data.Coerce
 import Data.Functor.Identity (Identity(..))

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,5 @@
-resolver: lts-14.27
+resolver: nightly-2021-11-14
+
 packages:
   - ./persistent
   - ./persistent-sqlite
@@ -10,4 +11,9 @@ packages:
   - ./persistent-qq
 
 extra-deps:
-    - lift-type-0.1.0.0
+  - aeson-2.0.2.0
+  # https://github.com/yesodweb/shakespeare/pull/260
+  - github: yesodweb/shakespeare
+    commit: ea390a0e6fa25349626a0c45f133d87e3725f0ba
+  # https://github.com/commercialhaskell/stackage/issues/6294
+  - happy-1.20.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2021-11-14
+resolver: nightly-2022-01-14
 
 packages:
   - ./persistent
@@ -13,7 +13,5 @@ packages:
 extra-deps:
   - aeson-2.0.2.0
   # https://github.com/yesodweb/shakespeare/pull/260
-  - github: yesodweb/shakespeare
-    commit: ea390a0e6fa25349626a0c45f133d87e3725f0ba
   # https://github.com/commercialhaskell/stackage/issues/6294
   - happy-1.20.0


### PR DESCRIPTION
Issue: #1344

Cherry-picks from https://github.com/yesodweb/persistent/pull/1335 and https://github.com/yesodweb/persistent/pull/1338

seems like GHC 9.2 support for dependencies could take a while, so I would appreciate an earlier release with only aeson 2 support.

The Arbitrary Value instance in the pg tests was more restrictive than the one in aeson 2.0.3.0 so i newtyped it.
