### PR TITLE
Further integer types in migration idempotency test

### DIFF
--- a/persistent-test/ChangeLog.md
+++ b/persistent-test/ChangeLog.md
@@ -1,5 +1,9 @@
 ## Unreleased changes
 
+## 2.13.1.1
+
+* Test migration idempotency on additional integer types [#1359](https://github.com/yesodweb/persistent/pull/1359)
+
 ## 2.13.1.0
 
 * Support `persistent-2.13.3.0` [#1341](https://github.com/yesodweb/persistent/pull/1341)

--- a/persistent-test/ChangeLog.md
+++ b/persistent-test/ChangeLog.md
@@ -1,7 +1,5 @@
 ## Unreleased changes
 
-## 2.13.1.1
-
 * Test migration idempotency on additional integer types [#1359](https://github.com/yesodweb/persistent/pull/1359)
 
 ## 2.13.1.0

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -1,5 +1,5 @@
 name:            persistent-test
-version:         2.13.1.0
+version:         2.13.1.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/persistent-test/src/MigrationIdempotencyTest.hs
+++ b/persistent-test/src/MigrationIdempotencyTest.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 module MigrationIdempotencyTest where
 
+import Data.Int (Int32, Int64)
 import qualified Data.Text as T
 
 import Database.Persist.TH
@@ -9,13 +10,15 @@ import Init
 
 share [mkPersist sqlSettings, mkMigrate "migration"] [persistLowerCase|
 Idempotency
-    field1 Int
+    field1 Int64
     field2 T.Text sqltype=varchar(5)
     field3 T.Text sqltype=mediumtext
     field4 T.Text sqltype=longtext
     field5 T.Text sqltype=mediumblob
     field6 T.Text sqltype=longblob
     field7 Double sqltype=double(6,5)
+    field8 Int32
+    field9 Bool
 |]
 
 specsWith :: (MonadIO m) => RunDb SqlBackend m -> Spec


### PR DESCRIPTION
The extra fields in the migration idempotency test are intended to show the problem in #1358, and test the fix which will come separately.  Before that fix is applied, the test is *expected to fail* when run against MySQL 8.

I have kept this PR separate from the fix since it is run for other backends too, making it somewhat independent.

Before submitting your PR, check that you've:

- [x] Ran `stylish-haskell` on any changed files.
- [x] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts) - the current failure is the **expected** one!

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
