### PR TITLE
Fix anomalies in migration of integer columns in MySQL 8 (#1358)

### DIFF
--- a/persistent-mysql/ChangeLog.md
+++ b/persistent-mysql/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for persistent-mysql
 
+## 2.13.1.1
+
+* [#1360](https://github.com/yesodweb/persistent/pull/1360)
+    * Fix anomalies in migration of integer columns in MySQL 8
+
 ## 2.13.1.0
 
 * [#1341](https://github.com/yesodweb/persistent/pull/1341)

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -1023,8 +1023,10 @@ showSqlType :: SqlType
             -> String
 showSqlType SqlBlob    Nothing    _     = "BLOB"
 showSqlType SqlBlob    (Just i)   _     = "VARBINARY(" ++ show i ++ ")"
--- The non-default display width "(1)" is kept for now to avoid differences
--- between persistent versions running against older MySQL versions (eg 5.7):
+-- "tinyint(1)" has been used historically here.  In MySQL 8, the display width
+-- is deprecated, and in the future it may need to be removed here.  However,
+-- "(1)" is not the default in older MySQL versions, so for them omitting it
+-- would alter the exact form of the column type in the information_schema.
 showSqlType SqlBool    _          _     = "TINYINT(1)"
 showSqlType SqlDay     _          _     = "DATE"
 showSqlType SqlDayTime _          _     = "DATETIME"

--- a/persistent-mysql/persistent-mysql.cabal
+++ b/persistent-mysql/persistent-mysql.cabal
@@ -1,5 +1,5 @@
 name:            persistent-mysql
-version:         2.13.1.0
+version:         2.13.1.1
 license:         MIT
 license-file:    LICENSE
 author:          Felipe Lessa <felipe.lessa@gmail.com>, Michael Snoyman


### PR DESCRIPTION
Fixes #1358.  I believe this remains compatible with older versions of MySQL, so should be a minor version bump.
 
Before submitting your PR, check that you've:

- [x] Ran `stylish-haskell` on any changed files.
- [x] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
