### PR TITLE
Add missing apostrophe to acquireSqlConn docs

### DIFF
--- a/persistent/Database/Persist/Sql/Run.hs
+++ b/persistent/Database/Persist/Sql/Run.hs
@@ -157,7 +157,7 @@ rawAcquireSqlConn isolation = do
 -- Upon an exception the transaction is rolled back and the connection
 -- destroyed.
 --
--- This is equivalent to 'runSqlConn but does not incur the 'MonadUnliftIO'
+-- This is equivalent to 'runSqlConn' but does not incur the 'MonadUnliftIO'
 -- constraint, meaning it can be used within, for example, a 'Conduit'
 -- pipeline.
 --


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [ ] Ran `stylish-haskell` on any changed files.
- [x] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
