### PR TITLE
Allow GHC 9.2 for compatible packages

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -45,13 +45,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        cabal: ["3.4"]
+        cabal: ["3.6"]
         ghc:
           - "8.4.4"
           - "8.6.5"
           - "8.8.4"
           - "8.10.3"
           - "9.0"
+          - "9.2.2"
 
     env:
       CONFIG: "--enable-tests --enable-benchmarks"

--- a/persistent-mongoDB/persistent-mongoDB.cabal
+++ b/persistent-mongoDB/persistent-mongoDB.cabal
@@ -19,6 +19,8 @@ Flag high_precision_date
    Default: False
 
 library
+    if impl(ghc >= 9.2)
+        buildable: False
     build-depends:   base               >= 4.8 && < 5
                    , persistent         >= 2.12   && < 3
                    , aeson              >= 1.0
@@ -45,6 +47,8 @@ library
      cpp-options: -DHIGH_PRECISION_DATE
 
 test-suite test
+    if impl(ghc >= 9.2)
+        buildable: False
     type:            exitcode-stdio-1.0
     main-is:         main.hs
     hs-source-dirs:  test

--- a/persistent-mongoDB/persistent-mongoDB.cabal
+++ b/persistent-mongoDB/persistent-mongoDB.cabal
@@ -19,8 +19,6 @@ Flag high_precision_date
    Default: False
 
 library
-    if impl(ghc >= 9.2)
-        buildable: False
     build-depends:   base               >= 4.8 && < 5
                    , persistent         >= 2.12   && < 3
                    , aeson              >= 1.0
@@ -47,8 +45,6 @@ library
      cpp-options: -DHIGH_PRECISION_DATE
 
 test-suite test
-    if impl(ghc >= 9.2)
-        buildable: False
     type:            exitcode-stdio-1.0
     main-is:         main.hs
     hs-source-dirs:  test

--- a/persistent-mongoDB/test/EmbedTestMongo.hs
+++ b/persistent-mongoDB/test/EmbedTestMongo.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE DataKinds, ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE MultiParamTypeClasses #-}

--- a/persistent-mongoDB/test/EntityEmbedTestMongo.hs
+++ b/persistent-mongoDB/test/EntityEmbedTestMongo.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE DataKinds, ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE QuasiQuotes #-}

--- a/persistent-mongoDB/test/main.hs
+++ b/persistent-mongoDB/test/main.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE DataKinds, ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE QuasiQuotes #-}

--- a/persistent-mysql/test/main.hs
+++ b/persistent-mysql/test/main.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}

--- a/persistent-postgresql/test/main.hs
+++ b/persistent-postgresql/test/main.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}

--- a/persistent-redis/persistent-redis.cabal
+++ b/persistent-redis/persistent-redis.cabal
@@ -17,13 +17,11 @@ source-repository head
         location:       https://github.com/yesodweb/persistent.git
 
 library
-    if impl(ghc >= 9.2)
-        buildable: False
     build-depends:   base                  >= 4.9        && < 5
                    , persistent            >= 2.12      && < 3.0
                    , aeson                 >= 1.0
                    , binary                >= 0.8      && < 0.9
-                   , bytestring            >= 0.10.8   && < 0.11
+                   , bytestring            >= 0.10.8   && < 0.12
                    , hedis                 >= 0.9
                    , http-api-data
                    , mtl                   >= 2.2.1    && < 2.3
@@ -47,8 +45,6 @@ library
     default-language: Haskell2010
 
 test-suite  basic
-    if impl(ghc >= 9.2)
-        buildable: False
     type: exitcode-stdio-1.0
     main-is: tests/basic-test.hs
     build-depends:   base                  >= 4.9      && < 5

--- a/persistent-redis/persistent-redis.cabal
+++ b/persistent-redis/persistent-redis.cabal
@@ -17,6 +17,8 @@ source-repository head
         location:       https://github.com/yesodweb/persistent.git
 
 library
+    if impl(ghc >= 9.2)
+        buildable: False
     build-depends:   base                  >= 4.9        && < 5
                    , persistent            >= 2.12      && < 3.0
                    , aeson                 >= 1.0
@@ -45,6 +47,8 @@ library
     default-language: Haskell2010
 
 test-suite  basic
+    if impl(ghc >= 9.2)
+        buildable: False
     type: exitcode-stdio-1.0
     main-is: tests/basic-test.hs
     build-depends:   base                  >= 4.9      && < 5

--- a/persistent-test/src/DataTypeTest.hs
+++ b/persistent-test/src/DataTypeTest.hs
@@ -49,7 +49,7 @@ cleanDB'
 cleanDB' = deleteWhere ([] :: [Filter (DataTypeTableGeneric backend)])
 
 roundFn :: RealFrac a => a -> Integer
-roundFn = round
+roundFn = truncate
 
 roundTime :: TimeOfDay -> TimeOfDay
 roundTime t = timeToTimeOfDay $ fromIntegral $ roundFn $ timeOfDayToTime t

--- a/persistent/Database/Persist/Class/PersistField.hs
+++ b/persistent/Database/Persist/Class/PersistField.hs
@@ -19,6 +19,7 @@ import qualified Data.ByteString.Lazy as L
 import Data.Fixed
 import Data.Int (Int8, Int16, Int32, Int64)
 import qualified Data.IntMap as IM
+import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Map as M
 import qualified Data.Set as S
 import Data.Text (Text)
@@ -308,22 +309,26 @@ instance PersistField UTCTime where
     fromPersistValue x@(PersistText t)  =
         let s = T.unpack t
         in
-          case reads s of
-            (d, _):_ -> Right d
-            _ ->
+          case NonEmpty.nonEmpty (reads s) of
+            Nothing ->
                 case parse8601 s <|> parsePretty s of
                     Nothing -> Left $ fromPersistValueParseError "UTCTime" x
                     Just x' -> Right x'
+            Just matches ->
+                -- The 'Read UTCTime' instance in newer versions of 'time' is
+                -- more flexible when parsing UTCTime strings and will return
+                -- UTCTimes with different microsecond parsings. The last result
+                -- here contains the parsed UTCTime with as much microsecond
+                -- precision parsed as posssible.
+                Right $ fst $ NonEmpty.last matches
       where
 #if MIN_VERSION_time(1,5,0)
-        parse8601 = parseTimeM True defaultTimeLocale format8601
-        parsePretty = parseTimeM True defaultTimeLocale formatPretty
+        parseTime' = parseTimeM True defaultTimeLocale
 #else
-        parse8601 = parseTime defaultTimeLocale format8601
-        parsePretty = parseTime defaultTimeLocale formatPretty
+        parseTime' = parseTime defaultTimeLocale
 #endif
-        format8601 = "%FT%T%Q"
-        formatPretty = "%F %T%Q"
+        parse8601 = parseTime' "%FT%T%Q"
+        parsePretty = parseTime' "%F %T%Q"
     fromPersistValue x@(PersistByteString s) =
         case reads $ unpack s of
             (d, _):_ -> Right d

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -130,6 +130,13 @@ import Database.Persist.EntityDef.Internal (EntityDef(..))
 import Database.Persist.ImplicitIdDef (autoIncrementingInteger)
 import Database.Persist.ImplicitIdDef.Internal
 
+#if MIN_VERSION_template_haskell(2,18,0)
+conp :: Name -> [Pat] -> Pat
+conp name pats = ConP name [] pats
+#else
+conp = ConP
+#endif
+
 -- | Converts a quasi-quoted syntax into a list of entity definitions, to be
 -- used as input to the template haskell generation code (mkPersist).
 persistWith :: PersistSettings -> QuasiQuoter
@@ -1287,7 +1294,7 @@ mkToPersistFields mps ed = do
     go = do
         xs <- sequence $ replicate fieldCount $ newName "x"
         let name = mkEntityDefName ed
-            pat = ConP name $ fmap VarP xs
+            pat = conp name $ fmap VarP xs
         sp <- [|SomePersistField|]
         let bod = ListE $ fmap (AppE sp . VarE) xs
         return $ normalClause [pat] bod
@@ -1309,7 +1316,7 @@ mkToPersistFields mps ed = do
                 , [sp `AppE` VarE x]
                 , after
                 ]
-        return $ normalClause [ConP name [VarP x]] body
+        return $ normalClause [conp name [VarP x]] body
 
 mkToFieldNames :: [UniqueDef] -> Q Dec
 mkToFieldNames pairs = do
@@ -1331,7 +1338,7 @@ mkUniqueToValues pairs = do
     go :: UniqueDef -> Q Clause
     go (UniqueDef constr _ names _) = do
         xs <- mapM (const $ newName "x") names
-        let pat = ConP (mkConstraintName constr) $ fmap VarP $ toList xs
+        let pat = conp (mkConstraintName constr) $ fmap VarP $ toList xs
         tpv <- [|toPersistValue|]
         let bod = ListE $ fmap (AppE tpv . VarE) $ toList xs
         return $ normalClause [pat] bod
@@ -1370,7 +1377,7 @@ mkFromPersistValues mps entDef
     mkClauses _ [] = return []
     mkClauses before (field:after) = do
         x <- newName "x"
-        let null' = ConP 'PersistNull []
+        let null' = conp 'PersistNull []
             pat = ListP $ mconcat
                 [ fmap (const null') before
                 , [VarP x]
@@ -1407,20 +1414,20 @@ mkLensClauses mps entDef = do
     valName <- newName "value"
     xName <- newName "x"
     let idClause = normalClause
-            [ConP (keyIdName entDef) []]
+            [conp (keyIdName entDef) []]
             (lens' `AppE` getId `AppE` setId)
     return $ idClause : if unboundEntitySum entDef
         then fmap (toSumClause lens' keyVar valName xName) (getUnboundFieldDefs entDef)
         else fmap (toClause lens' getVal dot keyVar valName xName) (getUnboundFieldDefs entDef)
   where
     toClause lens' getVal dot keyVar valName xName fieldDef = normalClause
-        [ConP (filterConName mps entDef fieldDef) []]
+        [conp (filterConName mps entDef fieldDef) []]
         (lens' `AppE` getter `AppE` setter)
       where
         fieldName = fieldDefToRecordName mps entDef fieldDef
         getter = InfixE (Just $ VarE fieldName) dot (Just getVal)
         setter = LamE
-            [ ConP 'Entity [VarP keyVar, VarP valName]
+            [ conp 'Entity [VarP keyVar, VarP valName]
             , VarP xName
             ]
             $ ConE 'Entity `AppE` VarE keyVar `AppE` RecUpdE
@@ -1428,20 +1435,20 @@ mkLensClauses mps entDef = do
                 [(fieldName, VarE xName)]
 
     toSumClause lens' keyVar valName xName fieldDef = normalClause
-        [ConP (filterConName mps entDef fieldDef) []]
+        [conp (filterConName mps entDef fieldDef) []]
         (lens' `AppE` getter `AppE` setter)
       where
         emptyMatch = Match WildP (NormalB $ VarE 'error `AppE` LitE (StringL "Tried to use fieldLens on a Sum type")) []
         getter = LamE
-            [ ConP 'Entity [WildP, VarP valName]
+            [ conp 'Entity [WildP, VarP valName]
             ] $ CaseE (VarE valName)
-            $ Match (ConP (sumConstrName mps entDef fieldDef) [VarP xName]) (NormalB $ VarE xName) []
+            $ Match (conp (sumConstrName mps entDef fieldDef) [VarP xName]) (NormalB $ VarE xName) []
 
             -- FIXME It would be nice if the types expressed that the Field is
             -- a sum type and therefore could result in Maybe.
             : if length (getUnboundFieldDefs entDef) > 1 then [emptyMatch] else []
         setter = LamE
-            [ ConP 'Entity [VarP keyVar, WildP]
+            [ conp 'Entity [VarP keyVar, WildP]
             , VarP xName
             ]
             $ ConE 'Entity `AppE` VarE keyVar `AppE` (ConE (sumConstrName mps entDef fieldDef) `AppE` VarE xName)
@@ -2363,7 +2370,7 @@ mkUniqueKeys def = do
             x' <- newName $ '_' : unpack (unFieldNameHS x)
             return (x, x')
         let pcs = fmap (go xs) $ entityUniques $ unboundEntityDef def
-        let pat = ConP
+        let pat = conp
                 (mkEntityDefName def)
                 (fmap (VarP . snd) xs)
         return $ normalClause [pat] (ListE pcs)
@@ -2552,7 +2559,7 @@ mkField mps entityMap et fieldDef = do
             maybeIdType mps entityMap fieldDef Nothing Nothing
     bod <- mkLookupEntityField et (unboundFieldNameHS fieldDef)
     let cla = normalClause
-                [ConP name []]
+                [conp name []]
                 bod
     return $ EntityFieldTH con cla
   where
@@ -2582,7 +2589,7 @@ mkIdField mps ued = do
                 [mkEqualP (VarT $ mkName "typ") entityIdType]
                 $ NormalC name []
         , entityFieldTHClause =
-            normalClause [ConP name []] clause
+            normalClause [conp name []] clause
         }
 
 lookupEntityField
@@ -2665,7 +2672,7 @@ mkJSON mps (fixEntityDef -> def) = do
             typeInstanceD ''ToJSON (mpsGeneric mps) typ [toJSON']
           where
             toJSON' = FunD 'toJSON $ return $ normalClause
-                [ConP conName $ fmap VarP xs]
+                [conp conName $ fmap VarP xs]
                 (objectE `AppE` ListE pairs)
               where
                 pairs = zipWith toPair fields xs
@@ -2677,7 +2684,7 @@ mkJSON mps (fixEntityDef -> def) = do
             typeInstanceD ''FromJSON (mpsGeneric mps) typ [parseJSON']
           where
             parseJSON' = FunD 'parseJSON
-                [ normalClause [ConP 'Object [VarP obj]]
+                [ normalClause [conp 'Object [VarP obj]]
                     (foldl'
                         (\x y -> InfixE (Just x) apE' (Just y))
                         (pureE `AppE` ConE conName)

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -34,7 +34,7 @@ library
       , resourcet                >= 1.1.10
       , scientific
       , silently
-      , template-haskell         >= 2.13 && < 2.18
+      , template-haskell         >= 2.13 && < 2.19
       , text                     >= 1.2
       , th-lift-instances        >= 0.1.14    && < 0.2
       , time                     >= 1.6


### PR DESCRIPTION
This is based on #1338 but avoids overriding dependencies. The compatible targets are built and tested in CI, ~~the others are marked as unbuildable and cabal-install will just skip them.~~ EDIT: nothing is disabled any more