### PR TITLE
Add spec to assert Persistent.TH is the only import required when defining entities

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,5 +1,8 @@
 # Changelog for persistent
 
+* [#1370](https://github.com/yesodweb/persistent/pull/1370)
+    * Add spec to assert Persistent.TH is the only import required when defining entities
+
 ## 2.13.3.3
 
 * [#1369](https://github.com/yesodweb/persistent/pull/1369)

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -182,6 +182,7 @@ test-suite test
         Database.Persist.TH.MultiBlockSpec
         Database.Persist.TH.MultiBlockSpec.Model
         Database.Persist.TH.OverloadedLabelSpec
+        Database.Persist.TH.RequireOnlyPersistImportSpec
         Database.Persist.TH.SharedPrimaryKeyImportedSpec
         Database.Persist.TH.SharedPrimaryKeySpec
         Database.Persist.THSpec

--- a/persistent/test/Database/Persist/TH/RequireOnlyPersistImportSpec.hs
+++ b/persistent/test/Database/Persist/TH/RequireOnlyPersistImportSpec.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Database.Persist.TH.RequireOnlyPersistImportSpec where
+
+-- This test asserts this is the only import required to define entities
+-- See: https://github.com/yesodweb/persistent/pull/1369
+import Database.Persist.TH
+
+-- always explicitly import Hspec in the context of this spec
+import qualified Test.Hspec as HS
+
+mkPersist sqlSettings [persistLowerCase|
+Plain
+    name String
+    age  Int
+    deriving Show Eq
+
+JsonEncoded json
+    name String
+    age  Int
+    deriving Show Eq
+|]
+
+spec :: HS.Spec
+spec =
+    HS.describe "RequireOnlyPersistImport" $ do
+        HS.it "Plain" $ do
+            let typeSigPlain :: String -> Int -> Plain
+                typeSigPlain = Plain
+            compiles
+
+        HS.it "JsonEncoded" $ do
+            let typeSigJsonEncoded :: String -> Int -> JsonEncoded
+                typeSigJsonEncoded = JsonEncoded
+            compiles
+
+compiles :: HS.Expectation
+compiles = True `HS.shouldBe` True

--- a/persistent/test/Database/Persist/TH/RequireOnlyPersistImportSpec.hs
+++ b/persistent/test/Database/Persist/TH/RequireOnlyPersistImportSpec.hs
@@ -15,7 +15,7 @@ module Database.Persist.TH.RequireOnlyPersistImportSpec where
 -- See: https://github.com/yesodweb/persistent/pull/1369
 import Database.Persist.TH
 
--- always explicitly import Hspec in the context of this spec
+-- always explicitly import qualified Hspec in the context of this spec
 import qualified Test.Hspec as HS
 
 mkPersist sqlSettings [persistLowerCase|

--- a/persistent/test/Database/Persist/THSpec.hs
+++ b/persistent/test/Database/Persist/THSpec.hs
@@ -46,7 +46,7 @@ import Database.Persist.TH
 import TemplateTestImports
 
 
-import qualified Database.Persist.TH.PersistWithSpec as PersistWithSpec
+import qualified Database.Persist.TH.CommentSpec as CommentSpec
 import qualified Database.Persist.TH.DiscoverEntitiesSpec as DiscoverEntitiesSpec
 import qualified Database.Persist.TH.EmbedSpec as EmbedSpec
 import qualified Database.Persist.TH.ForeignRefSpec as ForeignRefSpec
@@ -57,10 +57,11 @@ import qualified Database.Persist.TH.MaybeFieldDefsSpec as MaybeFieldDefsSpec
 import qualified Database.Persist.TH.MigrationOnlySpec as MigrationOnlySpec
 import qualified Database.Persist.TH.MultiBlockSpec as MultiBlockSpec
 import qualified Database.Persist.TH.OverloadedLabelSpec as OverloadedLabelSpec
+import qualified Database.Persist.TH.PersistWithSpec as PersistWithSpec
+import qualified Database.Persist.TH.RequireOnlyPersistImportSpec as RequireOnlyPersistImportSpec
 import qualified Database.Persist.TH.SharedPrimaryKeyImportedSpec as SharedPrimaryKeyImportedSpec
 import qualified Database.Persist.TH.SharedPrimaryKeySpec as SharedPrimaryKeySpec
 import qualified Database.Persist.TH.ToFromPersistValuesSpec as ToFromPersistValuesSpec
-import qualified Database.Persist.TH.CommentSpec as CommentSpec
 
 -- test to ensure we can have types ending in Id that don't trash the TH
 -- machinery


### PR DESCRIPTION
Follow on from https://github.com/yesodweb/persistent/pull/1369. Though that PR adds some additional coverage to preventing this from happening again, this PR adds an additional spec to explicitly verify we can generate entities where `Data.Persistent.TH` is the only import required.

![Screenshot from 2022-03-15 18-22-35](https://user-images.githubusercontent.com/2951404/158449411-71f18e81-11b7-42ad-b18b-0859352d4a43.png)


---

Before submitting your PR, check that you've:

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [ ] Ran `stylish-haskell` on any changed files.
- [ ] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
