### PR TITLE
Fix adding new column in persistent-mysql, and include MigrationTest

### DIFF
--- a/persistent-mysql/ChangeLog.md
+++ b/persistent-mysql/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog for persistent-mysql
 
+##  2.13.1.3
+
+* [#1372](https://github.com/yesodweb/persistent/pull/1372)
+    * Fix migrations which add a new column in `persistent-mysql` ([#1373](https://github.com/yesodweb/persistent/issues/1373)
+    * Include MigrationTest in `persistent-mysql` tests
+
 ##  2.13.1.2
 
 * [#1367](https://github.com/yesodweb/persistent/pull/1367),

--- a/persistent-mysql/ChangeLog.md
+++ b/persistent-mysql/ChangeLog.md
@@ -3,7 +3,7 @@
 ##  2.13.1.3
 
 * [#1372](https://github.com/yesodweb/persistent/pull/1372)
-    * Fix migrations which add a new column in `persistent-mysql` ([#1373](https://github.com/yesodweb/persistent/issues/1373)
+    * Fix migrations which add a new column in `persistent-mysql` ([#1373](https://github.com/yesodweb/persistent/issues/1373))
     * Include MigrationTest in `persistent-mysql` tests
 
 ##  2.13.1.2

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -921,7 +921,7 @@ findAlters edef allDefs col@(Column name isNull type_ def gen _defConstraintName
     -- new fkey that didn't exist before
         [] ->
             case ref of
-                Nothing -> ([Add' col],[])
+                Nothing -> ([Add' col],cols)
                 Just cr ->
                     let tname = crTableName cr
                         cname = crConstraintName cr

--- a/persistent-mysql/persistent-mysql.cabal
+++ b/persistent-mysql/persistent-mysql.cabal
@@ -1,5 +1,5 @@
 name:            persistent-mysql
-version:         2.13.1.2
+version:         2.13.1.3
 license:         MIT
 license-file:    LICENSE
 author:          Felipe Lessa <felipe.lessa@gmail.com>, Michael Snoyman

--- a/persistent-mysql/test/main.hs
+++ b/persistent-mysql/test/main.hs
@@ -41,6 +41,7 @@ import qualified MaybeFieldDefsTest
 import qualified MigrationColumnLengthTest
 import qualified MigrationIdempotencyTest
 import qualified MigrationOnlyTest
+import qualified MigrationTest
 import qualified MpsCustomPrefixTest
 import qualified MpsNoPrefixTest
 import qualified PersistUniqueTest
@@ -135,6 +136,7 @@ main = do
             , CustomPersistFieldTest.customFieldMigrate
             , InsertDuplicateUpdate.duplicateMigrate
             , MigrationIdempotencyTest.migration
+            , MigrationTest.migrationMigrate
             , CustomPrimaryKeyReferenceTest.migration
             , MigrationColumnLengthTest.migration
             , TransactionLevelTest.migration
@@ -209,6 +211,7 @@ main = do
         TransactionLevelTest.specsWith db
 
         MigrationIdempotencyTest.specsWith db
+        MigrationTest.specsWith db
         CustomConstraintTest.specs db
         -- TODO: implement automatic truncation for too long foreign keys, so we can run this test.
         xdescribe "The migration for this test currently fails because of MySQL's 64 character limit for identifiers. See https://github.com/yesodweb/persistent/issues/1000 for details" $


### PR DESCRIPTION
Fixes #1373. **This PR has now been modified to include the fix**

Fixes the bug, and adds a test - an existing one, but it wasn't run for MySQL.

It **fails at present,** but that is the point!  There will be a separate issue in a minute.

Before submitting your PR, check that you've:

- [x] Ran `stylish-haskell` on any changed files.
- [x] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:


<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
