### PR TITLE
Increasing test coverage for errors thrown when parsing entity definitions

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,5 +1,7 @@
 # Changelog for persistent
 
+* [#1374](https://github.com/yesodweb/persistent/pull/1374)
+    * Increasing test coverage for errors thrown when parsing entity definitions
 * [#1370](https://github.com/yesodweb/persistent/pull/1370)
     * Add spec to assert Persistent.TH is the only import required when defining entities
 

--- a/persistent/Database/Persist/Quasi/Internal.hs
+++ b/persistent/Database/Persist/Quasi/Internal.hs
@@ -1407,7 +1407,7 @@ parseCascade allTokens =
                                     Nothing ->
                                         go acc mupd (Just cascDel) rest
                                     Just _ ->
-                                        nope "found more than one OnDelete action: "
+                                        nope "found more than one OnDelete action"
                             Nothing ->
                                 go (this : acc) mupd mdel rest
     nope msg =

--- a/persistent/Database/Persist/Quasi/Internal.hs
+++ b/persistent/Database/Persist/Quasi/Internal.hs
@@ -1152,9 +1152,7 @@ takeUniq ps tableName defs (n : rest)
             _ -> Nothing
     dbName = fromMaybe usualDbName sqlName
 
-    getDBName [] t =
-      error $ "Unknown column in unique constraint: " ++ show t
-              ++ " " ++ show defs ++ show n ++ " " ++ show attrs
+    getDBName [] t = error $ T.unpack (unknownUniqueColumnError t defs n)
     getDBName (d:ds) t
         | unboundFieldNameHS d == FieldNameHS t =
             unboundFieldNameDB d
@@ -1166,6 +1164,15 @@ takeUniq _ tableName _ xs =
           ++ show tableName
           ++ "] expecting an uppercase constraint name xs="
           ++ show xs
+
+unknownUniqueColumnError :: Text -> [UnboundFieldDef] -> Text -> Text
+unknownUniqueColumnError t defs n =
+    "Unknown column in \"" <> n <> "\" constraint: \"" <> t <> "\""
+        <> " possible fields: " <> T.pack (show (toFieldName <$> defs))
+    where
+        toFieldName :: UnboundFieldDef -> Text
+        toFieldName fd =
+            unFieldNameHS (unboundFieldNameHS fd)
 
 -- | Define an explicit foreign key reference.
 --

--- a/persistent/test/Database/Persist/QuasiSpec.hs
+++ b/persistent/test/Database/Persist/QuasiSpec.hs
@@ -453,8 +453,10 @@ User
                 let [user] = parse lowerCaseSettings definitions
                     uniques = entityUniques (unboundEntityDef user)
                     [dbNames] = fmap snd . uniqueFields <$> uniques
-                    errMsg =
-                        "Unknown column in unique constraint: \"emailSecond\" [UnboundFieldDef {unboundFieldNameHS = FieldNameHS {unFieldNameHS = \"name\"}, unboundFieldNameDB = FieldNameDB {unFieldNameDB = \"name\"}, unboundFieldAttrs = [], unboundFieldStrict = True, unboundFieldType = FTTypeCon Nothing \"Text\", unboundFieldCascade = FieldCascade {fcOnUpdate = Nothing, fcOnDelete = Nothing}, unboundFieldGenerated = Nothing, unboundFieldComments = Nothing},UnboundFieldDef {unboundFieldNameHS = FieldNameHS {unFieldNameHS = \"emailFirst\"}, unboundFieldNameDB = FieldNameDB {unFieldNameDB = \"email_first\"}, unboundFieldAttrs = [], unboundFieldStrict = True, unboundFieldType = FTTypeCon Nothing \"Text\", unboundFieldCascade = FieldCascade {fcOnUpdate = Nothing, fcOnDelete = Nothing}, unboundFieldGenerated = Nothing, unboundFieldComments = Nothing}]\"UniqueEmail\" []"
+                    errMsg = unwords
+                        [ "Unknown column in \"UniqueEmail\" constraint: \"emailSecond\""
+                        , "possible fields: [\"name\",\"emailFirst\"]"
+                        ]
                 evaluate (head (NEL.tail dbNames)) `shouldThrow`
                     errorCall errMsg
 


### PR DESCRIPTION
Ups the test coverage in `QuasiSpec` to cover cases when there is an error, and make an assertion on the error message. 

The original motivation for this was discovering that this error here:

https://github.com/yesodweb/persistent/blob/aeaa4f61159e140fbf3a45fc2b59309b0bb4b53f/persistent/Database/Persist/Quasi/Internal.hs#L1155-L1157

Is actually `show`ing all the `UnboundField`s as illustrated in this commit prior to fixing:

https://github.com/yesodweb/persistent/pull/1374/commits/89b34a9b5e468b18b030591843c380a9ee60bb20#diff-31a6cff4e15cd1978c97554cd4fae33101b142ab0e6a6e03f427458d2851b26bR457

This PR corrects this, and extracts a function to generate the error message in a more type safe way.

Further to this I have added some similar tests around other errors in this module which do not appear to have coverage.

----

Before submitting your PR, check that you've:

- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [x] Ran `stylish-haskell` on any changed files.
- [x] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
