### PR TITLE
Increasing quasi module test coverage, improve error assertions

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,6 +1,11 @@
 # Changelog for persistent
 
-## 2.14.0.0 (unreleased)
+## (unreleased)
+
+* [#1391](https://github.com/yesodweb/persistent/pull/1391)
+    * Increasing quasi module test coverage, improve error assertions
+
+## 2.14.0.0
 
 * [#1343](https://github.com/yesodweb/persistent/pull/1343)
     * Implement Type Literal based field definitions


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [x] Ran `stylish-haskell` on any changed files.
- [x] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
