### PR TITLE
Update "Entity Syntax" link to go directly to Database.Persist.Quasi

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@ Get started with Persistent at: http://www.yesodweb.com/book/persistent
 
 ## Wiki
 
-* [Entity Syntax](./Persistent-entity-syntax.md)
+* [Entity Syntax](http://hackage.haskell.org/package/persistent/docs/Database-Persist-Quasi.html) is documented in the `Database.Persist.Quasi` module
 * [Database Configuration](./Database-Configuration.md)
 
 ## External Documentation


### PR DESCRIPTION
The documentation for `.persistentmodels` files is here, in `Database.Persist.Quasi`: https://hackage.haskell.org/package/persistent-2.14.0.0/docs/Database-Persist-Quasi.html, but it's very hard to find:
- A Google search for "persistentmodels syntax" links to https://hackage.haskell.org/package/persistent-parser-0.1.0.2/docs/Database-Persist-Syntax-Types.html
- Which links to https://github.com/yesodweb/persistent/wiki/Persistent-entity-syntax (I've since updated this page with a direct link to the documentation) 
- Which links to https://github.com/yesodweb/persistent/tree/master/docs#wiki
- Which links to https://github.com/yesodweb/persistent/blob/master/docs/Persistent-entity-syntax.md
- Which links to the actual documentation

This PR makes the https://github.com/yesodweb/persistent/tree/master/docs#wiki page link directly to the `Database.Persist.Quasi` module, removing one layer of indirection.