### PR TITLE
Fix a name shadowing warning (#1406)

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for persistent
 
+## 2.14.0.2
+
+* []()
+    * Fix a name shadowing warning.
+
 ## 2.14.0.1
 
 * [#1392](https://github.com/yesodweb/persistent/pull/1392)

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 2.14.0.2
 
-* []()
+* [#1407](https://github.com/yesodweb/persistent/pull/1407)
     * Fix a name shadowing warning.
 
 ## 2.14.0.1

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -119,8 +119,8 @@ import Language.Haskell.TH.Syntax
 import Web.HttpApiData (FromHttpApiData(..), ToHttpApiData(..))
 import Web.PathPieces (PathPiece(..))
 
-import Database.Persist.Class.PersistEntity
 import Database.Persist
+import Database.Persist.Class.PersistEntity
 import Database.Persist.Quasi
 import Database.Persist.Quasi.Internal
 import Database.Persist.Sql

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:            persistent
-version:         2.14.0.1
+version:         2.14.0.2
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/persistent/test/Database/Persist/TH/NoFieldSelectorsSpec.hs
+++ b/persistent/test/Database/Persist/TH/NoFieldSelectorsSpec.hs
@@ -32,9 +32,9 @@ spec = it "compiles" True
 
 #else
 
-spec :: Spec 
+spec :: Spec
 spec = do
     it "only works with GHC 9.2 or greater" $ do
-        pendingWith "only works with GHC 9.2 or greater"    
+        pendingWith "only works with GHC 9.2 or greater"
 
 #endif

--- a/persistent/test/Database/Persist/TH/OverloadedLabelSpec.hs
+++ b/persistent/test/Database/Persist/TH/OverloadedLabelSpec.hs
@@ -13,6 +13,8 @@
 {-# LANGUAGE TypeFamilies               #-}
 {-# LANGUAGE UndecidableInstances       #-}
 
+{-# OPTIONS_GHC -Wname-shadowing -Werror=name-shadowing #-}
+
 module Database.Persist.TH.OverloadedLabelSpec where
 
 import           TemplateTestImports

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2022-01-14
+resolver: nightly-2022-06-10
 
 packages:
   - ./persistent
@@ -14,7 +14,7 @@ extra-deps:
   - lift-type-0.1.0.0
   - mysql-0.2.1
   - mysql-simple-0.4.7
-  - aeson-2.0.2.0
+    # - aeson-2.0.2.0
   # https://github.com/yesodweb/shakespeare/pull/260
   # https://github.com/commercialhaskell/stackage/issues/6294
-  - happy-1.20.0
+  # - happy-1.20.0


### PR DESCRIPTION
This PR fixes #1406 which noticed that the code generated name shadowing warnings.

The specific problem si that we'd generate code like:

```haskell
case someRecord of
  Constructor { fieldName = fieldName } -> ...
```

where `fieldName` shadowed `fieldName`.

Before submitting your PR, check that you've:

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [x] Ran `stylish-haskell` on any changed files.
- [x] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
