### PR TITLE
Fix typo: FieldNameDB calls itself EntityNameDB

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog for persistent
 
+## 2.14.0.3
+
+* [#1411](https://github.com/yesodweb/persistent/pull/1411)
+    * Fix the docs for `FieldNameDB`, and update `FieldDef.fieldComments` docs
+      since the quasiquoter *supports* field comments now.
+
 ## 2.14.0.2
 
 * [#1407](https://github.com/yesodweb/persistent/pull/1407)

--- a/persistent/Database/Persist/Names.hs
+++ b/persistent/Database/Persist/Names.hs
@@ -18,8 +18,8 @@ import Instances.TH.Lift ()
 class DatabaseName a where
     escapeWith :: (Text -> str) -> (a -> str)
 
--- | An 'EntityNameDB' represents the datastore-side name that @persistent@
--- will use for an entity.
+-- | A 'FieldNameDB' represents the datastore-side name that @persistent@
+-- will use for a field.
 --
 -- @since 2.12.0.0
 newtype FieldNameDB = FieldNameDB { unFieldNameDB :: Text }

--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -681,8 +681,7 @@ data FieldDef = FieldDef
     --
     -- @since 2.11.0
     , fieldComments  :: !(Maybe Text)
-    -- ^ Optional comments for a 'Field'. There is not currently a way to
-    -- attach comments to a field in the quasiquoter.
+    -- ^ Optional comments for a 'Field'.
     --
     -- @since 2.10.0
     , fieldGenerated :: !(Maybe Text)

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:            persistent
-version:         2.14.0.2
+version:         2.14.0.3
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [ ] Ran `stylish-haskell` on any changed files.
- [ ] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
