### PR TITLE
MkPersistSettings option for preserve CamelCase style of composite keys

### DIFF
--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -3117,7 +3117,11 @@ keyFieldName mps entDef fieldDef
     | pkNewtype mps entDef =
         unKeyName entDef
     | otherwise =
-        mkName $ T.unpack $ lowerFirst (keyText entDef) `mappend` unFieldNameHS fieldDef
+        mkName $ T.unpack $ lowerFirst (keyText entDef) `mappend` fieldName
+    where
+      fieldName = modifyFieldName (unFieldNameHS fieldDef)
+      modifyFieldName =
+        if mpsCamelCaseCompositeKeySelector mps then upperFirst else id
 
 filterConName
     :: MkPersistSettings

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -994,8 +994,8 @@ data MkPersistSettings = MkPersistSettings
     -- @since 2.13.0.0
     , mpsCamelCaseCompositeKeySelector :: Bool
     -- ^ Should we generate composite key accessors in the correct CamelCase style.
-    -- 
-    -- If the 'mpsCamelCaseCompositeKeySelector' value is set to 'False', 
+    --
+    -- If the 'mpsCamelCaseCompositeKeySelector' value is set to 'False',
     -- then the field part of the accessor starts with the lowercase.
     -- This is a legacy style.
     --
@@ -1006,7 +1006,7 @@ data MkPersistSettings = MkPersistSettings
     --   }
     -- @
     --
-    -- If the 'mpsCamelCaseCompositeKeySelector' value is set to 'True', 
+    -- If the 'mpsCamelCaseCompositeKeySelector' value is set to 'True',
     -- then field accessors are generated in CamelCase style.
     --
     -- @

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -39,6 +39,7 @@ module Database.Persist.TH
     , mpsEntityJSON
     , mpsGenerateLenses
     , mpsDeriveInstances
+    , mpsCamelCaseCompositeKeySelector
     , EntityJSON(..)
     , mkPersistSettings
     , sqlSettings
@@ -991,6 +992,33 @@ data MkPersistSettings = MkPersistSettings
     -- ^ TODO: document
     --
     -- @since 2.13.0.0
+    , mpsCamelCaseCompositeKeySelector :: Bool
+    -- ^ Should we generate composite key accessors in the correct CamelCase style.
+    -- 
+    -- If the 'mpsCamelCaseCompositeKeySelector' value is set to 'False', 
+    -- then the field part of the accessor starts with the lowercase.
+    -- This is a legacy style.
+    --
+    -- @
+    -- data Key CompanyUser = CompanyUserKey
+    --   { companyUserKeycompanyId :: CompanyId
+    --   , companyUserKeyuserId :: UserId
+    --   }
+    -- @
+    --
+    -- If the 'mpsCamelCaseCompositeKeySelector' value is set to 'True', 
+    -- then field accessors are generated in CamelCase style.
+    --
+    -- @
+    -- data Key CompanyUser = CompanyUserKey
+    --   { companyUserKeyCompanyId :: CompanyId
+    --   , companyUserKeyUserId :: UserId
+    --   }
+    -- @
+
+    -- Default: False
+    --
+    -- @since 2.14.1.1
     }
 
 {-# DEPRECATED mpsGeneric "The mpsGeneric function adds a considerable amount of overhead and complexity to the library without bringing significant benefit. We would like to remove it. If you require this feature, please comment on the linked GitHub issue, and we'll either keep it around, or we can figure out a nicer way to solve your problem.\n\n Github: https://github.com/yesodweb/persistent/issues/1204" #-}
@@ -1035,6 +1063,7 @@ mkPersistSettings backend = MkPersistSettings
     , mpsDeriveInstances = []
     , mpsImplicitIdDef =
         autoIncrementingInteger
+    , mpsCamelCaseCompositeKeySelector = False
     }
 
 -- | Use the 'SqlPersist' backend.

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:            persistent
-version:         2.14.1.0
+version:         2.14.1.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -166,6 +166,7 @@ test-suite test
         Database.Persist.PersistValueSpec
         Database.Persist.QuasiSpec
         Database.Persist.TH.CommentSpec
+        Database.Persist.TH.CompositeKeyStyleSpec
         Database.Persist.TH.DiscoverEntitiesSpec
         Database.Persist.TH.EmbedSpec
         Database.Persist.TH.ForeignRefSpec

--- a/persistent/test/Database/Persist/TH/CompositeKeyStyleSpec.hs
+++ b/persistent/test/Database/Persist/TH/CompositeKeyStyleSpec.hs
@@ -1,0 +1,62 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Database.Persist.TH.CompositeKeyStyleSpec where
+
+import Data.Data (Data, constrFields, toConstr)
+import Data.Text (Text)
+import Database.Persist.Sql
+import Database.Persist.TH
+import Test.Hspec hiding (Selector)
+
+mkPersist sqlSettings
+  [persistLowerCase|
+    CompanyUserLegacyStyle
+      companyName Text
+      userName Text
+      Primary companyName userName
+  |]
+
+deriving instance Data CompanyUserLegacyStyle
+deriving instance Data (Key CompanyUserLegacyStyle)
+
+mkPersist sqlSettings {mpsCamelCaseCompositeKeySelector = True}
+  [persistLowerCase|
+    CompanyUserCamelStyle
+      companyName Text
+      userName Text
+      Primary companyName userName
+  |]
+
+deriving instance Data CompanyUserCamelStyle
+deriving instance Data (Key CompanyUserCamelStyle)
+
+spec :: Spec
+spec = describe "CompositeKeyStyleSpec" $ do
+  describe "mpsCamelCaseCompositeKeySelector is False" $ do
+    it "Should generate Legacy style key selectors" $ do
+      let key = CompanyUserLegacyStyleKey "cName" "uName"
+
+      constrFields (toConstr key)
+        `shouldBe`
+          [ "companyUserLegacyStyleKeycompanyName"
+          , "companyUserLegacyStyleKeyuserName"
+          ]
+  describe "mpsCamelCaseCompositeKeySelector is True" $ do
+    it "Should generate CamelCase style key selectors" $ do
+      let key = CompanyUserCamelStyleKey "cName" "uName"
+
+      constrFields (toConstr key)
+        `shouldBe`
+          [ "companyUserCamelStyleKeyCompanyName"
+          , "companyUserCamelStyleKeyUserName"
+          ]

--- a/persistent/test/Database/Persist/THSpec.hs
+++ b/persistent/test/Database/Persist/THSpec.hs
@@ -50,6 +50,7 @@ import TemplateTestImports
 
 
 import qualified Database.Persist.TH.CommentSpec as CommentSpec
+import qualified Database.Persist.TH.CompositeKeyStyleSpec as CompositeKeyStyleSpec
 import qualified Database.Persist.TH.DiscoverEntitiesSpec as DiscoverEntitiesSpec
 import qualified Database.Persist.TH.EmbedSpec as EmbedSpec
 import qualified Database.Persist.TH.ForeignRefSpec as ForeignRefSpec
@@ -198,6 +199,7 @@ spec = describe "THSpec" $ do
     ToFromPersistValuesSpec.spec
     JsonEncodingSpec.spec
     CommentSpec.spec
+    CompositeKeyStyleSpec.spec
     describe "TestDefaultKeyCol" $ do
         let EntityIdField FieldDef{..} =
                 entityId (entityDef (Proxy @TestDefaultKeyCol))

--- a/persistent/test/Database/Persist/THSpec.hs
+++ b/persistent/test/Database/Persist/THSpec.hs
@@ -1,10 +1,10 @@
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
@@ -24,8 +24,6 @@
 
 module Database.Persist.THSpec where
 
-import System.Environment
-import Data.Time
 import Control.Applicative (Const(..))
 import Data.Aeson (decode, encode)
 import Data.ByteString.Lazy.Char8 ()
@@ -35,7 +33,9 @@ import Data.Int
 import qualified Data.List as List
 import Data.Proxy
 import Data.Text (Text, pack)
+import Data.Time
 import GHC.Generics (Generic)
+import System.Environment
 import Test.Hspec
 import Test.Hspec.QuickCheck
 import Test.QuickCheck.Arbitrary
@@ -57,19 +57,19 @@ import qualified Database.Persist.TH.ForeignRefSpec as ForeignRefSpec
 import qualified Database.Persist.TH.ImplicitIdColSpec as ImplicitIdColSpec
 import qualified Database.Persist.TH.JsonEncodingSpec as JsonEncodingSpec
 import qualified Database.Persist.TH.KindEntitiesSpec as KindEntitiesSpec
-import qualified Database.Persist.TH.NestedSymbolsInTypeSpec as NestedSymbolsInTypeSpec
 import qualified Database.Persist.TH.MaybeFieldDefsSpec as MaybeFieldDefsSpec
 import qualified Database.Persist.TH.MigrationOnlySpec as MigrationOnlySpec
 import qualified Database.Persist.TH.MultiBlockSpec as MultiBlockSpec
+import qualified Database.Persist.TH.NestedSymbolsInTypeSpec as NestedSymbolsInTypeSpec
 import qualified Database.Persist.TH.NoFieldSelectorsSpec as NoFieldSelectorsSpec
 import qualified Database.Persist.TH.OverloadedLabelSpec as OverloadedLabelSpec
 import qualified Database.Persist.TH.PersistWithSpec as PersistWithSpec
 import qualified Database.Persist.TH.RequireOnlyPersistImportSpec as RequireOnlyPersistImportSpec
 import qualified Database.Persist.TH.SharedPrimaryKeyImportedSpec as SharedPrimaryKeyImportedSpec
 import qualified Database.Persist.TH.SharedPrimaryKeySpec as SharedPrimaryKeySpec
+import qualified Database.Persist.TH.SumSpec as SumSpec
 import qualified Database.Persist.TH.ToFromPersistValuesSpec as ToFromPersistValuesSpec
 import qualified Database.Persist.TH.TypeLitFieldDefsSpec as TypeLitFieldDefsSpec
-import qualified Database.Persist.TH.SumSpec as SumSpec
 
 -- test to ensure we can have types ending in Id that don't trash the TH
 -- machinery


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [x] Ran `stylish-haskell` on any changed files.
- [ ] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

----

In accordance with the  #1420 , this PR adds an additional field `mpsCamelCaseCompositeKeySelector` to the `MkPersistSettings`.
This field can be used to determine whether the entity composite key selectors should continue to match the Legacy style (**companyUserKeycompanyId**) or match the CameCase style (**companyUserKeyCompanyId**).