### PR TITLE
Add existsBy

### DIFF
--- a/persistent-mongoDB/Database/Persist/MongoDB.hs
+++ b/persistent-mongoDB/Database/Persist/MongoDB.hs
@@ -136,7 +136,7 @@ import Data.Bits (shiftR)
 import Data.Bson (ObjectId(..))
 import qualified Data.ByteString as BS
 import Data.Conduit
-import Data.Maybe (fromJust, mapMaybe)
+import Data.Maybe (fromJust, isJust, mapMaybe)
 import Data.Monoid (mappend)
 import qualified Data.Pool as Pool
 import qualified Data.Serialize as Serialize
@@ -604,6 +604,8 @@ instance PersistUniqueRead DB.MongoContext where
       where
         t = entityDef $ Just rec
         rec = dummyFromUnique uniq
+
+    existsBy uniq = isJust <$> getBy uniq
 
 instance PersistUniqueWrite DB.MongoContext where
     deleteBy uniq =

--- a/persistent-mongoDB/Database/Persist/MongoDB.hs
+++ b/persistent-mongoDB/Database/Persist/MongoDB.hs
@@ -136,7 +136,7 @@ import Data.Bits (shiftR)
 import Data.Bson (ObjectId(..))
 import qualified Data.ByteString as BS
 import Data.Conduit
-import Data.Maybe (fromJust, isJust, mapMaybe)
+import Data.Maybe (fromJust, mapMaybe)
 import Data.Monoid (mappend)
 import qualified Data.Pool as Pool
 import qualified Data.Serialize as Serialize

--- a/persistent-mongoDB/Database/Persist/MongoDB.hs
+++ b/persistent-mongoDB/Database/Persist/MongoDB.hs
@@ -605,8 +605,6 @@ instance PersistUniqueRead DB.MongoContext where
         t = entityDef $ Just rec
         rec = dummyFromUnique uniq
 
-    existsBy uniq = isJust <$> getBy uniq
-
 instance PersistUniqueWrite DB.MongoContext where
     deleteBy uniq =
         DB.delete DB.Select {

--- a/persistent-test/src/PersistUniqueTest.hs
+++ b/persistent-test/src/PersistUniqueTest.hs
@@ -51,6 +51,18 @@ specsWith runDb = describe "PersistUniqueTest" $ do
             Just vu <- getBy (UniqueBar b)
             vu @== Entity k vk
 
+    describe "existsBy" $ do
+        it "works to query the existence of a record in the database" $ runDb $ do
+            let b = 5
+            k <- insert Fo { foFoo = 3, foBar = b }
+            result <- existsBy $ UniqueBar b
+            result @== True
+
+        it "returns false for nonexistent records" $ runDb $ do
+            insert_ Fo { foFoo = 3, foBar = 5 }
+            result <- existsBy $ UniqueBar 17
+            result @== False
+
     describe "insertUniqueEntity" $ do
         it "inserts a value if no conflicts are present" $ runDb $ do
             let fo = Fo 3 5

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,8 +1,13 @@
 # Changelog for persistent
 
+## 2.14.5.0
+
+* [#1437](https://github.com/yesodweb/persistent/pull/1437)
+    * Add `existsBy` to `PersistUniqueRead`
+
 ## 2.14.4.4
 
-* [#1460] https://github.com/yesodweb/persistent/pull/1460
+* [#1460](https://github.com/yesodweb/persistent/pull/1460)
     * Fix a problem where a `Primary` key causes `mkPersist` to generate code
       that doesn't compile under `NoFieldSelectors`
 

--- a/persistent/Database/Persist/Class/PersistUnique.hs
+++ b/persistent/Database/Persist/Class/PersistUnique.hs
@@ -78,6 +78,25 @@ class PersistStoreRead backend => PersistUniqueRead backend  where
         :: forall record m. (MonadIO m, PersistRecordBackend record backend)
         => Unique record -> ReaderT backend m (Maybe (Entity record))
 
+    -- | Returns True if a record with this unique key exists, otherwise False.
+    --
+    -- === __Example usage__
+    --
+    -- With <#schema-persist-unique-1 schema-1> and <#dataset-persist-unique-1 dataset-1>:
+    --
+    -- > existsBySpjName :: MonadIO m  => ReaderT SqlBackend m Bool
+    -- > existsBySpjName = existsBy $ UniqueUserName "SPJ"
+    --
+    -- > spjEntExists <- existsBySpjName
+    --
+    -- The above query when applied on <#dataset-persist-unique-1 dataset-1>, will return
+    -- the value True.
+    --
+    -- @since 2.14.4
+    existsBy
+        :: forall record m. (MonadIO m, PersistRecordBackend record backend)
+        => Unique record -> ReaderT backend m Bool
+
 -- | Some functions in this module ('insertUnique', 'insertBy', and
 -- 'replaceUnique') first query the unique indexes to check for
 -- conflicts. You could instead optimistically attempt to perform the

--- a/persistent/Database/Persist/Class/PersistUnique.hs
+++ b/persistent/Database/Persist/Class/PersistUnique.hs
@@ -33,7 +33,7 @@ import Data.List (deleteFirstsBy, (\\))
 import Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NEL
 import qualified Data.Map as Map
-import Data.Maybe (catMaybes)
+import Data.Maybe (catMaybes, isJust)
 import GHC.TypeLits (ErrorMessage(..))
 
 import Database.Persist.Class.PersistEntity

--- a/persistent/Database/Persist/Class/PersistUnique.hs
+++ b/persistent/Database/Persist/Class/PersistUnique.hs
@@ -92,10 +92,11 @@ class PersistStoreRead backend => PersistUniqueRead backend  where
     -- The above query when applied on <#dataset-persist-unique-1 dataset-1>, will return
     -- the value True.
     --
-    -- @since 2.14.4
+    -- @since 2.14.5
     existsBy
         :: forall record m. (MonadIO m, PersistRecordBackend record backend)
         => Unique record -> ReaderT backend m Bool
+    existsBy uniq = isJust <$> getBy uniq
 
 -- | Some functions in this module ('insertUnique', 'insertBy', and
 -- 'replaceUnique') first query the unique indexes to check for

--- a/persistent/Database/Persist/Compatible/Types.hs
+++ b/persistent/Database/Persist/Compatible/Types.hs
@@ -12,10 +12,10 @@ module Database.Persist.Compatible.Types
     ( Compatible(..)
     ) where
 
+import Control.Monad.Trans.Reader (withReaderT)
 import Data.Aeson
 import Database.Persist.Class
 import Database.Persist.Sql.Class
-import Control.Monad.Trans.Reader (withReaderT)
 
 
 -- | A newtype wrapper for compatible backends, mainly useful for @DerivingVia@.

--- a/persistent/Database/Persist/Compatible/Types.hs
+++ b/persistent/Database/Persist/Compatible/Types.hs
@@ -104,6 +104,7 @@ instance (HasPersistBackend b, BackendCompatible b s, PersistQueryWrite b) => Pe
 
 instance (HasPersistBackend b, BackendCompatible b s, PersistUniqueRead b) => PersistUniqueRead (Compatible b s) where
     getBy = withReaderT (projectBackend @b @s . unCompatible) . getBy
+    existsBy = withReaderT (projectBackend @b @s . unCompatible) . existsBy
 
 instance (HasPersistBackend b, BackendCompatible b s, PersistStoreWrite b) => PersistStoreWrite (Compatible b s) where
     insert = withReaderT (projectBackend @b @s . unCompatible) . insert

--- a/persistent/Database/Persist/Sql/Orphan/PersistUnique.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistUnique.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ExplicitForAll  #-}
+{-# LANGUAGE ExplicitForAll #-}
 {-# OPTIONS_GHC -fno-warn-orphans  #-}
 module Database.Persist.Sql.Orphan.PersistUnique
   ()
@@ -8,18 +8,25 @@ import Control.Exception (throwIO)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Reader (ask)
 import qualified Data.Conduit.List as CL
+import Data.Foldable (toList)
 import Data.Function (on)
 import Data.List (nubBy)
 import qualified Data.Text as T
-import Data.Foldable (toList)
 
 import Database.Persist
-import Database.Persist.Class.PersistUnique (defaultUpsertBy, defaultPutMany, persistUniqueKeyValues)
+import Database.Persist.Class.PersistUnique
+       (defaultPutMany, defaultUpsertBy, persistUniqueKeyValues)
 
-import Database.Persist.Sql.Types.Internal
-import Database.Persist.Sql.Raw
 import Database.Persist.Sql.Orphan.PersistStore (withRawQuery)
-import Database.Persist.Sql.Util (dbColumns, parseEntityValues, parseExistsResult, updatePersistValue, mkUpdateText')
+import Database.Persist.Sql.Raw
+import Database.Persist.Sql.Types.Internal
+import Database.Persist.Sql.Util
+       ( dbColumns
+       , mkUpdateText'
+       , parseEntityValues
+       , parseExistsResult
+       , updatePersistValue
+       )
 
 instance PersistUniqueWrite SqlBackend where
     upsertBy uniqueKey record updates = do

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:            persistent
-version:         2.14.4.4
+version:         2.14.5.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
This adds `existsBy` in `PersistUniqueRead`, as a more efficient version of `isJust <$> getBy uniq`.

The intent is to provide an (a) more convenient to type and (b) more efficient way to query existence of a row by unique key.

The SQL is a combination of the `exists` and `getBy` impls, and looks like `SELECT EXISTS (SELECT 1 FROM ...constraints...)`.

The performance difference shouldn't be large, but conceivably on wider tables (or with heavy columns eg. JSON or binary blobs), `existsBy` would require less serialization (just a single response column) and may allow the query planner to do an index-only plan.

What do you think?

---

Before submitting your PR, check that you've:

- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [x] Ran `stylish-haskell` on any changed files.
- [x] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
