### PR TITLE
Clarify error message wording

### DIFF
--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -1191,7 +1191,7 @@ mkUnique mps entityMap entDef (UniqueDef constr _ fields attrs) =
               , "values to be equal for the purposes of an uniqueness constraint, "
               , "allowing insertion of more than one row with a NULL value for the "
               , "column in question.  If you understand this feature of SQL and still "
-              , "intend to add a uniqueness constraint here,    *** Use a "!force" "
+              , "intend to add a uniqueness constraint here,    *** Use a \"!force\" "
               , "attribute on the end of the line that defines your uniqueness "
               , "constraint in order to disable this check. ***" ]
 

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -1185,15 +1185,15 @@ mkUnique mps entityMap entDef (UniqueDef constr _ fields attrs) =
             lookup3 x rest
 
     nullErrMsg =
-      mconcat = [ "Error:  By default Persistent disallows NULLables in an uniqueness "
-                , "constraint.  The semantics of how NULL interacts with those constraints "
-                , "is non-trivial:  most SQL implementations will not consider two NULL "
-                , "values to be equal for the purposes of an uniqueness constraint, "
-                , "allowing insertion of more than one row with a NULL value for the "
-                , "column in question.  If you understand this feature of SQL and still "
-                , "intend to add a uniqueness constraint here,    *** Use a "!force" "
-                , "attribute on the end of the line that defines your uniqueness "
-                , "constraint in order to disable this check. ***" ]
+      mconcat [ "Error:  By default Persistent disallows NULLables in an uniqueness "
+              , "constraint.  The semantics of how NULL interacts with those constraints "
+              , "is non-trivial:  most SQL implementations will not consider two NULL "
+              , "values to be equal for the purposes of an uniqueness constraint, "
+              , "allowing insertion of more than one row with a NULL value for the "
+              , "column in question.  If you understand this feature of SQL and still "
+              , "intend to add a uniqueness constraint here,    *** Use a "!force" "
+              , "attribute on the end of the line that defines your uniqueness "
+              , "constraint in order to disable this check. ***" ]
 
 -- | This function renders a Template Haskell 'Type' for an 'UnboundFieldDef'.
 -- It takes care to respect the 'mpsGeneric' setting to render an Id faithfully,

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -1185,14 +1185,15 @@ mkUnique mps entityMap entDef (UniqueDef constr _ fields attrs) =
             lookup3 x rest
 
     nullErrMsg =
-      mconcat [ "Error:  By default we disallow NULLables in an uniqueness "
-              , "constraint.  The semantics of how NULL interacts with those "
-              , "constraints is non-trivial:  two NULL values are not "
-              , "considered equal for the purposes of an uniqueness "
-              , "constraint.  If you understand this feature, it is possible "
-              , "to use it your advantage.    *** Use a \"!force\" attribute "
-              , "on the end of the line that defines your uniqueness "
-              , "constraint in order to disable this check. ***" ]
+      mconcat = [ "Error:  By default Persistent disallows NULLables in an uniqueness "
+                , "constraint.  The semantics of how NULL interacts with those constraints "
+                , "is non-trivial:  most SQL implementations will not consider two NULL "
+                , "values to be equal for the purposes of an uniqueness constraint, "
+                , "allowing insertion of more than one row with a NULL value for the "
+                , "column in question.  If you understand this feature of SQL and still "
+                , "intend to add a uniqueness constraint here,    *** Use a "!force" "
+                , "attribute on the end of the line that defines your uniqueness "
+                , "constraint in order to disable this check. ***" ]
 
 -- | This function renders a Template Haskell 'Type' for an 'UnboundFieldDef'.
 -- It takes care to respect the 'mpsGeneric' setting to render an Id faithfully,


### PR DESCRIPTION
Just suggesting a wording change on the warning message when trying to add a uniqueness constraint to a nullable column.

Some people were confused about whether this warning came from our in-house code or from Persistent, so I clarified that. Also, some people were confused about whose equality semantics treated nulls as not equal, so I clarified that it's a SQL thing.

~~~

Before submitting your PR, check that you've:

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [ ] Ran `stylish-haskell` on any changed files.
- [ ] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
