### PR TITLE
NFData PersistValue

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for persistent
 
+## 2.14.4.0
+
+* [#1440](https://github.com/yesodweb/persistent/pull/1440)
+    * Defined NFData PersistValue
+
 ## 2.14.3.1
 
 * [#1428](https://github.com/yesodweb/persistent/pull/1428)

--- a/persistent/Database/Persist/PersistValue.hs
+++ b/persistent/Database/Persist/PersistValue.hs
@@ -11,6 +11,7 @@ module Database.Persist.PersistValue
     , LiteralType(..)
     ) where
 
+import Control.DeepSeq
 import qualified Data.ByteString.Base64 as B64
 import qualified Data.Text.Encoding as TE
 import qualified Data.ByteString.Char8 as BS8
@@ -69,6 +70,25 @@ data PersistValue
     --
     -- @since 2.12.0.0
     deriving (Show, Read, Eq, Ord)
+
+instance NFData PersistValue where
+  rnf val = case val of
+    PersistText txt -> rnf txt
+    PersistByteString bs -> rnf bs
+    PersistInt64 i -> rnf i
+    PersistDouble d -> rnf d
+    PersistRational q -> rnf q
+    PersistBool b -> rnf b
+    PersistDay d -> rnf d
+    PersistTimeOfDay t -> rnf t
+    PersistUTCTime t -> rnf t
+    PersistNull -> ()
+    PersistList vals -> rnf vals
+    PersistMap vals -> rnf vals
+    PersistObjectId bs -> rnf bs
+    PersistArray vals -> rnf vals
+    PersistLiteral_ ty bs -> ty `seq` rnf bs
+
 
 -- | A type that determines how a backend should handle the literal.
 --

--- a/persistent/Database/Persist/PersistValue.hs
+++ b/persistent/Database/Persist/PersistValue.hs
@@ -71,6 +71,8 @@ data PersistValue
     -- @since 2.12.0.0
     deriving (Show, Read, Eq, Ord)
 
+-- |
+-- @since 2.14.4.0
 instance NFData PersistValue where
   rnf val = case val of
     PersistText txt -> rnf txt

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -24,6 +24,7 @@ library
       , bytestring               >= 0.10
       , conduit                  >= 1.2.12
       , containers               >= 0.5
+      , deepseq
       , fast-logger              >= 2.4
       , http-api-data            >= 0.3
       , lift-type                >= 0.1.0.0 && < 0.2.0.0
@@ -127,6 +128,7 @@ test-suite test
       , bytestring
       , conduit
       , containers
+      , deepseq
       , fast-logger
       , hspec         >= 2.4
       , http-api-data


### PR DESCRIPTION
Fully evaluating a `PersistValue` is important for gathering correct metrics. E.g. to get an accurate estimation of how long the SQL itself takes to run, it's essential to force the `[PersistValue]` which is used to construct the statement _before_ starting the timer.