### PR TITLE
Default impl for insert_ that does not do a secondary query

### DIFF
--- a/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
@@ -159,6 +159,18 @@ instance PersistStoreWrite SqlBackend where
         rawExecute sql $
             map updatePersistValue upds `mappend` keyToValues k
 
+    insert_ val = do
+        conn <- ask
+        let vals = mkInsertValues val
+        case connInsertSql conn (entityDef (Just val)) vals  of
+            ISRSingle sql -> do
+                withRawQuery sql vals $ do
+                    pure ()
+            ISRInsertGet sql1 _sql2 -> do
+                rawExecute sql1 vals
+            ISRManyKeys sql _fs -> do
+                rawExecute sql vals
+
     insert val = do
         conn <- ask
         let esql = connInsertSql conn t vals


### PR DESCRIPTION
Fixes #1441 

This is a patch-level PR that swaps out the default implementation of `insert_` for one that *does not* perform a secondary query. In local testing, this fixes the issue where `insert` and `insert_` take the same amount of time for SQLite. All tests pass locally for `postgresql`. There is likely not a performance benefit for Postgres since it';sa ble to do `insert ... returning ..`. However, the code never demands the result, so it is probably not parsed.

Before submitting your PR, check that you've:

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [ ] Ran `stylish-haskell` on any changed files.
- [ ] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
