### PR TITLE
Support `mtl >= 2.3`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -8,6 +8,10 @@ packages:
   persistent-redis
   persistent-qq
 
+constraints:
+    mtl == 2.3.1
+    , exceptions == 0.10.7
+
 -- GHC 9.4 shims for persistent
 
 -- These need hackage revisions but otherwise test fine in the repo

--- a/cabal.project
+++ b/cabal.project
@@ -10,7 +10,6 @@ packages:
 
 constraints:
     mtl == 2.3.1
-    , exceptions == 0.10.7
 
 -- GHC 9.4 shims for persistent
 
@@ -19,3 +18,8 @@ allow-newer:
     -- https://github.com/haskellari/postgresql-simple/pull/95
    , postgresql-simple:base
    , postgresql-simple:template-haskell
+
+source-repository-package
+    type: git
+    location: https://github.com/ysangkok/hedis
+    tag: 6f36989836b49974f51a6ee8edaf156490590980

--- a/cabal.project
+++ b/cabal.project
@@ -18,7 +18,7 @@ allow-newer:
 
 -- Needed to test that `persistent-redis` works with mtl-2.3
 -- https://github.com/informatikr/hedis/pull/190
-source-repository-package
-    type: git
-    location: https://github.com/ysangkok/hedis
-    tag: 6f36989836b49974f51a6ee8edaf156490590980
+-- source-repository-package
+--     type: git
+--     location: https://github.com/ysangkok/hedis
+--     tag: 6f36989836b49974f51a6ee8edaf156490590980

--- a/cabal.project
+++ b/cabal.project
@@ -8,9 +8,6 @@ packages:
   persistent-redis
   persistent-qq
 
-constraints:
-    mtl == 2.3.1
-
 -- GHC 9.4 shims for persistent
 
 -- These need hackage revisions but otherwise test fine in the repo
@@ -19,6 +16,8 @@ allow-newer:
    , postgresql-simple:base
    , postgresql-simple:template-haskell
 
+-- Needed to test that `persistent-redis` works with mtl-2.3
+-- https://github.com/informatikr/hedis/pull/190
 source-repository-package
     type: git
     location: https://github.com/ysangkok/hedis

--- a/persistent-redis/persistent-redis.cabal
+++ b/persistent-redis/persistent-redis.cabal
@@ -24,7 +24,7 @@ library
                    , bytestring            >= 0.10.8   && < 0.12
                    , hedis                 >= 0.9
                    , http-api-data
-                   , mtl                   >= 2.2.1    && < 2.3
+                   , mtl                   >= 2.2.1    && < 2.4
                    , path-pieces           >= 0.2
                    , scientific            >= 0.3.5    && < 0.4
                    , text                  >= 1.2

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for persistent
 
+## 2.14.4.2
+
+* [#1451](https://github.com/yesodweb/persistent/pull/1451)
+    * Support `mtl >= 2.3`
+
 ## 2.14.4.1
 
 * [#1449](https://github.com/yesodweb/persistent/pull/1449)

--- a/persistent/Database/Persist/Sql/Run.hs
+++ b/persistent/Database/Persist/Sql/Run.hs
@@ -5,7 +5,8 @@ module Database.Persist.Sql.Run where
 
 import Control.Monad.IO.Unlift
 import Control.Monad.Logger.CallStack
-import Control.Monad.Reader (MonadReader, void)
+import Control.Monad (void)
+import Control.Monad.Reader (MonadReader)
 import qualified Control.Monad.Reader as MonadReader
 import Control.Monad.Trans.Reader hiding (local)
 import Control.Monad.Trans.Resource

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:            persistent
-version:         2.14.4.1
+version:         2.14.4.2
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>
@@ -29,7 +29,7 @@ library
       , http-api-data            >= 0.3
       , lift-type                >= 0.1.0.0 && < 0.2.0.0
       , monad-logger             >= 0.3.28
-      , mtl                                    < 2.3
+      , mtl                                   
       , path-pieces              >= 0.2
       , resource-pool            >= 0.2.3
       , resourcet                >= 1.1.10

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,7 +11,6 @@ packages:
   - ./persistent-qq
 
 extra-deps:
-  - mtl-2.3
   - lift-type-0.1.0.0
   - mysql-0.2.1
   - mysql-simple-0.4.7

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,6 +11,7 @@ packages:
   - ./persistent-qq
 
 extra-deps:
+  - mtl-2.3
   - lift-type-0.1.0.0
   - mysql-0.2.1
   - mysql-simple-0.4.7


### PR DESCRIPTION
Tested locally by forcing `mtl == 2.3.1` in the `constraints`. Appears to work OK.

`persistent-redis` has an upper bound, but `hedis` itself can't work. Pending https://github.com/informatikr/hedis/pull/190 PR. 

Before submitting your PR, check that you've:

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [ ] Ran `stylish-haskell` on any changed files.
- [ ] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
