### PR TITLE
make repsert a special case of repsertMany

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog for persistent
 
+## 2.14.4.3
+
+* [#1452](https://github.com/yesodweb/persistent/pull/1452)
+    * Implement `repsert` as a special case of `respertMany`.  Allows backend
+      specific behavior.
+
 ## 2.14.4.2
 
 * [#1451](https://github.com/yesodweb/persistent/pull/1451)

--- a/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
+++ b/persistent/Database/Persist/Sql/Orphan/PersistStore.hs
@@ -303,9 +303,9 @@ instance PersistStoreWrite SqlBackend where
                     Just _  -> mkInsertValues r
         case connRepsertManySql conn of
             (Just mkSql) -> rawExecute (mkSql ent nr) (concatMap toVals krs)
-            Nothing -> mapM_ (uncurry repsert') krs
+            Nothing -> mapM_ repsert' krs
               where
-                repsert' = do
+                repsert' (key, value) = do
                   mExisting <- get key
                   case mExisting of
                     Nothing -> insertKey key value

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:            persistent
-version:         2.14.4.2
+version:         2.14.4.3
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
`repsertMany` admits backends to provide a custom implementation via `connRepsertManySql`. in the case of the postrgres backend, repsertMany becomes an atomic operation.  It would be nice to take advantage of this for `repsert` as well.  (it's fairly well known as a gotcha in our codebase but this would be a nice QoL improvement for us)

Before submitting your PR, check that you've:

- [ ] ~Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)~
- [ ] ~Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock~
- [x] Ran `stylish-haskell` on any changed files.
- [x] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
