### PR TITLE
Make use of `CautiousMigration` type alias in SQL backends.

### DIFF
--- a/persistent-mysql/ChangeLog.md
+++ b/persistent-mysql/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for persistent-mysql
 
+##  2.13.1.4
+
+* [#1459](https://github.com/yesodweb/persistent/pull/1459)
+    * Make use of `CautiousMigration` type alias for clarity.
+
 ##  2.13.1.3
 
 * [#1372](https://github.com/yesodweb/persistent/pull/1372)

--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -355,7 +355,7 @@ migrate' :: MySQL.ConnectInfo
          -> [EntityDef]
          -> (Text -> IO Statement)
          -> EntityDef
-         -> IO (Either [Text] [(Bool, Text)])
+         -> IO (Either [Text] CautiousMigration)
 migrate' connectInfo allDefs getter val = do
     let name = getEntityDBName val
     let (newcols, udefs, fdefs) = mysqlMkColumns allDefs val

--- a/persistent-mysql/persistent-mysql.cabal
+++ b/persistent-mysql/persistent-mysql.cabal
@@ -1,5 +1,5 @@
 name:            persistent-mysql
-version:         2.13.1.3
+version:         2.13.1.4
 license:         MIT
 license-file:    LICENSE
 author:          Felipe Lessa <felipe.lessa@gmail.com>, Michael Snoyman

--- a/persistent-postgresql/ChangeLog.md
+++ b/persistent-postgresql/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for persistent-postgresql
 
+## 2.13.5.1
+
+* [#1459](https://github.com/yesodweb/persistent/pull/1459)
+    * Make use of `CautiousMigration` type alias for clarity.
+
 ## 2.13.5.0
 
 * [#1362](https://github.com/yesodweb/persistent/pull/1362/)

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -612,7 +612,7 @@ doesTableExist getter (EntityNameDB name) = do
 migrate' :: [EntityDef]
          -> (Text -> IO Statement)
          -> EntityDef
-         -> IO (Either [Text] [(Bool, Text)])
+         -> IO (Either [Text] CautiousMigration)
 migrate' allDefs getter entity = fmap (fmap $ map showAlterDb) $ do
     old <- getColumns getter entity newcols'
     case partitionEithers old of

--- a/persistent-postgresql/persistent-postgresql.cabal
+++ b/persistent-postgresql/persistent-postgresql.cabal
@@ -1,5 +1,5 @@
 name:            persistent-postgresql
-version:         2.13.5.0
+version:         2.13.5.1
 license:         MIT
 license-file:    LICENSE
 author:          Felipe Lessa, Michael Snoyman <michael@snoyman.com>

--- a/persistent-sqlite/ChangeLog.md
+++ b/persistent-sqlite/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for persistent-sqlite
 
+## 2.13.1.1
+
+* [#1459](https://github.com/yesodweb/persistent/pull/1459)
+    * Make use of `CautiousMigration` type alias for clarity.
+
 ## 2.13.1.0
 
 * [#1341](https://github.com/yesodweb/persistent/pull/1341)

--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -112,7 +112,6 @@ import qualified Database.Persist.Sql.Util as Util
 import Database.Persist.SqlBackend
 import qualified Database.Sqlite as Sqlite
 
-
 -- | Create a pool of SQLite connections.
 --
 -- Note that this should not be used with the @:memory:@ connection string, as
@@ -442,7 +441,7 @@ migrate'
     :: [EntityDef]
     -> (Text -> IO Statement)
     -> EntityDef
-    -> IO (Either [Text] [(Bool, Text)])
+    -> IO (Either [Text] CautiousMigration)
 migrate' allDefs getter val = do
     let (cols, uniqs, fdefs) = sqliteMkColumns allDefs val
     let newSql = mkCreateTable False def (filter (not . safeToRemove val . cName) cols, uniqs, fdefs)

--- a/persistent-sqlite/persistent-sqlite.cabal
+++ b/persistent-sqlite/persistent-sqlite.cabal
@@ -1,5 +1,5 @@
 name:            persistent-sqlite
-version:         2.13.1.0
+version:         2.13.1.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
When reading `migrate'` implementations of `persistent-sqlite` and `persistent-postgresql` it took me a while to figure out what `(Bool, Text)` actually means. Using the type alias from `Database.Persist.Sql.Migration` makes it clearer.