### PR TITLE
fix a problem preventing use of Primary with NoFieldselectors

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog for persistent
 
+## 2.14.4.4
+
+* [#1460] https://github.com/yesodweb/persistent/pull/1460
+    * Fix a problem where a `Primary` key causes `mkPersist` to generate code
+      that doesn't compile under `NoFieldSelectors`
+
 ## 2.14.4.3
 
 * [#1452](https://github.com/yesodweb/persistent/pull/1452)

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:            persistent
-version:         2.14.4.3
+version:         2.14.4.4
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/persistent/test/Database/Persist/TH/NoFieldSelectorsSpec.hs
+++ b/persistent/test/Database/Persist/TH/NoFieldSelectorsSpec.hs
@@ -21,7 +21,10 @@ import TemplateTestImports
 
 mkPersist sqlSettings {mpsFieldLabelModifier = const id} [persistLowerCase|
 User
+    ident Text
     name Text
+    Primary ident
+    team TeamId
 
 Team
     name Text


### PR DESCRIPTION
There was a couple of places where it still generates code using selector functions; this PR replaces them with `fieldSel`.

Before submitting your PR, check that you've:

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [ ] Ran `stylish-haskell` on any changed files.
- [x] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
