### PR TITLE
Remove extraneous `map toPersistValue` call.

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog for persistent
 
+## unreleased
+
+* [#1460] https://github.com/yesodweb/persistent/pull/1468
+    * Remove extraneous `map toPersistValue` call in the `mkInsertValues`
+      function, as it evaluates to `id`.
+
 ## 2.14.4.4
 
 * [#1460] https://github.com/yesodweb/persistent/pull/1460

--- a/persistent/Database/Persist/Sql/Util.hs
+++ b/persistent/Database/Persist/Sql/Util.hs
@@ -243,7 +243,6 @@ mkInsertValues
 mkInsertValues entity =
     Maybe.catMaybes
         . zipWith redactGeneratedCol (getEntityFields . entityDef $ Just entity)
-        . map toPersistValue
         $ toPersistFields entity
   where
     redactGeneratedCol fd pv = case fieldGenerated fd of


### PR DESCRIPTION
The list produced by `toPersistFields entity` is already of type `[PersistValue]`. This can be checked by putting a type hole inside, which will reveal that `toPersistValue` call in this context has `PersistValue -> PersistValue` type and boils down to `id`.

Before submitting your PR, check that you've:

- [X] Ran `stylish-haskell` on any changed files.
- [X] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [X] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)