### PR TITLE
Explicitly import Control.Monad.Trans for mtl-2.3 compat

### DIFF
--- a/persistent-postgresql/ChangeLog.md
+++ b/persistent-postgresql/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for persistent-postgresql
 
+## 2.13.5.2
+
+* [#1471](https://github.com/yesodweb/persistent/pull/1471)
+   * Explicitly import `Control.Monad.Trans.lift` to support mtl-2.3.
+
 ## 2.13.5.1
 
 * [#1459](https://github.com/yesodweb/persistent/pull/1459)

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -83,6 +83,7 @@ import Control.Monad.Except
 import Control.Monad.IO.Unlift (MonadIO(..), MonadUnliftIO)
 import Control.Monad.Logger (MonadLoggerIO, runNoLoggingT)
 import Control.Monad.Trans.Reader (ReaderT(..), asks, runReaderT)
+import Control.Monad.Trans.Class (lift)
 #if !MIN_VERSION_base(4,12,0)
 import Control.Monad.Trans.Reader (withReaderT)
 #endif

--- a/persistent-postgresql/persistent-postgresql.cabal
+++ b/persistent-postgresql/persistent-postgresql.cabal
@@ -1,5 +1,5 @@
 name:            persistent-postgresql
-version:         2.13.5.1
+version:         2.13.5.2
 license:         MIT
 license-file:    LICENSE
 author:          Felipe Lessa, Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
I needed to make this change to have this module compile with GHC-9.6.1-alpha1.
I see that there is already an mtl-2.3 compat branch merged, so I'm not sure why this wasn't picked up there.
Perhaps this was being re-exported by something else?
