### PR TITLE
Avoid parse error occurred when the field name generated by TH matches any of Haskell keywords

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,10 +1,12 @@
 # Changelog for persistent
 
-## unreleased
+## 2.14.4.5
 
 * [#1460] https://github.com/yesodweb/persistent/pull/1468
     * Remove extraneous `map toPersistValue` call in the `mkInsertValues`
       function, as it evaluates to `id`.
+* [#1476](https://github.com/yesodweb/persistent/pull/1476)
+    * Fix `mkRecordName` to suffix `_` if the field name matches any of Haskell keywords.
 
 ## 2.14.4.4
 

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -3100,7 +3100,7 @@ mkEntityLensName mps entDef fieldDef =
 
 mkRecordName :: MkPersistSettings -> Maybe Text -> EntityNameHS -> FieldNameHS -> Name
 mkRecordName mps prefix entNameHS fieldNameHS =
-    mkName $ T.unpack $ fromMaybe "" prefix <> lowerFirst recName
+    mkName $ T.unpack . avoidKeyword $ fromMaybe "" prefix <> lowerFirst recName
   where
     recName :: Text
     recName
@@ -3114,6 +3114,17 @@ mkRecordName mps prefix entNameHS fieldNameHS =
     fieldNameText :: Text
     fieldNameText =
         unFieldNameHS fieldNameHS
+
+    avoidKeyword :: Text -> Text
+    avoidKeyword name = if name `elem` keywords then name ++ "_" else name
+
+    keywords :: [Text]
+    keywords =
+      ["case","class","data","default","deriving","do","else"
+      ,"if","import","in","infix","infixl","infixr","instance","let","module"
+      ,"newtype","of","then","type","where","_"
+      ,"foreign"
+      ]
 
 -- | Construct a list of TH Names for the typeclasses of an EntityDef's `entityDerives`
 mkEntityDefDeriveNames :: MkPersistSettings -> UnboundEntityDef -> [Name]

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -3118,13 +3118,13 @@ mkRecordName mps prefix entNameHS fieldNameHS =
     avoidKeyword :: Text -> Text
     avoidKeyword name = if name `Set.member` haskellKeywords then name ++ "_" else name
 
-haskellKeywords :: Set Text
+haskellKeywords :: Set.Set Text
 haskellKeywords = Set.fromList
-      ["case","class","data","default","deriving","do","else"
-      ,"if","import","in","infix","infixl","infixr","instance","let","module"
-      ,"newtype","of","then","type","where","_"
-      ,"foreign"
-      ]
+    ["case","class","data","default","deriving","do","else"
+    ,"if","import","in","infix","infixl","infixr","instance","let","module"
+    ,"newtype","of","then","type","where","_"
+    ,"foreign"
+    ]
 
 -- | Construct a list of TH Names for the typeclasses of an EntityDef's `entityDerives`
 mkEntityDefDeriveNames :: MkPersistSettings -> UnboundEntityDef -> [Name]

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -3116,10 +3116,10 @@ mkRecordName mps prefix entNameHS fieldNameHS =
         unFieldNameHS fieldNameHS
 
     avoidKeyword :: Text -> Text
-    avoidKeyword name = if name `elem` keywords then name ++ "_" else name
+    avoidKeyword name = if name `Set.member` haskellKeywords then name ++ "_" else name
 
-    keywords :: [Text]
-    keywords =
+haskellKeywords :: Set Text
+haskellKeywords = Set.fromList
       ["case","class","data","default","deriving","do","else"
       ,"if","import","in","infix","infixl","infixr","instance","let","module"
       ,"newtype","of","then","type","where","_"

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:            persistent
-version:         2.14.4.4
+version:         2.14.4.5
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/persistent/test/Database/Persist/TH/NoFieldSelectorsSpec.hs
+++ b/persistent/test/Database/Persist/TH/NoFieldSelectorsSpec.hs
@@ -25,6 +25,7 @@ User
     name Text
     Primary ident
     team TeamId
+    type Text
 
 Team
     name Text


### PR DESCRIPTION
To avoid the problem that GHC fails compiling due to parse error when the field name generated by Template Haskell matches any of Haskell keywords, this PR fixes `mkRecordName` to suffix `_` if the field name matches any of keywords.

Before submitting your PR, check that you've:

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [x] Ran `stylish-haskell` on any changed files.
- [x] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)
