### PR TITLE
Handle qualified table name

### DIFF
--- a/persistent-redis/persistent-redis.cabal
+++ b/persistent-redis/persistent-redis.cabal
@@ -29,7 +29,7 @@ library
                    , scientific            >= 0.3.5    && < 0.4
                    , text                  >= 1.2
                    , time                  >= 1.6
-                   , transformers          >= 0.5         && < 0.6
+                   , transformers          >= 0.5
                    , utf8-string           >= 1.0         && < 1.1
 
     exposed-modules: Database.Persist.Redis

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## 2.14.6.0 (unreleased)
 
+* [#1477](https://github.com/yesodweb/persistent/pull/1477)
+    * Qualified references to other tables will work
 * [#1503](https://github.com/yesodweb/persistent/pull/1503)
     * Create Haddocks from entity documentation comments
 * [1497](https://github.com/yesodweb/persistent/pull/1497)

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -521,8 +521,9 @@ guessReference ft =
     guessReferenceText mft =
         asum
             [ do
-                FTTypeCon _ (checkIdSuffix -> Just tableName) <- mft
-                pure tableName
+                FTTypeCon mmod (checkIdSuffix -> Just tableName) <- mft
+                -- handle qualified name.
+                pure $ maybe tableName (\qualName -> qualName <> "." <> tableName) mmod
             , do
                 FTApp (FTTypeCon _ "Key") (FTTypeCon _ tableName) <- mft
                 pure tableName


### PR DESCRIPTION
When a table name is specified with qualifier, the guessed name for SqlType had better be qualified by default in order to avoid   potential name collisions with the unqualified name.

Before submitting your PR, check that you've:

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [x] Ran `stylish-haskell` on any changed files.
- [x] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
