### PR TITLE
add Database.Sqlite.open' which takes a ByteString

### DIFF
--- a/persistent-sqlite/ChangeLog.md
+++ b/persistent-sqlite/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for persistent-sqlite
 
+## 2.13.2.0 (unreleased)
+
+* [#1486](https://github.com/yesodweb/persistent/pull/1486)
+    * Add Database.Sqlite.open' which takes a ByteString
+
 ## 2.13.1.1
 
 * [#1459](https://github.com/yesodweb/persistent/pull/1459)


### PR DESCRIPTION
This allows using a sqlite database that is in a directory whose name cannot be expressed using Text.

Fixes https://github.com/yesodweb/persistent/issues/1481

Eventually it would make sense for open to use OsPath, but the [Abstract FilePath Proposal](https://gitlab.haskell.org/ghc/ghc/-/wikis/proposal/abstract-file-path) is still rolling out. In the meantime, this avoids an API change for users of open.

Before submitting your PR, check that you've:

- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [x] Ran `stylish-haskell` on any changed files.
- [x] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)
