### PR TITLE
Import `Control.Monad` in `persistent-qq`

### DIFF
--- a/persistent-qq/test/Spec.hs
+++ b/persistent-qq/test/Spec.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TypeFamilies #-}
 
+import Control.Monad (when)
 import Control.Monad.Logger (LoggingT, runLoggingT)
 import Control.Monad.Trans.Resource
 import Control.Monad.Reader


### PR DESCRIPTION
mtl-2.3 removes these reexports
