### PR TITLE
persistent-sqlite: Add `openRawSqliteConn`

### DIFF
--- a/persistent-sqlite/ChangeLog.md
+++ b/persistent-sqlite/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog for persistent-sqlite
 
+## 2.13.2
+
+* [#1488](https://github.com/yesodweb/persistent/pull/1488)
+    * Add `openRawSqliteConn` for creating `RawSqlite SqlBackend` connections
+      that aren't automatically cleaned-up.
+
 ## 2.13.1.1
 
 * [#1459](https://github.com/yesodweb/persistent/pull/1459)

--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -48,6 +48,7 @@ module Database.Persist.Sqlite
     , ForeignKeyViolation(..)
     , checkForeignKeys
     , RawSqlite
+    , openRawSqliteConn
     , persistentBackend
     , rawSqliteConnection
     , withRawSqliteConnInfo
@@ -937,6 +938,20 @@ data RawSqlite backend = RawSqlite
     { _persistentBackend :: backend -- ^ The persistent backend
     , _rawSqliteConnection :: Sqlite.Connection -- ^ The underlying `Sqlite.Connection`
     }
+
+-- | Open a @'RawSqlite' 'SqlBackend'@ connection from a 'SqliteConnectionInfo'.
+--
+-- When using this function, the caller has to accept the responsibility of
+-- cleaning up the resulting connection. To do this, use 'close' with the
+-- 'rawSqliteConnection' - it's enough to simply drop the 'persistBackend'
+-- afterwards.
+openRawSqliteConn
+    :: (MonadUnliftIO m, MonadLoggerIO m)
+    => SqliteConnectionInfo
+    -> m (RawSqlite SqlBackend)
+openRawSqliteConn connInfo = do
+    logFunc <- askLoggerIO
+    liftIO $ openWith RawSqlite connInfo logFunc
 
 instance BackendCompatible b (RawSqlite b) where
     projectBackend = _persistentBackend

--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -945,6 +945,8 @@ data RawSqlite backend = RawSqlite
 -- cleaning up the resulting connection. To do this, use 'close' with the
 -- 'rawSqliteConnection' - it's enough to simply drop the 'persistBackend'
 -- afterwards.
+--
+-- @since 2.13.2
 openRawSqliteConn
     :: (MonadUnliftIO m, MonadLoggerIO m)
     => SqliteConnectionInfo

--- a/persistent-sqlite/Database/Persist/Sqlite.hs
+++ b/persistent-sqlite/Database/Persist/Sqlite.hs
@@ -95,8 +95,8 @@ import qualified Data.Conduit.Combinators as C
 import qualified Data.Conduit.List as CL
 import Data.Foldable (toList)
 import qualified Data.HashMap.Lazy as HashMap
-import Data.Int (Int64)
 import Data.IORef (newIORef)
+import Data.Int (Int64)
 import Data.Maybe
 import Data.Pool (Pool)
 import Data.Text (Text)

--- a/persistent-sqlite/persistent-sqlite.cabal
+++ b/persistent-sqlite/persistent-sqlite.cabal
@@ -1,5 +1,5 @@
 name:            persistent-sqlite
-version:         2.13.1.1
+version:         2.13.2.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
This adds a new function for manually constructing a `RawSqlite SqlBackend` connection without having to use the resource-cleaning `with*` functions.

I want to use this because I'm working with a `resource-pool` fork and I don't want to be constricted by the API exposed by `persistent-sqlite` for creating pools - but I can't create my own custom pool without a way to create new `RawSqlite SqlBackend` resources from scratch that don't get automatically cleaned up.

---

Before submitting your PR, check that you've:

- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [x] Ran `stylish-haskell` on any changed files.
- [x] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
