### PR TITLE
Support deserialising Word (and Word8 etc.) from PersistDouble

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,5 +1,12 @@
 # Changelog for persistent
 
+## 2.14.5.1
+
+* [#1491](https://github.com/yesodweb/persistent/pull/1491)
+    * Change `PersistField` instance for `Word`, `Word64`, etc. to allow
+      deserialising from `PersistDouble` values, by truncating the floating
+      point value.
+
 ## 2.14.5.0
 
 * [#1469](https://github.com/yesodweb/persistent/pull/1469)

--- a/persistent/Database/Persist/Class/PersistField.hs
+++ b/persistent/Database/Persist/Class/PersistField.hs
@@ -1,44 +1,46 @@
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE GADTs #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE PatternGuards, DataKinds, TypeOperators, UndecidableInstances, GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
 module Database.Persist.Class.PersistField
     ( PersistField (..)
     , getPersistMap
     , OverflowNatural(..)
     ) where
 
+import Control.Applicative ((<|>))
 import Control.Arrow (second)
 import Control.Monad ((<=<))
-import Control.Applicative ((<|>))
 import qualified Data.Aeson as A
-import Data.ByteString.Char8 (ByteString, unpack, readInt)
+import Data.ByteString.Char8 (ByteString, readInt, unpack)
 import qualified Data.ByteString.Lazy as L
 import Data.Fixed
-import Data.Int (Int8, Int16, Int32, Int64)
+import Data.Int (Int16, Int32, Int64, Int8)
 import qualified Data.IntMap as IM
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Data.Map as M
 import qualified Data.Set as S
 import Data.Text (Text)
 import qualified Data.Text as T
-import Data.Text.Read (double)
 import qualified Data.Text.Encoding as TE
 import qualified Data.Text.Encoding.Error as TERR
 import qualified Data.Text.Lazy as TL
+import Data.Text.Read (double)
 import qualified Data.Vector as V
-import Data.Word (Word, Word8, Word16, Word32, Word64)
+import Data.Word (Word, Word16, Word32, Word64, Word8)
+import GHC.TypeLits
 import Numeric.Natural (Natural)
 import Text.Blaze.Html
 import Text.Blaze.Html.Renderer.Text (renderHtml)
-import GHC.TypeLits
 
 import Database.Persist.Types.Base
 
-import Data.Time (Day(..), TimeOfDay, UTCTime,
-    parseTimeM)
-import Data.Time (defaultTimeLocale)
+import Data.Time (Day(..), TimeOfDay, UTCTime, defaultTimeLocale, parseTimeM)
 
 #ifdef HIGH_PRECISION_DATE
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)

--- a/persistent/Database/Persist/Class/PersistField.hs
+++ b/persistent/Database/Persist/Class/PersistField.hs
@@ -209,26 +209,31 @@ intParseError haskellType original = T.concat
 instance PersistField Data.Word.Word where
     toPersistValue = PersistInt64 . fromIntegral
     fromPersistValue (PersistInt64 i) = Right $ fromIntegral i
+    fromPersistValue (PersistDouble i) = Right $ truncate i
     fromPersistValue x = Left $ fromPersistValueError "Word" "integer" x
 
 instance PersistField Word8 where
     toPersistValue = PersistInt64 . fromIntegral
     fromPersistValue (PersistInt64 i) = Right $ fromIntegral i
+    fromPersistValue (PersistDouble i) = Right $ truncate i
     fromPersistValue x = Left $ fromPersistValueError "Word8" "integer" x
 
 instance PersistField Word16 where
     toPersistValue = PersistInt64 . fromIntegral
     fromPersistValue (PersistInt64 i) = Right $ fromIntegral i
+    fromPersistValue (PersistDouble i) = Right $ truncate i
     fromPersistValue x = Left $ fromPersistValueError "Word16" "integer" x
 
 instance PersistField Word32 where
     toPersistValue = PersistInt64 . fromIntegral
     fromPersistValue (PersistInt64 i) = Right $ fromIntegral i
+    fromPersistValue (PersistDouble i) = Right $ truncate i
     fromPersistValue x = Left $ fromPersistValueError "Word32" "integer" x
 
 instance PersistField Word64 where
     toPersistValue = PersistInt64 . fromIntegral
     fromPersistValue (PersistInt64 i) = Right $ fromIntegral i
+    fromPersistValue (PersistDouble i) = Right $ truncate i
     fromPersistValue x = Left $ fromPersistValueError "Word64" "integer" x
 
 instance PersistField Double where

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:            persistent
-version:         2.14.5.0
+version:         2.14.5.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
This implements approach no. 2 as discussed in #831. Just after authoring this I noticed that there's also PR #1096 which seems to do something more like approach no. 3, and it would conflict with this PR (e.g. it's stricter about deserialising PersistDoubles), though it looks like it's stalled for now.

Closes: #831

Before submitting your PR, check that you've:

- [ ] ~~Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock~~ I'd like to add these to the relevant instances documenting the change in behaviour, but it looks like Haddock doesn't support adding a comment or the like.
- [x] Ran `stylish-haskell` on any changed files.
- [x] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
