### PR TITLE
Fixes name shadowing error at keyFromRecordM for Primary keys

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* #1496
+* [#1496](https://github.com/yesodweb/persistent/pull/1496)
     * Fixes name shadowing error at the generated `keyFromRecordM` function.
 
 ## 2.14.5.0

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for persistent
 
+## Unreleased
+
+* #1496
+    * Fixes name shadowing error at the generated `keyFromRecordM` function.
+
 ## 2.14.5.0
 
 * [#1469](https://github.com/yesodweb/persistent/pull/1469)

--- a/persistent/test/Database/Persist/TH/CompositeKeyStyleSpec.hs
+++ b/persistent/test/Database/Persist/TH/CompositeKeyStyleSpec.hs
@@ -10,6 +10,8 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE UndecidableInstances #-}
 
+{-# OPTIONS_GHC -Wname-shadowing -Werror=name-shadowing #-}
+
 module Database.Persist.TH.CompositeKeyStyleSpec where
 
 import Data.Data (Data, constrFields, toConstr)


### PR DESCRIPTION
With a persistent definition like,

```
Customer
  firstName String
  lastName String
  Primary firstName lastName
```

the `keyFromRecordM` was generated like 
```
keyFromRecordM = Just
            (\ Customer {customerFirstName = customerFirstName,
                         customerLastName = customerLastName}
               -> (CustomerKey customerFirstName) customerLastName)
```

hence the name-shadowing error.

The fixes is simply append index to those variables, like

```
keyFromRecordM
        = Just
            (\ Customer {customerFirstName = customerFirstName_1,
                         customerLastName = customerLastName_2}
               -> (CustomerKey customerFirstName_1) customerLastName_2)

```

-----

Before submitting your PR, check that you've:

- [x] Ran `stylish-haskell` on any changed files.

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
