### PR TITLE
Always creates `SymbolToField "id"` instance

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for persistent
 
+## Unreleased
+
+* [1497](https://github.com/yesodweb/persistent/pull/1497)
+    * Always generates `SymbolToField "id"` instance
+
 ## 2.14.5.1
 
 * [#1496](https://github.com/yesodweb/persistent/pull/1496)

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -2980,11 +2980,7 @@ mkSymbolToFieldInstances mps entityMap (fixEntityDef -> ed) = do
                 mkEntityFieldConstr fieldHaskellName
         mkInstance fieldNameT fieldTypeT entityFieldConstr
 
-    mkey <-
-        case unboundPrimarySpec ed of
-            NaturalKey _ ->
-                pure []
-            _ -> do
+    mkey <- do
                 let
                     fieldHaskellName =
                         FieldNameHS "Id"

--- a/persistent/test/Database/Persist/TH/OverloadedLabelSpec.hs
+++ b/persistent/test/Database/Persist/TH/OverloadedLabelSpec.hs
@@ -1,23 +1,23 @@
-{-# LANGUAGE DataKinds                  #-}
-{-# LANGUAGE DerivingStrategies         #-}
-{-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE FlexibleInstances          #-}
-{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE MultiParamTypeClasses      #-}
-{-# LANGUAGE OverloadedLabels           #-}
-{-# LANGUAGE PartialTypeSignatures      #-}
-{-# LANGUAGE QuasiQuotes                #-}
-{-# LANGUAGE StandaloneDeriving         #-}
-{-# LANGUAGE TemplateHaskell            #-}
-{-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE UndecidableInstances       #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 {-# OPTIONS_GHC -Wname-shadowing -Werror=name-shadowing #-}
 
 module Database.Persist.TH.OverloadedLabelSpec where
 
-import           TemplateTestImports
+import TemplateTestImports
 
 mkPersist sqlSettings [persistUpperCase|
 
@@ -33,6 +33,10 @@ Dog
 Organization
     name    String
 
+Student
+    userId  UserId
+    departmentName String
+    Primary userId
 |]
 
 spec :: Spec
@@ -57,6 +61,12 @@ spec = describe "OverloadedLabels" $ do
     it "works for id labels" $ do
         let UserId = #id
             orgId = #id :: EntityField Organization OrganizationId
+
+        compiles
+
+    it "works for Primary labels" $ do
+        let StudentId = #id
+            studentId = #id :: EntityField Student StudentId
 
         compiles
 


### PR DESCRIPTION
## Context

- Regardless the type of primary key, there is always a `{EntityName}Id` type hence I think it's safe to always create a `SymbolToField` instance for ID.
