### PR TITLE
Create Haddocks from entity documentation comments

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for persistent
 
+## 2.14.6.0
+
+* [#1503](https://github.com/yesodweb/persistent/pull/1503)
+    * Create Haddocks from entity documentation comments
+
 ## 2.14.5.0
 
 * [#1469](https://github.com/yesodweb/persistent/pull/1469)

--- a/persistent/Database/Persist/Quasi.hs
+++ b/persistent/Database/Persist/Quasi.hs
@@ -612,8 +612,9 @@ Likewise, the field documentation is present in the @fieldComments@ field on the
 "A user can be old, or young, and we care about\nthis for some reason."
 @
 
-Unfortunately, we can't use this to create Haddocks for you, because <https://gitlab.haskell.org/ghc/ghc/issues/5467 Template Haskell does not support Haddock yet>.
-@persistent@ backends *can* use this to generate SQL @COMMENT@s, which are useful for a database perspective, and you can use the <https://hackage.haskell.org/package/persistent-documentation @persistent-documentation@> library to render a Markdown document of the entity definitions.
+Since @persistent-2.14.6.0@, documentation comments on *entities* are included in documentation generated using Haddock.
+Generating Haddocks for fields is not yet supported in Template Haskell.
+@persistent@ backends can also use this to generate SQL @COMMENT@s, which are useful for a database perspective, and you can use the <https://hackage.haskell.org/package/persistent-documentation @persistent-documentation@> library to render a Markdown document of the entity definitions.
 
 = Sum types
 

--- a/persistent/Database/Persist/Quasi.hs
+++ b/persistent/Database/Persist/Quasi.hs
@@ -612,8 +612,7 @@ Likewise, the field documentation is present in the @fieldComments@ field on the
 "A user can be old, or young, and we care about\nthis for some reason."
 @
 
-Since @persistent-2.14.6.0@, documentation comments on *entities* are included in documentation generated using Haddock if `mpsEntityHaddocks` is enabled (defaults to False).
-Generating Haddocks for fields is not yet supported in Template Haskell.
+Since @persistent-2.14.6.0@, documentation comments are included in documentation generated using Haddock if `mpsEntityHaddocks` is enabled (defaults to False).
 @persistent@ backends can also use this to generate SQL @COMMENT@s, which are useful for a database perspective, and you can use the <https://hackage.haskell.org/package/persistent-documentation @persistent-documentation@> library to render a Markdown document of the entity definitions.
 
 = Sum types

--- a/persistent/Database/Persist/Quasi.hs
+++ b/persistent/Database/Persist/Quasi.hs
@@ -612,7 +612,7 @@ Likewise, the field documentation is present in the @fieldComments@ field on the
 "A user can be old, or young, and we care about\nthis for some reason."
 @
 
-Since @persistent-2.14.6.0@, documentation comments on *entities* are included in documentation generated using Haddock.
+Since @persistent-2.14.6.0@, documentation comments on *entities* are included in documentation generated using Haddock if `mpsEntityHaddocks` is enabled (defaults to False).
 Generating Haddocks for fields is not yet supported in Template Haskell.
 @persistent@ backends can also use this to generate SQL @COMMENT@s, which are useful for a database perspective, and you can use the <https://hackage.haskell.org/package/persistent-documentation @persistent-documentation@> library to render a Markdown document of the entity definitions.
 

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -45,6 +45,7 @@ module Database.Persist.TH
     , mpsPrefixFields
     , mpsFieldLabelModifier
     , mpsConstraintLabelModifier
+    , mpsEntityHaddocks
     , mpsEntityJSON
     , mpsGenerateLenses
     , mpsDeriveInstances
@@ -1070,6 +1071,10 @@ data MkPersistSettings = MkPersistSettings
     -- Note: this setting is ignored if mpsPrefixFields is set to False.
     --
     -- @since 2.11.0.0
+    , mpsEntityHaddocks :: Bool
+    -- ^ Generate Haddocks from entity documentation comments. Default: False.
+    --
+    -- @since 2.14.6.0
     , mpsEntityJSON :: Maybe EntityJSON
     -- ^ Generate @ToJSON@/@FromJSON@ instances for each model types. If it's
     -- @Nothing@, no instances will be generated. Default:
@@ -1161,6 +1166,7 @@ mkPersistSettings backend = MkPersistSettings
     , mpsPrefixFields = True
     , mpsFieldLabelModifier = (++)
     , mpsConstraintLabelModifier = (++)
+    , mpsEntityHaddocks = False
     , mpsEntityJSON = Just EntityJSON
         { entityToJSON = 'entityIdToJSON
         , entityFromJSON = 'entityIdFromJSON
@@ -1209,8 +1215,9 @@ dataTypeDec mps entityMap entDef = do
                 (stockDerives <> anyclassDerives)
 #if __GLASGOW_HASKELL__ > 900
     case entityComments (unboundEntityDef entDef) of
-        Just doc -> withDecDoc (unpack doc) (pure dec)
-        Nothing -> pure dec
+        Just doc
+            | mpsEntityHaddocks mps -> withDecDoc (unpack doc) (pure dec)
+        _ -> pure dec
 #else
     pure dec
 #endif

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -121,7 +121,7 @@ import Instances.TH.Lift ()
 import Data.Foldable (asum, toList)
 import qualified Data.Set as Set
 import Language.Haskell.TH.Lib
-#if __GLASGOW_HASKELL__ > 900
+#if MIN_VERSION_template_haskell(2,18,0)
        (appT, conE, conK, conT, litT, strTyLit, varE, varP, varT, withDecDoc)
 #else
        (appT, conE, conK, conT, litT, strTyLit, varE, varP, varT)
@@ -1213,7 +1213,7 @@ dataTypeDec mps entityMap entDef = do
                 Nothing
                 constrs
                 (stockDerives <> anyclassDerives)
-#if __GLASGOW_HASKELL__ > 900
+#if MIN_VERSION_template_haskell(2,18,0)
     case entityComments (unboundEntityDef entDef) of
         Just doc
             | mpsEntityHaddocks mps -> withDecDoc (unpack doc) (pure dec)

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -145,6 +145,7 @@ test-suite test
       , silently
       , template-haskell         >= 2.4
       , text
+      , th-lift
       , th-lift-instances
       , time
       , transformers
@@ -172,6 +173,7 @@ test-suite test
         Database.Persist.TH.CompositeKeyStyleSpec
         Database.Persist.TH.DiscoverEntitiesSpec
         Database.Persist.TH.EmbedSpec
+        Database.Persist.TH.EntityHaddockSpec
         Database.Persist.TH.ForeignRefSpec
         Database.Persist.TH.ImplicitIdColSpec
         Database.Persist.TH.JsonEncodingSpec

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -145,7 +145,6 @@ test-suite test
       , silently
       , template-haskell         >= 2.4
       , text
-      , th-lift
       , th-lift-instances
       , time
       , transformers

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:            persistent
-version:         2.14.5.0
+version:         2.14.6.0
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/persistent/test/Database/Persist/TH/CommentSpec.hs
+++ b/persistent/test/Database/Persist/TH/CommentSpec.hs
@@ -12,14 +12,19 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Database.Persist.TH.CommentSpec where
+{-# OPTIONS_GHC -haddock #-}
+
+module Database.Persist.TH.CommentSpec
+    ( CommentModel (..)
+    , spec
+    ) where
 
 import TemplateTestImports
 
 import Database.Persist.EntityDef.Internal (EntityDef(..))
 import Database.Persist.FieldDef.Internal (FieldDef(..))
 
-mkPersist sqlSettings [persistLowerCase|
+mkPersist (sqlSettings {mpsEntityHaddocks = True}) [persistLowerCase|
 
 -- | Doc comments work.
 -- | Has multiple lines.

--- a/persistent/test/Database/Persist/TH/EntityHaddockSpec.hs
+++ b/persistent/test/Database/Persist/TH/EntityHaddockSpec.hs
@@ -8,7 +8,7 @@ import TemplateTestImports
 #if MIN_VERSION_template_haskell(2,18,0)
 import Database.Persist.TH.CommentSpec (CommentModel (..))
 import Language.Haskell.TH (DocLoc (DeclDoc), getDoc)
-import Language.Haskell.TH.Lift (lift)
+import Language.Haskell.TH.Syntax (lift)
 
 [d|
     commentModelDoc :: Maybe String

--- a/persistent/test/Database/Persist/TH/EntityHaddockSpec.hs
+++ b/persistent/test/Database/Persist/TH/EntityHaddockSpec.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Database.Persist.TH.EntityHaddockSpec (spec) where
+
+import TemplateTestImports
+
+#if MIN_VERSION_template_haskell(2,18,0)
+import Database.Persist.TH.CommentSpec (CommentModel (..))
+import Language.Haskell.TH (DocLoc (DeclDoc), getDoc)
+import Language.Haskell.TH.Lift (lift)
+
+[d|
+    commentModelDoc :: Maybe String
+    commentModelDoc = $(lift =<< getDoc (DeclDoc ''CommentModel))
+
+    commentFieldDoc :: Maybe String
+    commentFieldDoc = $(lift =<< getDoc (DeclDoc 'commentModelName))
+    |]
+
+spec :: Spec
+spec = describe "EntityHaddockSpec" $ do
+    it "generates entity Haddock" $ do
+        let expected = unlines [ "Doc comments work."
+                               , "Has multiple lines."
+                               ]
+        commentModelDoc `shouldBe` Just expected
+    it "generates field Haddock" $ do
+        let expected = unlines [ "First line of comment on column."
+                               , "Second line of comment on column."
+                               ]
+        commentFieldDoc `shouldBe` Just expected
+#else
+spec :: Spec
+spec = pure ()
+#endif

--- a/persistent/test/Database/Persist/THSpec.hs
+++ b/persistent/test/Database/Persist/THSpec.hs
@@ -53,6 +53,7 @@ import qualified Database.Persist.TH.CommentSpec as CommentSpec
 import qualified Database.Persist.TH.CompositeKeyStyleSpec as CompositeKeyStyleSpec
 import qualified Database.Persist.TH.DiscoverEntitiesSpec as DiscoverEntitiesSpec
 import qualified Database.Persist.TH.EmbedSpec as EmbedSpec
+import qualified Database.Persist.TH.EntityHaddockSpec as EntityHaddockSpec
 import qualified Database.Persist.TH.ForeignRefSpec as ForeignRefSpec
 import qualified Database.Persist.TH.ImplicitIdColSpec as ImplicitIdColSpec
 import qualified Database.Persist.TH.JsonEncodingSpec as JsonEncodingSpec
@@ -204,6 +205,7 @@ spec = describe "THSpec" $ do
     ToFromPersistValuesSpec.spec
     JsonEncodingSpec.spec
     CommentSpec.spec
+    EntityHaddockSpec.spec
     CompositeKeyStyleSpec.spec
     describe "TestDefaultKeyCol" $ do
         let EntityIdField FieldDef{..} =


### PR DESCRIPTION
This PR adds a flag to `MkPersistSettings` which enables Haddock generation from entity documentation comments. The default is `False` to avoid any unexpected performance impacts from upgrading `persistent`.

Fixes #1462.

---

Before submitting your PR, check that you've:

- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
  - Changes to the documentation assume that this feature will be made available in `persistent` version `2.14.6.0`.
- [x] Ran `stylish-haskell` on any changed files.
  - `stylish-haskell` fails on the `#if`-`#else`-`#endif` construct in the import list in `TH.hs` as all three preprocessor directives are ignored, resulting in two identifier lists for `Language.Haskell.TH.Lib`.
- [x] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [x] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
