### PR TITLE
Store object IDs as blobs in SQL

### DIFF
--- a/persistent-mongoDB/Database/Persist/MongoDB.hs
+++ b/persistent-mongoDB/Database/Persist/MongoDB.hs
@@ -238,10 +238,10 @@ instance PersistField DB.ObjectId where
     fromPersistValue _ = Left $ T.pack "expected PersistObjectId"
 
 instance Sql.PersistFieldSql DB.ObjectId where
-    sqlType _ = Sql.SqlOther "doesn't make much sense for MongoDB"
+    sqlType = const Sql.SqlBlob
 
 instance Sql.PersistFieldSql (BackendKey DB.MongoContext) where
-    sqlType _ = Sql.SqlOther "doesn't make much sense for MongoDB"
+    sqlType = const Sql.SqlBlob
 
 
 withConnection :: (Trans.MonadIO m)


### PR DESCRIPTION
I'm mostly opening this PR for discussion. 

The `persistent-mongoDB` package provides a `PersistFieldSql` instance for the `ObjectId` type. Unfortunately the implementation just uses `SqlOther` with a message to the developer. Usually this doesn't matter because MongoDB doesn't use `PersistFieldSql`. The instance could have anything in it and everything would still work.

However, a proper instance for the `ObjectId` type is useful if you want to store object IDs in a SQL database. In that case, storing them as a `BLOB` makes sense. In fact that's what the `PersistField` instance already does. 

Does this change make sense? Am I missing something else about these instances? 