### PR TITLE
persistent-postgresql: add `createPostgresqlPoolTailored` function

### DIFF
--- a/persistent-postgresql/ChangeLog.md
+++ b/persistent-postgresql/ChangeLog.md
@@ -5,6 +5,7 @@
 * [#1511](https://github.com/yesodweb/persistent/pull/1511)
    * Add `createPostgresqlPoolTailored` function to support creating connection
      pools with a custom connection creation function.
+   * Expose `getServerVersion` and `createBackend` for user's convenience.
 
 ## 2.13.5.2
 

--- a/persistent-postgresql/ChangeLog.md
+++ b/persistent-postgresql/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog for persistent-postgresql
 
+## 2.13.6 (unreleased)
+
+* [#1511](https://github.com/yesodweb/persistent/pull/1511)
+   * Add `createPostgresqlPoolTailored` function to support creating connection
+     pools with a custom connection creation function.
+
 ## 2.13.5.2
 
 * [#1471](https://github.com/yesodweb/persistent/pull/1471)

--- a/persistent-postgresql/ChangeLog.md
+++ b/persistent-postgresql/ChangeLog.md
@@ -3,8 +3,8 @@
 ## 2.13.6 (unreleased)
 
 * [#1511](https://github.com/yesodweb/persistent/pull/1511)
-   * Add `createPostgresqlPoolTailored` function to support creating connection
-     pools with a custom connection creation function.
+   * Add the `createPostgresqlPoolTailored` function to support creating
+     connection pools with a custom connection creation function.
    * Expose `getServerVersion` and `createBackend` for user's convenience.
 
 ## 2.13.5.2

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -286,14 +286,9 @@ createPostgresqlPoolTailored
     =>
     (    (PG.Connection -> IO ())
       -> (PG.Connection -> IO (NonEmpty Word))
-      -> ((PG.Connection -> SqlBackend) -> PG.Connection -> SqlBackend)
-      -- ^ How to construct the actual backend type desired. For most uses,
-      -- this is just 'id', since the desired backend type is 'SqlBackend'.
-      -- But some callers want a @'RawPostgresql' 'SqlBackend'@, and will
-      -- pass in 'withRawConnection'.
+      -> ((PG.Connection -> SqlBackend) -> PG.Connection -> SqlBackend) -- ^ How to construct the actual backend type desired. For most uses, this is just 'id', since the desired backend type is 'SqlBackend'. But some callers want a @'RawPostgresql' 'SqlBackend'@, and will pass in 'withRawConnection'.
       -> ConnectionString -> LogFunc -> IO SqlBackend
-    )
-    -- ^ Action that creates a postgresql connection.
+    ) -- ^ Action that creates a postgresql connection.
     -> (PG.Connection -> IO (Maybe Double)) -- ^ Action to perform to get the server version.
     -> (PG.Connection -> IO ()) -- ^ Action to perform after connection is created.
     -> ConnectionString -- ^ Connection string to the database.

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -53,6 +53,7 @@ module Database.Persist.Postgresql
     , upsertManyWhere
     , openSimpleConn
     , openSimpleConnWithVersion
+    , getServerVersion
     , getSimpleConn
     , tableName
     , fieldName
@@ -358,6 +359,8 @@ open' modConn getVer constructor cstr logFunc = do
     return $ constructor (createBackend logFunc ver smap) conn
 
 -- | Gets the PostgreSQL server version
+--
+-- @since 2.13.6
 getServerVersion :: PG.Connection -> IO (Maybe Double)
 getServerVersion conn = do
   [PG.Only version] <- PG.query_ conn "show server_version";

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -83,8 +83,8 @@ import Control.Monad
 import Control.Monad.Except
 import Control.Monad.IO.Unlift (MonadIO(..), MonadUnliftIO)
 import Control.Monad.Logger (MonadLoggerIO, runNoLoggingT)
-import Control.Monad.Trans.Reader (ReaderT(..), asks, runReaderT)
 import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.Reader (ReaderT(..), asks, runReaderT)
 #if !MIN_VERSION_base(4,12,0)
 import Control.Monad.Trans.Reader (withReaderT)
 #endif
@@ -103,8 +103,8 @@ import qualified Data.Conduit.List as CL
 import Data.Data (Data)
 import Data.Either (partitionEithers)
 import Data.Function (on)
-import Data.IORef
 import Data.Int (Int64)
+import Data.IORef
 import Data.List (find, foldl', groupBy, sort)
 import qualified Data.List as List
 import Data.List.NonEmpty (NonEmpty)
@@ -123,12 +123,13 @@ import System.Environment (getEnvironment)
 #if MIN_VERSION_base(4,12,0)
 import Database.Persist.Compatible
 #endif
+import qualified Data.Vault.Strict as Vault
 import Database.Persist.Postgresql.Internal
 import Database.Persist.Sql
 import qualified Database.Persist.Sql.Util as Util
 import Database.Persist.SqlBackend
-import Database.Persist.SqlBackend.StatementCache (StatementCache, mkSimpleStatementCache, mkStatementCache)
-import qualified Data.Vault.Strict as Vault
+import Database.Persist.SqlBackend.StatementCache
+       (StatementCache, mkSimpleStatementCache, mkStatementCache)
 import System.IO.Unsafe (unsafePerformIO)
 
 -- | A @libpq@ connection string.  A simple example of connection

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -279,7 +279,7 @@ createPostgresqlPoolModifiedWithVersion = createPostgresqlPoolTailored open'
 -- The only time you should reach for this function is if you need to write custom logic for creating
 -- a connection to the database.
 --
--- @since 2.13.5.2
+-- @since 2.13.6
 createPostgresqlPoolTailored
     :: (MonadUnliftIO m, MonadLoggerIO m)
     =>

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -66,6 +66,7 @@ module Database.Persist.Postgresql
     , createRawPostgresqlPoolModified
     , createRawPostgresqlPoolModifiedWithVersion
     , createRawPostgresqlPoolWithConf
+    , createBackend
     ) where
 
 import qualified Database.PostgreSQL.LibPQ as LibPQ
@@ -439,6 +440,8 @@ getSimpleConn = Vault.lookup underlyingConnectionKey <$> getConnVault
 
 -- | Create the backend given a logging function, server version, mutable statement cell,
 -- and connection.
+--
+-- @since 2.13.6
 createBackend :: LogFunc -> NonEmpty Word
               -> IORef (Map.Map Text Statement) -> PG.Connection -> SqlBackend
 createBackend logFunc serverVersion smap conn =

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -286,9 +286,9 @@ createPostgresqlPoolTailored
     =>
     (    (PG.Connection -> IO ())
       -> (PG.Connection -> IO (NonEmpty Word))
-      -> ((PG.Connection -> SqlBackend) -> PG.Connection -> SqlBackend) -- ^ How to construct the actual backend type desired. For most uses, this is just 'id', since the desired backend type is 'SqlBackend'. But some callers want a @'RawPostgresql' 'SqlBackend'@, and will pass in 'withRawConnection'.
+      -> ((PG.Connection -> SqlBackend) -> PG.Connection -> SqlBackend)
       -> ConnectionString -> LogFunc -> IO SqlBackend
-    ) -- ^ Action that creates a postgresql connection.
+    ) -- ^ Action that creates a postgresql connection (please see documentation on the un-exported @open'@ function in this same module.
     -> (PG.Connection -> IO (Maybe Double)) -- ^ Action to perform to get the server version.
     -> (PG.Connection -> IO ()) -- ^ Action to perform after connection is created.
     -> ConnectionString -- ^ Connection string to the database.

--- a/persistent-postgresql/persistent-postgresql.cabal
+++ b/persistent-postgresql/persistent-postgresql.cabal
@@ -1,5 +1,5 @@
 name:            persistent-postgresql
-version:         2.13.5.2
+version:         2.13.6
 license:         MIT
 license-file:    LICENSE
 author:          Felipe Lessa, Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
This change adds a connection pool creation function that is just like the `createPostgresqlPoolModifiedWithVersion` function but that can take a custom `open'`-like connection-creation function.

The motivation for this change is that we need to be able to customize the resource creation action dynamically at run-time.

#### Before submitting your PR, check that you've:

- [X] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [X] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [X] Ran `stylish-haskell` on any changed files.
- [X] Adhered to the code style (see the `.editorconfig` file for details)

#### After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [X] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)
