### PR TITLE
Fix #1512 Allow use with aeson >= 2.2.0.0 and GHC 9.8

### DIFF
--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -121,6 +121,9 @@ import Data.Foldable (asum, toList)
 import qualified Data.Set as Set
 import Language.Haskell.TH.Lib
        (appT, conE, conK, conT, litT, strTyLit, varE, varP, varT)
+#if MIN_VERSION_template_haskell(2,21,0)
+import Language.Haskell.TH.Lib (defaultBndrFlag)
+#endif
 import Language.Haskell.TH.Quote
 import Language.Haskell.TH.Syntax
 import Web.HttpApiData (FromHttpApiData(..), ToHttpApiData(..))
@@ -2325,7 +2328,15 @@ mkLenses mps entityMap ent = fmap mconcat $ forM (getUnboundFieldDefs ent `zip` 
     where
         fieldNames = fieldDefToRecordName mps ent <$> getUnboundFieldDefs ent
 
-#if MIN_VERSION_template_haskell(2,17,0)
+#if MIN_VERSION_template_haskell(2,21,0)
+mkPlainTV
+    :: Name
+    -> TyVarBndr BndrVis
+mkPlainTV n = PlainTV n defaultBndrFlag
+
+mkForallTV :: Name -> TyVarBndr Specificity
+mkForallTV n = PlainTV n SpecifiedSpec
+#elif MIN_VERSION_template_haskell(2,17,0)
 mkPlainTV
     :: Name
     -> TyVarBndr ()

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -15,10 +15,11 @@ bug-reports:     https://github.com/yesodweb/persistent/issues
 extra-source-files: ChangeLog.md README.md
 
 library
-    build-depends:   
+    build-depends:
         base                     >= 4.11.1.0     && < 5
-      , aeson                    >= 1.0 && < 2.2
+      , aeson                    >= 1.0 && < 2.3
       , attoparsec
+      , attoparsec-aeson         >= 2.1.0.0 && < 2.3
       , base64-bytestring
       , blaze-html               >= 0.9
       , bytestring               >= 0.10
@@ -29,13 +30,13 @@ library
       , http-api-data            >= 0.3
       , lift-type                >= 0.1.0.0 && < 0.2.0.0
       , monad-logger             >= 0.3.28
-      , mtl                                   
+      , mtl
       , path-pieces              >= 0.2
       , resource-pool            >= 0.2.3
       , resourcet                >= 1.1.10
       , scientific
       , silently
-      , template-haskell         >= 2.13 && < 2.20
+      , template-haskell         >= 2.13 && < 2.22
       , text                     >= 1.2
       , th-lift-instances        >= 0.1.14    && < 0.2
       , time                     >= 1.6
@@ -46,13 +47,13 @@ library
       , vault
       , vector
 
-    default-extensions: 
+    default-extensions:
         FlexibleContexts
       , MultiParamTypeClasses
       , OverloadedStrings
       , TypeFamilies
 
-    exposed-modules: 
+    exposed-modules:
         Database.Persist
         Database.Persist.Types
         Database.Persist.Names
@@ -92,7 +93,7 @@ library
         Database.Persist.Class.PersistField
         Database.Persist.Class.PersistStore
 
-    other-modules:   
+    other-modules:
         Database.Persist.Types.Base
 
         Database.Persist.Sql.Internal
@@ -106,9 +107,9 @@ library
 
     -- These modules only make sense for compilers with access to DerivingVia
     if impl(ghc >= 8.6.1)
-        exposed-modules: 
+        exposed-modules:
             Database.Persist.Compatible
-        other-modules: 
+        other-modules:
             Database.Persist.Compatible.Types
             Database.Persist.Compatible.TH
 
@@ -119,7 +120,7 @@ test-suite test
     type:          exitcode-stdio-1.0
     main-is:       main.hs
 
-    build-depends:   
+    build-depends:
         base >= 4.9 && < 5
       , aeson
       , attoparsec
@@ -164,7 +165,7 @@ test-suite test
                       , TypeFamilies
                       , TypeOperators
 
-    other-modules:   
+    other-modules:
         Database.Persist.ClassSpec
         Database.Persist.PersistValueSpec
         Database.Persist.QuasiSpec


### PR DESCRIPTION
Written by referring, in part, to:
* the description in the Cabal file for [`attoparsec-aeson-2.1.0.0`](https://hackage.haskell.org/package/attoparsec-aeson-2.1.0.0); and
* the migration guide in the change log of [`th-abstraction-0.6.0.0`](https://hackage.haskell.org/package/th-abstraction-0.6.0.0/changelog).

Tested by building Stack (which depends on `persistent`) using GHC 9.8.0.20230809 on Alpine Linux (on WSL 2) and a dependency on `aeson-2.2.0.0`.