### PR TITLE
Bump versions for postgresql-simple and postgresql-libpq

### DIFF
--- a/persistent-postgresql/ChangeLog.md
+++ b/persistent-postgresql/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for persistent-postgresql
 
+## 2.13.5.3
+
+* [#1516](https://github.com/yesodweb/persistent/pull/1516)
+   * Support postgresql-simple 0.7 and postgresql-libpq 0.10
+
 ## 2.13.5.2
 
 * [#1471](https://github.com/yesodweb/persistent/pull/1471)

--- a/persistent-postgresql/persistent-postgresql.cabal
+++ b/persistent-postgresql/persistent-postgresql.cabal
@@ -1,5 +1,5 @@
 name:            persistent-postgresql
-version:         2.13.5.2
+version:         2.13.5.3
 license:         MIT
 license-file:    LICENSE
 author:          Felipe Lessa, Michael Snoyman <michael@snoyman.com>

--- a/persistent-postgresql/persistent-postgresql.cabal
+++ b/persistent-postgresql/persistent-postgresql.cabal
@@ -25,8 +25,8 @@ library
                    , containers            >= 0.5
                    , monad-logger          >= 0.3.25
                    , mtl
-                   , postgresql-simple     >= 0.6.1    && < 0.7
-                   , postgresql-libpq      >= 0.9.4.2  && < 0.10
+                   , postgresql-simple     >= 0.6.1    && < 0.8
+                   , postgresql-libpq      >= 0.9.4.2  && < 0.11
                    , resourcet             >= 1.1.9
                    , resource-pool
                    , string-conversions


### PR DESCRIPTION
Builds and tests fine

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
