### PR TITLE
postgres(normalize types to eliminate noop migrations)

### DIFF
--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -1103,7 +1103,15 @@ getColumn _ _ columnName _ =
 -- | Intelligent comparison of SQL types, to account for SqlInt32 vs SqlOther integer
 sqlTypeEq :: SqlType -> SqlType -> Bool
 sqlTypeEq x y =
-    T.toCaseFold (showSqlType x) == T.toCaseFold (showSqlType y)
+    let
+        -- Non exhaustive helper to map postgres aliases to the same name. Based on
+        -- https://www.postgresql.org/docs/9.5/datatype.html.
+        -- This prevents needless `ALTER TYPE`s when the type is the same.
+        normalize "int8"    = "bigint"
+        normalize "serial8" = "bigserial"
+        normalize v         = v
+    in
+        normalize (T.toCaseFold (showSqlType x)) == normalize (T.toCaseFold (showSqlType y))
 
 findAlters
     :: [EntityDef]


### PR DESCRIPTION
Fixes #1517. I've kept the list non exhaustive because I simply was not sure how to handle every case. Notably when the alias did not have a placeholder variable but the base name did (e.g. timestamptz). I also looked around in the `Postgresql.Simple` modules to see if something like this already existed but it did not look like it.

At the risk of sounding selfish, this fixes my immediate problem does not make the code worse.

<hr>

Before submitting your PR, check that you've:

- [x] Ran `stylish-haskell` on any changed files.
- [x] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
