### PR TITLE
Add keyAndEntityFieldsDatabase function to return key with migration only fields

### DIFF
--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -201,7 +201,28 @@ entityKeyFields =
 -- columns for an 'EntityDef'.
 keyAndEntityFields :: EntityDef -> NonEmpty FieldDef
 keyAndEntityFields ent =
-    case entityId ent of
+    keyWithFields (entityId ent) fields
+  where
+    fields = filter isHaskellField $ entityFields ent
+
+-- | Returns a 'NonEmpty' list of 'FieldDef' that correspond with the key
+-- columns for an 'EntityDef' including those fields that are marked as
+-- 'MigrationOnly' (and therefore only present in the database) or
+-- 'SafeToRemove' (and a migration will drop the column if it exists in the
+-- database).
+--
+-- For fields on the Haskell type use 'keyAndEntityFieldsDatabase'
+--
+-- @since 2.14.7.0
+keyAndEntityFieldsDatabase :: EntityDef -> NonEmpty FieldDef
+keyAndEntityFieldsDatabase ent =
+    keyWithFields (entityId ent) fields
+  where
+    fields = entityFields ent
+
+keyWithFields :: EntityIdDef -> [FieldDef] -> NonEmpty FieldDef
+keyWithFields entId fields =
+    case entId of
         EntityIdField fd ->
             fd :| fields
         EntityIdNaturalKey _ ->
@@ -214,8 +235,6 @@ keyAndEntityFields ent =
                         ]
                 Just xs ->
                     xs
-  where
-    fields = filter isHaskellField $ entityFields ent
 
 type ExtraLine = [Text]
 

--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -213,7 +213,7 @@ keyAndEntityFields ent =
 --
 -- For fields on the Haskell type use 'keyAndEntityFieldsDatabase'
 --
--- @since 2.14.7.0
+-- @since 2.14.6.0
 keyAndEntityFieldsDatabase :: EntityDef -> NonEmpty FieldDef
 keyAndEntityFieldsDatabase ent =
     keyWithFields (entityId ent) fields


### PR DESCRIPTION
This PR adds a version of the `keyAndEntityFields` function which includes `MigrationOnly` and `SafeToRemove` fields. We would like to make use of this in `persistent-documentation` in order to generate documentation for fields marked by those modifiers.

Before submitting your PR, check that you've:

- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [x] Ran `stylish-haskell` on any changed files.
- [x] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
