### PR TITLE
Remove attoparsec-aeson dependency

### DIFF
--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -19,7 +19,6 @@ library
         base                     >= 4.11.1.0     && < 5
       , aeson                    >= 1.0 && < 2.3
       , attoparsec
-      , attoparsec-aeson         >= 2.1.0.0 && < 2.3
       , base64-bytestring
       , blaze-html               >= 0.9
       , bytestring               >= 0.10


### PR DESCRIPTION
This dependency in `persistent` was causing issues with the stack resolver for `persistent-postgresql`.  Removing it seems to fix the issue.

Before submitting your PR, check that you've:

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [ ] Ran `stylish-haskell` on any changed files.
- [ ] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
