### PR TITLE
persistent-mysql: treat tinyint as SqlOther "tinyint", not SqlBool

### DIFF
--- a/persistent-mysql/ChangeLog.md
+++ b/persistent-mysql/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for persistent-mysql
 
+##  2.13.1.5
+
+* [#1526](https://github.com/yesodweb/persistent/pull/1526)
+    * Parse `tinyint` column as `SqlOther "tinyint"` rather than `SqlBool`, fixing breakage in legitimate non-Boolean uses of `tinyint` on MySQL 8.0
+
 ##  2.13.1.4
 
 * [#1459](https://github.com/yesodweb/persistent/pull/1459)

--- a/persistent-mysql/test/MyInit.hs
+++ b/persistent-mysql/test/MyInit.hs
@@ -137,7 +137,7 @@ runConn f = do
             }
     _ <- if not travis
       then withMySQLPool baseConnectInfo
-                        { connectHost     = "localhost"
+                        { connectHost     = "127.0.0.1"
                         , connectUser     = "test"
                         , connectPassword = "test"
                         , connectDatabase = "test"

--- a/persistent-mysql/test/main.hs
+++ b/persistent-mysql/test/main.hs
@@ -18,6 +18,7 @@ import MyInit
 
 import qualified Data.ByteString as BS
 import Data.Fixed
+import Data.Int (Int8)
 import Data.IntMap (IntMap)
 import qualified Data.Text as T
 import Data.Time (Day, TimeOfDay, UTCTime(..), timeOfDayToTime, timeToTimeOfDay)
@@ -90,6 +91,8 @@ DataTypeTable no-json
     -- off for older servers by defining OLD_MYSQL.
     timeFrac TimeOfDay sqltype=TIME(6)
     utcFrac UTCTime sqltype=DATETIME(6)
+    tinyint Int8 sqltype=TINYINT
+    tinyint4 Int8 sqltype=TINYINT(4)
 |]
 
 instance Arbitrary (DataTypeTableGeneric backend) where
@@ -110,7 +113,8 @@ instance Arbitrary (DataTypeTableGeneric backend) where
      <*> (truncateUTCTime   =<< arbitrary) -- utc
      <*> (truncateTimeOfDay =<< arbitrary) -- timeFrac
      <*> (truncateUTCTime   =<< arbitrary) -- utcFrac
-
+     <*> arbitrary              -- tinyint
+     <*> choose (-8, 7)         -- tinyint4
 setup :: (HasCallStack, MonadUnliftIO m) => Migration -> ReaderT SqlBackend m ()
 setup migration = do
   printMigration migration
@@ -169,6 +173,8 @@ main = do
             , TestFn "utc" (roundUTCTime . dataTypeTableUtc)
             , TestFn "timeFrac" (dataTypeTableTimeFrac)
             , TestFn "utcFrac" (dataTypeTableUtcFrac)
+            , TestFn "tinyint" dataTypeTableTinyint
+            , TestFn "tinyint4" dataTypeTableTinyint4
             ]
             [ ("pico", dataTypeTablePico) ]
             dataTypeTableDouble


### PR DESCRIPTION
I noticed that our application reports schema mismatch after upgrading to MySQL 8.0, even if I change the column type to `SqlOther "tinyint"` (removing the width). I realised that the recent versions of persistent-mysql parses tinyint as SqlBool, but it doesn't work in our usecase, where some tinyint columns represent non-Boolean values.

After this change, I confirmed that our application works both on MySQL 5.7 and MySQL 8.0, but I'm not quite confident that this change is in the right direction. What are your thoughts?

----

Before submitting your PR, check that you've:

- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [ ] Ran `stylish-haskell` on any changed files.
- [ ] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
