### PR TITLE
Allow `Integral` types to parse `PersistRational`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -9,7 +9,8 @@ packages:
   persistent-qq
 
 constraints:
-  mongoDB < 2.7.1.3 -- https://github.com/mongodb-haskell/mongodb/pull/152
+  -- https://github.com/mongodb-haskell/mongodb/pull/152
+  mongoDB < 2.7.1.3 
 
 -- GHC 9.4 shims for persistent
 

--- a/cabal.project
+++ b/cabal.project
@@ -9,7 +9,7 @@ packages:
   persistent-qq
 
 constraints:
-  mongoDB < 2.7.1.3
+  mongoDB < 2.7.1.3 -- https://github.com/mongodb-haskell/mongodb/pull/152
 
 -- GHC 9.4 shims for persistent
 

--- a/cabal.project
+++ b/cabal.project
@@ -8,6 +8,9 @@ packages:
   persistent-redis
   persistent-qq
 
+constraints:
+  mongoDB < 2.7.1.3
+
 -- GHC 9.4 shims for persistent
 
 -- These need hackage revisions but otherwise test fine in the repo

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,5 +1,12 @@
 # Changelog for persistent
 
+## 2.14.6.1
+
+* [#1528](https://github.com/yesodweb/persistent/pull/1528)
+    * The `PersistField Int{,8,16,32,64}` instances will now work with a
+      `PersistRational`, provided that the denominator is 1. This fixes the bug
+      where `SUM` in Postgres would change the type of a column being summed.
+
 ## 2.14.6.0
 
 * [#1477](https://github.com/yesodweb/persistent/pull/1477)

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:            persistent
-version:         2.14.6.0
+version:         2.14.6.1
 license:         MIT
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,3 +9,6 @@ packages:
   - ./persistent-postgresql
   - ./persistent-redis
   - ./persistent-qq
+
+extra-deps:
+  - attoparsec-aeson-2.1.0.0


### PR DESCRIPTION
This issue addresses #1527 

If the `denominator` is `1`, then we allow it. Otherwise, we go boom.

This *should* fix the issue with `esqueleto`.

Before submitting your PR, check that you've:

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [ ] Ran `stylish-haskell` on any changed files.
- [ ] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
