### PR TITLE
Document the `!no-migrate` Entity Attribute

### DIFF
--- a/persistent/Database/Persist/Quasi.hs
+++ b/persistent/Database/Persist/Quasi.hs
@@ -352,6 +352,17 @@ userAttrs = do
 -- [["sad"],["sogood"]]
 @
 
+== @!no-migrate@
+
+To prevent @migrateModels@ from generating _any_ migrations for an entity, add
+the @!no-migrate@ attribute to it's definition:
+
+@
+User !no-migrate
+    field   String
+    good    Dog
+@
+
 == @MigrationOnly@
 
 Introduced with @persistent-template@ 1.2.0. The purpose of this attribute is


### PR DESCRIPTION
Add docs to the quasiquoter module about how the `!no-migrate` entity attribute will prevent any migrations from being generated for an entity. This is currently only "documented" in the source code:

https://github.com/yesodweb/persistent/blob/97013604d9ca9bf39b03a36005287027b621bfff/persistent/Database/Persist/TH.hs#L2769

This has existed for a while, does it need a `@since` declaration or CHANGELOG entry in here?
