### PR TITLE
Migration with lowercase 'current_timestamp' is not idempotent

### DIFF
--- a/persistent-test/src/MigrationTest.hs
+++ b/persistent-test/src/MigrationTest.hs
@@ -4,6 +4,7 @@ module MigrationTest where
 
 import Database.Persist.TH
 import qualified Data.Text as T
+import Data.Time
 
 import Init
 
@@ -36,6 +37,13 @@ Source1 sql=source
     field4 Target1Id
 |]
 
+share [mkPersist sqlSettings, mkMigrate "migrationWithDefaultTime"] [persistLowerCase|
+TimeDefault
+    field3 Int
+    extra  UTCTime default=current_timestamp
+    field4 Target1Id
+|]
+
 specsWith :: (MonadUnliftIO m) => RunDb SqlBackend m -> Spec
 specsWith runDb = describe "Migration" $ do
     it "is idempotent" $ runDb $ do
@@ -53,3 +61,7 @@ specsWith runDb = describe "Migration" $ do
       void $ runMigrationSilent migrationAddCol
       again <- getMigration migrationAddCol
       liftIO $ again @?= []
+    it "is idempotent (default time example)" $ runDb $ do
+      void $ runMigrationSilent migrationWithDefaultTime
+      again <- getMigration migrationWithDefaultTime
+      liftIO $ again @?= ["ALTER TABLE \"time_default\" ALTER COLUMN \"extra\" SET DEFAULT current_timestamp"]


### PR DESCRIPTION
Before submitting your PR, check that you've:

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [ ] Ran `stylish-haskell` on any changed files.
- [ ] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
