### PR TITLE
Elaborate on 'upsertManyWhere'

### DIFF
--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -1714,7 +1714,7 @@ upsertWhere record updates filts =
 
 -- | Postgres specific 'upsertManyWhere'.
 --
--- The first argument determines a list of new records to insert.
+-- The first argument is a list of new records to insert.
 --
 -- If there's unique key collisions for some or all of the proposed insertions,
 -- you can use the second argument to specify which fields, under which
@@ -1744,14 +1744,22 @@ upsertWhere record updates filts =
 --
 -- @
 --   upsertManyWhere
---     [record] -- new records to insert if there's no conflicts
---     [ copyField recordField1 -- for each conflicting existing row, replace the value of recordField1 with the one present in the conflicting new record
---     , copyUnlessEq recordField2 -- only replace the existing value if it's different from the one present in the conflicting new record
---     , copyUnlessNull recordField3 -- only replace the existing value if the new value is non-NULL (i.e. don't replace existing values with NULLs.)
+--     [record]                         -- (1) 
+--     [ copyField recordField1         -- (2) 
+--     , copyUnlessEq recordField2      -- (3) 
+--     , copyUnlessNull recordField3    -- (4) 
 --     ]
---     [recordField4 =. arbitraryValue] -- update recordField4 with an arbitrary new value
---     [recordField4 !=. anotherValue] -- only apply the above updates for conflicting rows that meet this condition
+--     [recordField4 =. arbitraryValue] -- (5) 
+--     [recordField4 !=. anotherValue]  -- (6) 
 -- @
+-- 
+-- 1. new records to insert if there's no conflicts
+-- 2. for each conflicting existing row, replace the value of recordField1 with the one present in the conflicting new record
+-- 3. only replace the existing value if it's different from the one present in the conflicting new record
+-- 4. only replace the existing value if the new value is non-NULL (i.e. don't replace existing values with NULLs.)
+-- 
+-- 5. update recordField4 with an arbitrary new value
+-- 6. only apply the above updates for conflicting rows that meet this condition
 --
 -- Called thusly, this method will insert a new record (if none exists) OR it
 -- will copy three fields (@recordField1@, @recordField2@, @recordField3@) from


### PR DESCRIPTION
Expand the documentation of the Postgres version of `upsertManyWhere`: it wasn't clear how the second argument behaves and at least two coders interpreted it backwards introducing a subtle production bug; hopefully the examples now make it clear!

I don't have a dev env setup for this so I didn't run `stylish-haskell`, nor do I know if a documentation update warrants a version bump — happy to comply if necessary though!

Before submitting your PR, check that you've:

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [ ] Ran `stylish-haskell` on any changed files.
- [ ] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
