### PR TITLE
Use toEncoding for toPersistValueJSON

### DIFF
--- a/persistent/Database/Persist/Class/PersistEntity.hs
+++ b/persistent/Database/Persist/Class/PersistEntity.hs
@@ -53,9 +53,10 @@ import Data.Aeson
        , (.=)
        )
 import qualified Data.Aeson.Parser as AP
-import Data.Aeson.Text (encodeToTextBuilder)
+import Data.Aeson.Encoding (encodingToLazyByteString)
 import Data.Aeson.Types (Parser, Result(Error, Success))
 import Data.Attoparsec.ByteString (parseOnly)
+import qualified Data.ByteString as B
 import Data.Functor.Identity
 import Web.PathPieces (PathMultiPiece(..), PathPiece(..))
 
@@ -71,8 +72,6 @@ import Data.Maybe (isJust)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
-import qualified Data.Text.Lazy as LT
-import qualified Data.Text.Lazy.Builder as TB
 import GHC.Generics
 import GHC.OverloadedLabels
 import GHC.TypeLits
@@ -452,7 +451,7 @@ idField = "_id"
 --   toPersistValue = toPersistValueJSON
 -- @
 toPersistValueJSON :: ToJSON a => a -> PersistValue
-toPersistValueJSON = PersistText . LT.toStrict . TB.toLazyText . encodeToTextBuilder . toJSON
+toPersistValueJSON = PersistByteString . B.toStrict . encodingToLazyByteString . toEncoding
 
 -- | Convenience function for getting a free 'PersistField' instance
 -- from a type with JSON instances. The JSON parser used will accept JSON


### PR DESCRIPTION
This should give us a performance benefit for free. Instead of creating a bunch of intermediate values and serializing them, we can just go straight to serialization with toEncoding. No new constraints are needed because ToJSON provides a default toEncoding.

Before submitting your PR, check that you've:

- [ ] ~Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)~
- [ ] ~Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock~
- [x] Ran `stylish-haskell` on any changed files.
- [x] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
