### PR TITLE
Update mongo repsert and replace calls

### DIFF
--- a/persistent-mongoDB/ChangeLog.md
+++ b/persistent-mongoDB/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for persistent-mongoDB
 
+## 2.13.1.0
+
+* Restore update write concern behavior with MongoDB Driver for MongoDB >= 6.0 [#1550](https://github.com/yesodweb/persistent/pull/1550)
+
 ## 2.13.0.2
 
 * Fix behavioral compatibility with MongoDB Driver for MongoDB >= 6.0 [#1545](https://github.com/yesodweb/persistent/pull/1545)

--- a/persistent-mongoDB/persistent-mongoDB.cabal
+++ b/persistent-mongoDB/persistent-mongoDB.cabal
@@ -1,5 +1,5 @@
 name:            persistent-mongoDB
-version:         2.13.0.2
+version:         2.13.1.0
 license:         MIT
 license-file:    LICENSE
 author:          Greg Weber <greg@gregweber.info>


### PR DESCRIPTION
Replace mongo driver `save` and `replace` API calls with `updateMany` to restore correct behavior in MongoDB >=6.0

This is an extension of https://github.com/yesodweb/persistent/pull/1545. The change in behavior lies in the underlying driver `update` function which  is called indirectly via persistent's `repsert` and `replace` APIs. In this function, the driver uses a write concern of 0 overriding the preference set by the mongo access mode or default write concern as configured in the DB. In test suites or other scenarios where the written data is immediately queried for again from a secondary this can result in flaky "Not Found" failures.

I have opened a [PR](https://github.com/mongodb-haskell/mongodb/pull/156) against the driver library to directly address this issue among others, however, until that change gets approved and merged we can circumvent the problem here in this repository which has more active maintenance.