### PR TITLE
Add test case wth a schema to `sqlQQ` package

### DIFF
--- a/persistent-postgresql/test/main.hs
+++ b/persistent-postgresql/test/main.hs
@@ -56,6 +56,7 @@ import qualified RawSqlTest
 import qualified ReadWriteTest
 import qualified Recursive
 import qualified RenameTest
+import qualified SchemaTest
 import qualified SumTypeTest
 import qualified TransactionLevelTest
 import qualified TreeTest
@@ -140,6 +141,7 @@ main = do
       , PgIntervalTest.pgIntervalMigrate
       , UpsertWhere.upsertWhereMigrate
       , ImplicitUuidSpec.implicitUuidMigrate
+      , SchemaTest.migration
       ]
     PersistentTest.cleanDB
     ForeignKey.cleanDB
@@ -215,3 +217,4 @@ main = do
       PgIntervalTest.specs
       ArrayAggTest.specs
       GeneratedColumnTestSQL.specsWith runConnAssert
+      SchemaTest.specsWith runConnAssert

--- a/persistent-qq/test/PersistentTestModels.hs
+++ b/persistent-qq/test/PersistentTestModels.hs
@@ -110,10 +110,16 @@ share
     ~no Int
     def Int
 
+  PetAnimal schema=animals
+    ownerId PersonId
+    name Text
 |]
 
 deriving instance Show (BackendKey backend) => Show (PetGeneric backend)
 deriving instance Eq (BackendKey backend) => Eq (PetGeneric backend)
+
+deriving instance Show (BackendKey backend) => Show (PetAnimalGeneric backend)
+deriving instance Eq (BackendKey backend) => Eq (PetAnimalGeneric backend)
 
 share [ mkPersist sqlSettings { mpsPrefixFields = False, mpsGeneric = True }
       , mkMigrate "noPrefixMigrate"
@@ -178,3 +184,4 @@ cleanDB = do
   deleteWhere ([] :: [Filter (OutdoorPetGeneric backend)])
   deleteWhere ([] :: [Filter (UserPTGeneric backend)])
   deleteWhere ([] :: [Filter (EmailPTGeneric backend)])
+  deleteWhere ([] :: [Filter (PetAnimalGeneric backend)])

--- a/persistent-qq/test/Spec.hs
+++ b/persistent-qq/test/Spec.hs
@@ -115,6 +115,18 @@ spec = describe "persistent-qq" $ do
         liftIO $ ret1 @?= [Entity p1k p1]
         liftIO $ ret2 @?= [Entity (RFOKey $ unPersonKey p1k) (RFO p1)]
 
+    it "sqlQQ/entity in schema" $ db $ do
+        let person = Person "Zacarias" 93 Nothing
+        personKey <- insert person
+        let pet = PetAnimal personKey "Fluffy"
+        petKey <- insert pet
+        let runQuery
+              :: (RawSql a, Functor m, MonadIO m)
+              => ReaderT SqlBackend m [a]
+            runQuery = [sqlQQ| SELECT ?? FROM ^{PetAnimal} |]
+        ret <- runQuery
+        liftIO $ ret @?= [Entity petKey pet]
+
     it "sqlQQ/OUTER JOIN" $ db $ do
         let insert' :: (PersistStore backend, PersistEntity val, PersistEntityBackend val ~ BaseBackend backend, MonadIO m, SafeToInsert val)
                     => val -> ReaderT backend m (Key val, val)

--- a/persistent-redis/Database/Persist/Redis/Internal.hs
+++ b/persistent-redis/Database/Persist/Redis/Internal.hs
@@ -23,10 +23,10 @@ toLabel :: FieldDef -> B.ByteString
 toLabel = U.fromString . unpack . unFieldNameDB . fieldDB
 
 toEntityString :: PersistEntity val => val -> Text
-toEntityString = unEntityNameDB . entityDB . entityDef . Just
+toEntityString = unEntityNameDB . getEntityDBName . entityDef . Just
 
 toEntityName :: EntityDef -> B.ByteString
-toEntityName = U.fromString . unpack . unEntityNameDB . entityDB
+toEntityName = U.fromString . unpack . unEntityNameDB . getEntityDBName
 
 mkEntity :: (MonadFail m, PersistEntity val) => Key val -> [(B.ByteString, B.ByteString)] -> m (Entity val)
 mkEntity key fields = do

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -57,6 +57,7 @@ library
         UniqueTest
         UpsertTest
         LongIdentifierTest
+        SchemaTest
 
     hs-source-dirs: src
 

--- a/persistent-test/src/SchemaTest.hs
+++ b/persistent-test/src/SchemaTest.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE UndecidableInstances #-}
+module SchemaTest (specsWith, migration, cleanDB) where
+
+import Database.Persist.Sql
+import Database.Persist.TH
+
+import Init
+
+share [mkPersist sqlSettings { mpsGeneric = True }, mkMigrate "migration"] [persistLowerCase|
+SchemaEntity schema="foo"
+    foo Int
+    Primary foo
+|]
+
+cleanDB
+    ::
+    ( PersistQueryWrite backend
+    , MonadIO m
+    , PersistStoreWrite (BaseBackend backend)
+    )
+    => ReaderT backend m ()
+cleanDB = deleteWhere ([] :: [Filter (SchemaEntityGeneric backend)])
+
+specsWith
+    :: Runner backend m
+    => RunDb backend m
+    -> Spec
+specsWith runConn = describe "entity with non-null schema" $
+    it "inserts and selects work as expected" $ asIO $ runConn $ do
+        -- Ensure we can write to the database
+        x <- insert $
+            SchemaEntity
+                { schemaEntityFoo = 42
+                }
+        Just _ <- get x
+        return ()

--- a/persistent-test/src/SchemaTest.hs
+++ b/persistent-test/src/SchemaTest.hs
@@ -8,7 +8,7 @@ import Database.Persist.TH
 import Init
 
 share [mkPersist sqlSettings { mpsGeneric = True }, mkMigrate "migration"] [persistLowerCase|
-SchemaEntity schema="foo"
+SchemaEntity schema=foo
     foo Int
     Primary foo
 |]

--- a/persistent/Database/Persist/EntityDef.hs
+++ b/persistent/Database/Persist/EntityDef.hs
@@ -84,7 +84,9 @@ getEntityHaskellName = entityHaskell
 getEntityDBName
     :: EntityDef
     -> EntityNameDB
-getEntityDBName = entityDB
+getEntityDBName entityDef = case entitySchema entityDef of
+    Nothing -> entityDB entityDef
+    Just schema -> EntityNameDB $ schema <> "." <> unEntityNameDB (entityDB entityDef)
 
 getEntityExtra :: EntityDef -> Map Text [[Text]]
 getEntityExtra = entityExtra

--- a/persistent/Database/Persist/EntityDef.hs
+++ b/persistent/Database/Persist/EntityDef.hs
@@ -19,6 +19,7 @@ module Database.Persist.EntityDef
     , getEntityKeyFields
     , getEntityComments
     , getEntityExtra
+    , getEntitySchema
     , isEntitySum
     , entityPrimary
     , entitiesPrimary
@@ -27,6 +28,7 @@ module Database.Persist.EntityDef
     , setEntityId
     , setEntityIdDef
     , setEntityDBName
+    , setEntitySchema
     , overEntityFields
       -- * Related Types
     , EntityIdDef(..)
@@ -88,6 +90,9 @@ getEntityDBName = entityDB
 
 getEntityExtra :: EntityDef -> Map Text [[Text]]
 getEntityExtra = entityExtra
+
+getEntitySchema :: EntityDef -> Maybe SchemaNameDB
+getEntitySchema = entitySchema
 
 -- |
 --
@@ -194,6 +199,9 @@ getEntityKeyFields = entityKeyFields
 -- @since 2.13.0.0
 setEntityFields :: [FieldDef] -> EntityDef -> EntityDef
 setEntityFields fd ed = ed { entityFields = fd }
+
+setEntitySchema :: Maybe SchemaNameDB -> EntityDef -> EntityDef
+setEntitySchema sn ed = ed { entitySchema = sn }
 
 -- | Perform a mapping function over all of the entity fields, as determined by
 -- 'getEntityFieldsDatabase'.

--- a/persistent/Database/Persist/EntityDef.hs
+++ b/persistent/Database/Persist/EntityDef.hs
@@ -84,9 +84,7 @@ getEntityHaskellName = entityHaskell
 getEntityDBName
     :: EntityDef
     -> EntityNameDB
-getEntityDBName entityDef = case entitySchema entityDef of
-    Nothing -> entityDB entityDef
-    Just schema -> EntityNameDB $ schema <> "." <> unEntityNameDB (entityDB entityDef)
+getEntityDBName = entityDB
 
 getEntityExtra :: EntityDef -> Map Text [[Text]]
 getEntityExtra = entityExtra

--- a/persistent/Database/Persist/Names.hs
+++ b/persistent/Database/Persist/Names.hs
@@ -70,3 +70,9 @@ instance DatabaseName ConstraintNameDB where
 -- @since 2.12.0.0
 newtype ConstraintNameHS = ConstraintNameHS { unConstraintNameHS :: Text }
   deriving (Show, Eq, Read, Ord, Lift)
+
+newtype SchemaNameDB = SchemaNameDB { unSchemaNameDB :: Text }
+  deriving (Show, Eq, Read, Ord, Lift)
+
+instance DatabaseName SchemaNameDB where
+  escapeWith f (SchemaNameDB n) = f n

--- a/persistent/Database/Persist/Quasi/Internal.hs
+++ b/persistent/Database/Persist/Quasi/Internal.hs
@@ -712,6 +712,8 @@ mkUnboundEntityDef ps parsedEntDef =
                     case parsedEntityDefComments parsedEntDef of
                         [] -> Nothing
                         comments -> Just (T.unlines comments)
+                , -- TODO: start parsing the schema attribute and write it here.
+                  entitySchema = Nothing
                 }
         }
   where

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -335,7 +335,7 @@ liftAndFixKeys mps emEntities entityMap unboundEnt =
             |]
           where
             fixForeignRefTableDBName =
-                entityDB (unboundEntityDef parentDef)
+                getEntityDBName (unboundEntityDef parentDef)
             foreignFieldNames =
                 case unboundForeignFields of
                     FieldListImpliedId ffns ->
@@ -1968,7 +1968,7 @@ fromValues entDef funName constructExpr fields = do
     return [ suc, normalClause [VarP x] patternMatchFailure ]
   where
     tableName =
-        unEntityNameDB (entityDB (unboundEntityDef entDef))
+        unEntityNameDB (getEntityDBName (unboundEntityDef entDef))
     patternSuccess =
         case fields of
             [] -> do

--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -153,7 +153,7 @@ data EntityDef = EntityDef
     -- ^ Whether or not this entity represents a sum type in the database.
     , entityComments :: !(Maybe Text)
     -- ^ Optional comments on the entity.
-    , entitySchema :: !(Maybe Text)
+    , entitySchema :: !(Maybe SchemaNameDB)
     -- ^ The schema the entity belongs to.
     --
     -- @since 2.10.0

--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -153,6 +153,8 @@ data EntityDef = EntityDef
     -- ^ Whether or not this entity represents a sum type in the database.
     , entityComments :: !(Maybe Text)
     -- ^ Optional comments on the entity.
+    , entitySchema :: !(Maybe Text)
+    -- ^ The schema the entity belongs to.
     --
     -- @since 2.10.0
     }

--- a/persistent/test/Database/Persist/THSpec.hs
+++ b/persistent/test/Database/Persist/THSpec.hs
@@ -371,6 +371,7 @@ spec = describe "THSpec" $ do
                             , entityExtra = mempty
                             , entitySum = False
                             , entityComments = Nothing
+                            , entitySchema = Nothing
                             }
         it "has the cascade on the field def" $ do
             fieldCascade subject `shouldBe` expected


### PR DESCRIPTION
It turns out that `sqlQQ` defers to the Persistent backend to generate the table name, so if we update all the database-specific packages, this should "just work".

I've added a test to this package to witness that. The test suite for `persistent-qq` uses the SQLite backend, so we'll have to update that backend for this test to actually witness what we need it to witness.