### PR TITLE
Make `NO ACTION` the default action for foreign keys

### DIFF
--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -1193,7 +1193,7 @@ findAlters defs edef col@(Column name isNull sqltype def _gen _defConstraintName
                 )
 
 -- We check if we should alter a foreign key. This is almost an equality check,
--- except we consider 'Nothing' and 'Just Restrict' equivalent.
+-- except we consider 'Nothing' and 'Just NoAction' equivalent.
 equivalentRef :: Maybe ColumnReference -> Maybe ColumnReference -> Bool
 equivalentRef Nothing Nothing = True
 equivalentRef (Just cr1) (Just cr2) =
@@ -1204,8 +1204,8 @@ equivalentRef (Just cr1) (Just cr2) =
   where
     eqCascade :: Maybe CascadeAction -> Maybe CascadeAction -> Bool
     eqCascade Nothing Nothing         = True
-    eqCascade Nothing (Just Restrict) = True
-    eqCascade (Just Restrict) Nothing = True
+    eqCascade Nothing (Just NoAction) = True
+    eqCascade (Just NoAction) Nothing = True
     eqCascade (Just cs1) (Just cs2)   = cs1 == cs2
     eqCascade _ _                     = False
 equivalentRef _ _ = False

--- a/persistent/Database/Persist/Quasi.hs
+++ b/persistent/Database/Persist/Quasi.hs
@@ -434,8 +434,9 @@ AnotherVeryLongTableName
 These options affects how a referring record behaves when the target record is changed.
 There are several options:
 
-* 'Restrict' - This is the default. It prevents the action from occurring.
-* 'Cascade' - this copies the change to the child record. If a parent record is deleted, then the child record will be deleted too.
+* 'NoAction' - This is the default. It prevents the action from occurring, but the check can be deferred until the end of the transaction.
+* 'Restrict' - This prevents the action from occurring by immediately aborting a transaction.
+* 'Cascade' - This copies the change to the child record. If a parent record is deleted, then the child record will be deleted too.
 * 'SetNull' - If the parent record is modified, then this sets the reference to @NULL@. This only works on @Maybe@ foreign keys.
 * 'SetDefault' - This will set the column's value to the @default@ for the column, if specified.
 

--- a/persistent/Database/Persist/Sql/Internal.hs
+++ b/persistent/Database/Persist/Sql/Internal.hs
@@ -167,12 +167,12 @@ mkColumns allDefs t overrides =
         $ ref (fieldDB fd) (fieldReference fd) (fieldAttrs fd)
 
     -- a 'Nothing' in the definition means that the QQ migration doesn't
-    -- specify behavior. the default is RESTRICT. setting this here
+    -- specify behavior. the default is NO ACTION. setting this here
     -- explicitly makes migrations run smoother.
     overrideNothings (FieldCascade { fcOnUpdate = upd, fcOnDelete = del }) =
         FieldCascade
-            { fcOnUpdate = upd <|> Just Restrict
-            , fcOnDelete = del <|> Just Restrict
+            { fcOnUpdate = upd <|> Just NoAction
+            , fcOnDelete = del <|> Just NoAction
             }
 
     ref :: FieldNameDB

--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -574,7 +574,7 @@ data ForeignDef = ForeignDef
 -- This type is used in both parsing the model definitions and performing
 -- migrations. A 'Nothing' in either of the field values means that the
 -- user has not specified a 'CascadeAction'. An unspecified 'CascadeAction'
--- is defaulted to 'Restrict' when doing migrations.
+-- is defaulted to 'NoAction' when doing migrations.
 --
 -- @since 2.11.0
 data FieldCascade = FieldCascade
@@ -604,7 +604,7 @@ renderFieldCascade (FieldCascade onUpdate onDelete) =
 -- change.
 --
 -- @since 2.11.0
-data CascadeAction = Cascade | Restrict | SetNull | SetDefault
+data CascadeAction = NoAction | Cascade | Restrict | SetNull | SetDefault
     deriving (Show, Eq, Read, Ord, Lift)
 
 -- | Render a 'CascadeAction' to 'Text' such that it can be used in a SQL
@@ -613,6 +613,7 @@ data CascadeAction = Cascade | Restrict | SetNull | SetDefault
 -- @since 2.11.0
 renderCascadeAction :: CascadeAction -> Text
 renderCascadeAction action = case action of
+  NoAction   -> "NO ACTION"
   Cascade    -> "CASCADE"
   Restrict   -> "RESTRICT"
   SetNull    -> "SET NULL"


### PR DESCRIPTION
See #1416 for motivation, but tl;dr is that `NO ACTION` is a more sensible default across the supported databases.

---

Before submitting your PR, check that you've:

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [ ] Ran `stylish-haskell` on any changed files.
- [ ] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
