### PR TITLE
Add schema support to Persistent (issue #93)

### DIFF
--- a/persistent-mysql/README.md
+++ b/persistent-mysql/README.md
@@ -7,11 +7,14 @@ A backend for the `persistent` database library for the MySQL database server.
 ## Development
 
 To run tests on this library, you will need to have a MySQL database server set up and running on your computer.
-The test suite expects to see a database named `test` with a username `test` and password `test`. You can set this up with roughly as follows:
+The test suite expects to see databases named `test` and `foo`, and a user with username `test` and password `test`. You can set this up with roughly as follows:
 
 ```
 mysql -u root # MySQL root username and password may vary
 CREATE DATABASE test;
+CREATE DATABASE foo;
 CREATE USER 'test'@'localhost' IDENTIFIED BY 'test';
 GRANT ALL on test.* TO 'test'@'localhost';
+GRANT ALL on foo.* TO 'test'@'localhost';
+USE test;
 ```

--- a/persistent-mysql/test/main.hs
+++ b/persistent-mysql/test/main.hs
@@ -48,6 +48,7 @@ import qualified MpsCustomPrefixTest
 import qualified MpsNoPrefixTest
 import qualified PersistUniqueTest
 import qualified PersistentTest
+import qualified SchemaTest
 import qualified TypeLitFieldDefsTest
 -- FIXME: Not used... should it be?
 -- import qualified PrimaryTest
@@ -149,6 +150,7 @@ main = do
             , TransactionLevelTest.migration
             -- , LongIdentifierTest.migration
             , ForeignKey.compositeMigrate
+            , SchemaTest.migration
             ]
         PersistentTest.cleanDB
         ForeignKey.cleanDB
@@ -228,6 +230,7 @@ main = do
             LongIdentifierTest.specsWith db
         GeneratedColumnTestSQL.specsWith db
         JSONTest.specs
+        SchemaTest.specsWith db
 
 roundFn :: RealFrac a => a -> Integer
 roundFn = round

--- a/persistent-postgresql/Database/Persist/Postgresql.hs
+++ b/persistent-postgresql/Database/Persist/Postgresql.hs
@@ -469,7 +469,7 @@ createBackend logFunc serverVersion smap conn =
         , connCommit     = const $ PG.commit   conn
         , connRollback   = const $ PG.rollback conn
         , connEscapeFieldName = escapeF
-        , connEscapeTableName = escapeE . getEntityDBName
+        , connEscapeTableName = entityIdentifier
         , connEscapeRawName = escape
         , connNoLimit    = "LIMIT ALL"
         , connRDBMS      = "postgresql"
@@ -498,7 +498,7 @@ insertSql' ent vals =
     (fieldNames, placeholders) = unzip (Util.mkInsertPlaceholders ent escapeF)
     sql = T.concat
         [ "INSERT INTO "
-        , escapeE $ getEntityDBName ent
+        , entityIdentifier ent
         , if null (getEntityFields ent)
             then " DEFAULT VALUES"
             else T.concat
@@ -514,7 +514,7 @@ upsertSql' :: EntityDef -> NonEmpty (FieldNameHS, FieldNameDB) -> Text -> Text
 upsertSql' ent uniqs updateVal =
     T.concat
         [ "INSERT INTO "
-        , escapeE (getEntityDBName ent)
+        , entityIdentifier ent
         , "("
         , T.intercalate "," fieldNames
         , ") VALUES ("
@@ -543,7 +543,7 @@ insertManySql' ent valss =
     (fieldNames, placeholders)= unzip (Util.mkInsertPlaceholders ent escapeF)
     sql = T.concat
         [ "INSERT INTO "
-        , escapeE (getEntityDBName ent)
+        , entityIdentifier ent
         , "("
         , T.intercalate "," fieldNames
         , ") VALUES ("
@@ -626,14 +626,16 @@ withStmt' conn query vals =
 
 doesTableExist :: (Text -> IO Statement)
                -> EntityNameDB
+               -> (Maybe SchemaNameDB)
                -> IO Bool
-doesTableExist getter (EntityNameDB name) = do
+doesTableExist getter (EntityNameDB name) mSchema = do
     stmt <- getter sql
     with (stmtQuery stmt vals) (\src -> runConduit $ src .| start)
   where
-    sql = "SELECT COUNT(*) FROM pg_catalog.pg_tables WHERE schemaname != 'pg_catalog'"
-          <> " AND schemaname != 'information_schema' AND tablename=?"
-    vals = [PersistText name]
+    schema = maybe "public" escapeS mSchema
+    sql = "SELECT COUNT(*) FROM pg_catalog.pg_tables "
+          <> "WHERE tablename=? AND schemaname=?"
+    vals = [PersistText name, PersistText schema]
 
     start = await >>= maybe (error "No results when checking doesTableExist") start'
     start' [PersistInt64 0] = finish False
@@ -651,12 +653,13 @@ migrate' allDefs getter entity = fmap (fmap $ map showAlterDb) $ do
         ([], old'') -> do
             exists' <-
                 if null old
-                    then doesTableExist getter name
+                    then doesTableExist getter name schema
                     else return True
             return $ Right $ migrationText exists' old''
         (errs, _) -> return $ Left errs
   where
     name = getEntityDBName entity
+    schema = getEntitySchema entity
     (newcols', udefs, fdefs) = postgresMkColumns allDefs entity
     migrationText exists' old''
         | not exists' =
@@ -664,8 +667,8 @@ migrate' allDefs getter entity = fmap (fmap $ map showAlterDb) $ do
         | otherwise =
             let (acs, ats) =
                     getAlters allDefs entity (newcols, udspair) old'
-                acs' = map (AlterColumn name) acs
-                ats' = map (AlterTable name) ats
+                acs' = map (AlterColumn name schema) acs
+                ats' = map (AlterTable name schema) ats
             in
                 acs' ++ ats'
        where
@@ -679,7 +682,7 @@ migrate' allDefs getter entity = fmap (fmap $ map showAlterDb) $ do
         (addTable newcols entity) : uniques ++ references ++ foreignsAlt
       where
         uniques = flip concatMap udspair $ \(uname, ucols) ->
-                [AlterTable name $ AddUniqueConstraint uname ucols]
+                [AlterTable name schema $ AddUniqueConstraint uname ucols]
         references =
             mapMaybe
                 (\Column { cName, cReference } ->
@@ -692,12 +695,14 @@ mkForeignAlt
     :: EntityDef
     -> ForeignDef
     -> Maybe AlterDB
-mkForeignAlt entity fdef = pure $ AlterColumn tableName_ addReference
+mkForeignAlt entity fdef = pure $ AlterColumn tableName_ schemaName_ addReference
   where
     tableName_ = getEntityDBName entity
+    schemaName_ = getEntitySchema entity
     addReference =
         AddReference
             (foreignRefTableDBName fdef)
+            (foreignRefSchemaDBName fdef)
             constraintName
             childfields
             escapedParentFields
@@ -711,17 +716,22 @@ mkForeignAlt entity fdef = pure $ AlterColumn tableName_ addReference
 
 addTable :: [Column] -> EntityDef -> AlterDB
 addTable cols entity =
-    AddTable $ T.concat
+    AddTable $ T.concat $
+        case schema of
+            Nothing -> stmt
+            -- Lower case e: see Database.Persist.Sql.Migration
+            Just s -> "CREATe SCHEMA IF NOT EXISTS " <> s <> ";\n" : stmt
+  where
+    stmt =
         -- Lower case e: see Database.Persist.Sql.Migration
         [ "CREATe TABLE " -- DO NOT FIX THE CAPITALIZATION!
-        , escapeE name
+        , entityIdentifier entity
         , "("
         , idtxt
         , if null nonIdCols then "" else ","
         , T.intercalate "," $ map showColumn nonIdCols
         , ")"
         ]
-  where
     nonIdCols =
         case entityPrimary entity of
             Just _ ->
@@ -735,6 +745,8 @@ addTable cols entity =
 
     name =
         getEntityDBName entity
+    schema =
+        escapeS <$> getEntitySchema entity
     idtxt =
         case getEntityId entity of
             EntityIdNaturalKey pdef ->
@@ -773,7 +785,7 @@ data AlterColumn
     | Default Column Text
     | NoDefault Column
     | Update' Column Text
-    | AddReference EntityNameDB ConstraintNameDB [FieldNameDB] [Text] FieldCascade
+    | AddReference EntityNameDB (Maybe SchemaNameDB) ConstraintNameDB [FieldNameDB] [Text] FieldCascade
     | DropReference ConstraintNameDB
     deriving Show
 
@@ -783,8 +795,8 @@ data AlterTable
     deriving Show
 
 data AlterDB = AddTable Text
-             | AlterColumn EntityNameDB AlterColumn
-             | AlterTable EntityNameDB AlterTable
+             | AlterColumn EntityNameDB (Maybe SchemaNameDB) AlterColumn
+             | AlterTable EntityNameDB (Maybe SchemaNameDB) AlterTable
              deriving Show
 
 -- | Returns all of the columns in the given table currently in the database.
@@ -865,7 +877,7 @@ getColumns getter def cols = do
                $ groupBy ((==) `on` fst) rows
     processColumns =
         CL.mapM $ \x'@((PersistText cname) : _) -> do
-            col <- liftIO $ getColumn getter (getEntityDBName def) x' (Map.lookup cname refMap)
+            col <- liftIO $ getColumn getter (getEntityDBName def) (getEntitySchema def) x' (Map.lookup cname refMap)
             pure $ case col of
                 Left e -> Left e
                 Right c -> Right $ Left c
@@ -923,18 +935,22 @@ getAlters defs def (c1, u1) (c2, u2) =
 getColumn
     :: (Text -> IO Statement)
     -> EntityNameDB
+    -> Maybe SchemaNameDB
     -> [PersistValue]
     -> Maybe (EntityNameDB, ConstraintNameDB)
     -> IO (Either Text Column)
-getColumn getter tableName' [ PersistText columnName
-                            , PersistText isNullable
-                            , PersistText typeName
-                            , defaultValue
-                            , generationExpression
-                            , numericPrecision
-                            , numericScale
-                            , maxlen
-                            ] refName_ = runExceptT $ do
+getColumn getter
+          tableName'
+          schemaName'
+          [ PersistText columnName
+          , PersistText isNullable
+          , PersistText typeName
+          , defaultValue
+          , generationExpression
+          , numericPrecision
+          , numericScale
+          , maxlen
+          ] refName_ = runExceptT $ do
     defaultValue' <-
         case defaultValue of
             PersistNull ->
@@ -974,7 +990,11 @@ getColumn getter tableName' [ PersistText columnName
         , cGenerated = fmap stripSuffixes generationExpression'
         , cDefaultConstraintName = Nothing
         , cMaxLen = Nothing
-        , cReference = fmap (\(a,b,c,d) -> ColumnReference a b (mkCascade c d)) ref
+        , -- The ColumnReference always has a non-null SchemaNameDB. The default schema name
+          -- in Postgres is "public", but Postgres doesn't know whether a table with
+          -- schema "public" was explicitly given that schema by the Persistent
+          -- app developer.
+          cReference = fmap (\(a,b,c,d,e) -> ColumnReference a (Just b) c (mkCascade d e)) ref
         }
 
   where
@@ -1012,10 +1032,15 @@ getColumn getter tableName' [ PersistText columnName
                 Nothing -> loop' ps
                 Just t' -> t'
 
+    getRef
+        :: FieldNameDB
+        -> (a, ConstraintNameDB)
+        -> IO (Maybe (EntityNameDB, SchemaNameDB, ConstraintNameDB, Text, Text))
     getRef cname (_, refName') = do
         let sql = T.concat
                 [ "SELECT DISTINCT "
                 , "ccu.table_name, "
+                , "ccu.table_schema, "
                 , "tc.constraint_name, "
                 , "rc.update_rule, "
                 , "rc.delete_rule "
@@ -1029,6 +1054,7 @@ getColumn getter tableName' [ PersistText columnName
                 , "WHERE tc.constraint_type='FOREIGN KEY' "
                 , "AND kcu.ordinal_position=1 "
                 , "AND kcu.table_name=? "
+                , "AND kcu.table_schema=? "
                 , "AND kcu.column_name=? "
                 , "AND tc.constraint_name=?"
                 ]
@@ -1037,6 +1063,7 @@ getColumn getter tableName' [ PersistText columnName
             with
                 (stmtQuery stmt
                     [ PersistText $ unEntityNameDB tableName'
+                    , PersistText $ fromMaybe "public" $ unSchemaNameDB <$> schemaName'
                     , PersistText $ unFieldNameDB cname
                     , PersistText $ unConstraintNameDB refName'
                     ]
@@ -1045,8 +1072,8 @@ getColumn getter tableName' [ PersistText columnName
         case cntrs of
           [] ->
               return Nothing
-          [[PersistText table, PersistText constraint, PersistText updRule, PersistText delRule]] ->
-              return $ Just (EntityNameDB table, ConstraintNameDB constraint, updRule, delRule)
+          [[PersistText table, PersistText schema, PersistText constraint, PersistText updRule, PersistText delRule]] ->
+              return $ Just (EntityNameDB table, SchemaNameDB schema, ConstraintNameDB constraint, updRule, delRule)
           xs ->
               error $ mconcat
                   [ "Postgresql.getColumn: error fetching constraints. Expected a single result for foreign key query for table: "
@@ -1098,7 +1125,7 @@ getColumn getter tableName' [ PersistText columnName
         , " Specify the values as numeric(total_digits, digits_after_decimal_place)."
         ]
 
-getColumn _ _ columnName _ =
+getColumn _ _ _ columnName _ =
     return $ Left $ T.pack $ "Invalid result from information_schema: " ++ show columnName
 
 -- | Intelligent comparison of SQL types, to account for SqlInt32 vs SqlOther integer
@@ -1140,6 +1167,7 @@ findAlters defs edef col@(Column name isNull sqltype def _gen _defConstraintName
                             ->
                             [AddReference
                                 (crTableName colRef)
+                                (crSchemaName colRef)
                                 (crConstraintName colRef)
                                 [name]
                                 (NEL.toList $ Util.dbIdColumnsEsc escapeF refdef)
@@ -1217,14 +1245,16 @@ getAddReference
     -> FieldNameDB
     -> ColumnReference
     -> Maybe AlterDB
-getAddReference allDefs entity cname cr@ColumnReference {crTableName = s, crConstraintName=constraintName} = do
+getAddReference allDefs entity cname cr@ColumnReference {crTableName = s, crSchemaName = refschema, crConstraintName=constraintName} = do
     guard $ Just cname /= fmap fieldDB (getEntityIdField entity)
     pure $ AlterColumn
         table
-        (AddReference s constraintName [cname] id_ (crFieldCascade cr)
+        schema
+        (AddReference s refschema constraintName [cname] id_ (crFieldCascade cr)
         )
   where
     table = getEntityDBName entity
+    schema = getEntitySchema entity
     id_ =
         fromMaybe
             (error $ "Could not find ID of entity " ++ show s)
@@ -1266,90 +1296,90 @@ showSqlType (SqlOther t) = t
 
 showAlterDb :: AlterDB -> (Bool, Text)
 showAlterDb (AddTable s) = (False, s)
-showAlterDb (AlterColumn t ac) =
-    (isUnsafe ac, showAlter t ac)
+showAlterDb (AlterColumn t s ac) =
+    (isUnsafe ac, showAlter t s ac)
   where
     isUnsafe (Drop _ safeRemove) = not safeRemove
     isUnsafe _ = False
-showAlterDb (AlterTable t at) = (False, showAlterTable t at)
+showAlterDb (AlterTable t s at) = (False, showAlterTable t s at)
 
-showAlterTable :: EntityNameDB -> AlterTable -> Text
-showAlterTable table (AddUniqueConstraint cname cols) = T.concat
+showAlterTable :: EntityNameDB -> Maybe SchemaNameDB -> AlterTable -> Text
+showAlterTable table schema (AddUniqueConstraint cname cols) = T.concat
     [ "ALTER TABLE "
-    , escapeE table
+    , escapeES table schema
     , " ADD CONSTRAINT "
     , escapeC cname
     , " UNIQUE("
     , T.intercalate "," $ map escapeF cols
     , ")"
     ]
-showAlterTable table (DropConstraint cname) = T.concat
+showAlterTable table schema (DropConstraint cname) = T.concat
     [ "ALTER TABLE "
-    , escapeE table
+    , escapeES table schema
     , " DROP CONSTRAINT "
     , escapeC cname
     ]
 
-showAlter :: EntityNameDB -> AlterColumn -> Text
-showAlter table (ChangeType c t extra) =
+showAlter :: EntityNameDB -> Maybe SchemaNameDB -> AlterColumn -> Text
+showAlter table schema (ChangeType c t extra) =
     T.concat
         [ "ALTER TABLE "
-        , escapeE table
+        , escapeES table schema
         , " ALTER COLUMN "
         , escapeF (cName c)
         , " TYPE "
         , showSqlType t
         , extra
         ]
-showAlter table (IsNull c) =
+showAlter table schema (IsNull c) =
     T.concat
         [ "ALTER TABLE "
-        , escapeE table
+        , escapeES table schema
         , " ALTER COLUMN "
         , escapeF (cName c)
         , " DROP NOT NULL"
         ]
-showAlter table (NotNull c) =
+showAlter table schema (NotNull c) =
     T.concat
         [ "ALTER TABLE "
-        , escapeE table
+        , escapeES table schema
         , " ALTER COLUMN "
         , escapeF (cName c)
         , " SET NOT NULL"
         ]
-showAlter table (Add' col) =
+showAlter table schema (Add' col) =
     T.concat
         [ "ALTER TABLE "
-        , escapeE table
+        , escapeES table schema
         , " ADD COLUMN "
         , showColumn col
         ]
-showAlter table (Drop c _) =
+showAlter table schema (Drop c _) =
     T.concat
         [ "ALTER TABLE "
-        , escapeE table
+        , escapeES table schema
         , " DROP COLUMN "
         , escapeF (cName c)
         ]
-showAlter table (Default c s) =
+showAlter table schema (Default c s) =
     T.concat
         [ "ALTER TABLE "
-        , escapeE table
+        , escapeES table schema
         , " ALTER COLUMN "
         , escapeF (cName c)
         , " SET DEFAULT "
         , s
         ]
-showAlter table (NoDefault c) = T.concat
+showAlter table schema (NoDefault c) = T.concat
     [ "ALTER TABLE "
-    , escapeE table
+    , escapeES table schema
     , " ALTER COLUMN "
     , escapeF (cName c)
     , " DROP DEFAULT"
     ]
-showAlter table (Update' c s) = T.concat
+showAlter table schema (Update' c s) = T.concat
     [ "UPDATE "
-    , escapeE table
+    , escapeES table schema
     , " SET "
     , escapeF (cName c)
     , "="
@@ -1358,22 +1388,22 @@ showAlter table (Update' c s) = T.concat
     , escapeF (cName c)
     , " IS NULL"
     ]
-showAlter table (AddReference reftable fkeyname t2 id2 cascade) = T.concat
+showAlter table schema (AddReference reftable refschema fkeyname t2 id2 cascade) = T.concat
     [ "ALTER TABLE "
-    , escapeE table
+    , escapeES table schema
     , " ADD CONSTRAINT "
     , escapeC fkeyname
     , " FOREIGN KEY("
     , T.intercalate "," $ map escapeF t2
     , ") REFERENCES "
-    , escapeE reftable
+    , escapeES reftable refschema
     , "("
     , T.intercalate "," id2
     , ")"
     ] <> renderFieldCascade cascade
-showAlter table (DropReference cname) = T.concat
+showAlter table schema (DropReference cname) = T.concat
     [ "ALTER TABLE "
-    , escapeE table
+    , escapeES table schema
     , " DROP CONSTRAINT "
     , escapeC cname
     ]
@@ -1397,6 +1427,8 @@ escapeE = escapeWith escape
 escapeF :: FieldNameDB -> Text
 escapeF = escapeWith escape
 
+escapeS :: SchemaNameDB -> Text
+escapeS = escapeWith escape
 
 escape :: Text -> Text
 escape s =
@@ -1405,6 +1437,14 @@ escape s =
     go "" = ""
     go ('"':xs) = "\"\"" ++ go xs
     go (x:xs) = x : go xs
+
+entityIdentifier :: EntityDef -> Text
+entityIdentifier ed = escapeES (getEntityDBName ed) (getEntitySchema ed)
+
+escapeES :: EntityNameDB -> Maybe SchemaNameDB -> Text
+escapeES entityName schemaName = case schemaName of
+    Nothing -> escapeE entityName
+    Just schema -> escapeS schema <> "." <> escapeE entityName
 
 -- | Information required to connect to a PostgreSQL database
 -- using @persistent@'s generic facilities.  These values are the
@@ -1563,12 +1603,13 @@ mockMigrate allDefs _ entity = fmap (fmap $ map showAlterDb) $ do
         (errs, _) -> return $ Left errs
   where
     name = getEntityDBName entity
+    schema = getEntitySchema entity
     migrationText exists' old'' =
         if not exists'
             then createText newcols fdefs udspair
             else let (acs, ats) = getAlters allDefs entity (newcols, udspair) old'
-                     acs' = map (AlterColumn name) acs
-                     ats' = map (AlterTable name) ats
+                     acs' = map (AlterColumn name schema) acs
+                     ats' = map (AlterTable name schema) ats
                  in  acs' ++ ats'
        where
          old' = partitionEithers old''
@@ -1582,7 +1623,7 @@ mockMigrate allDefs _ entity = fmap (fmap $ map showAlterDb) $ do
         (addTable newcols entity) : uniques ++ references ++ foreignsAlt
       where
         uniques = flip concatMap udspair $ \(uname, ucols) ->
-                [AlterTable name $ AddUniqueConstraint uname ucols]
+                [AlterTable name schema $ AddUniqueConstraint uname ucols]
         references =
             mapMaybe
                 (\Column { cName, cReference } ->
@@ -2065,4 +2106,3 @@ instance (PersistUniqueWrite b) => PersistUniqueWrite (RawPostgresql b) where
     upsertBy uniq rec = withReaderT persistentBackend . upsertBy uniq rec
     putMany = withReaderT persistentBackend . putMany
 #endif
-

--- a/persistent-postgresql/test/main.hs
+++ b/persistent-postgresql/test/main.hs
@@ -56,6 +56,7 @@ import qualified RawSqlTest
 import qualified ReadWriteTest
 import qualified Recursive
 import qualified RenameTest
+import qualified SchemaTest
 import qualified SumTypeTest
 import qualified TransactionLevelTest
 import qualified TreeTest
@@ -140,6 +141,7 @@ main = do
       , PgIntervalTest.pgIntervalMigrate
       , UpsertWhere.upsertWhereMigrate
       , ImplicitUuidSpec.implicitUuidMigrate
+      , SchemaTest.migration
       ]
     PersistentTest.cleanDB
     ForeignKey.cleanDB
@@ -215,3 +217,4 @@ main = do
       PgIntervalTest.specs
       ArrayAggTest.specs
       GeneratedColumnTestSQL.specsWith runConnAssert
+      SchemaTest.specsWith runConnAssert

--- a/persistent-qq/test/PersistentTestModels.hs
+++ b/persistent-qq/test/PersistentTestModels.hs
@@ -110,10 +110,16 @@ share
     ~no Int
     def Int
 
+  PetAnimal schema=animals
+    ownerId PersonId
+    name Text
 |]
 
 deriving instance Show (BackendKey backend) => Show (PetGeneric backend)
 deriving instance Eq (BackendKey backend) => Eq (PetGeneric backend)
+
+deriving instance Show (BackendKey backend) => Show (PetAnimalGeneric backend)
+deriving instance Eq (BackendKey backend) => Eq (PetAnimalGeneric backend)
 
 share [ mkPersist sqlSettings { mpsPrefixFields = False, mpsGeneric = True }
       , mkMigrate "noPrefixMigrate"
@@ -178,3 +184,4 @@ cleanDB = do
   deleteWhere ([] :: [Filter (OutdoorPetGeneric backend)])
   deleteWhere ([] :: [Filter (UserPTGeneric backend)])
   deleteWhere ([] :: [Filter (EmailPTGeneric backend)])
+  deleteWhere ([] :: [Filter (PetAnimalGeneric backend)])

--- a/persistent-redis/Database/Persist/Redis/Internal.hs
+++ b/persistent-redis/Database/Persist/Redis/Internal.hs
@@ -23,10 +23,10 @@ toLabel :: FieldDef -> B.ByteString
 toLabel = U.fromString . unpack . unFieldNameDB . fieldDB
 
 toEntityString :: PersistEntity val => val -> Text
-toEntityString = unEntityNameDB . entityDB . entityDef . Just
+toEntityString = unEntityNameDB . getEntityDBName . entityDef . Just
 
 toEntityName :: EntityDef -> B.ByteString
-toEntityName = U.fromString . unpack . unEntityNameDB . entityDB
+toEntityName = U.fromString . unpack . unEntityNameDB . getEntityDBName
 
 mkEntity :: (MonadFail m, PersistEntity val) => Key val -> [(B.ByteString, B.ByteString)] -> m (Entity val)
 mkEntity key fields = do

--- a/persistent-sqlite/test/main.hs
+++ b/persistent-sqlite/test/main.hs
@@ -44,6 +44,7 @@ import qualified RawSqlTest
 import qualified ReadWriteTest
 import qualified Recursive
 import qualified RenameTest
+import qualified SchemaTest
 import qualified SumTypeTest
 import qualified TransactionLevelTest
 import qualified TypeLitFieldDefsTest
@@ -151,6 +152,8 @@ main :: IO ()
 main = do
     handle (\(_ :: IOException) -> return ())
         $ removeFile $ fromText sqlite_database_file
+    handle (\(_ :: IOException) -> return ())
+        $ removeFile $ fromText sqlite_foo_database_file
 
     runConn $ do
         mapM_ setup
@@ -176,6 +179,8 @@ main = do
             , MigrationColumnLengthTest.migration
             , TransactionLevelTest.migration
             , LongIdentifierTest.migration
+            , SchemaTest.migration
+            , SchemaTest.migration
             ]
         PersistentTest.cleanDB
         ForeignKey.cleanDB
@@ -244,6 +249,7 @@ main = do
         MigrationTest.specsWith db
         LongIdentifierTest.specsWith db
         GeneratedColumnTestSQL.specsWith db
+        SchemaTest.specsWith db
 
         it "issue #328" $ asIO $ runSqliteInfo (mkSqliteConnectionInfo ":memory:") $ do
             void $ runMigrationSilent migrateAll

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -57,6 +57,7 @@ library
         UniqueTest
         UpsertTest
         LongIdentifierTest
+        SchemaTest
 
     hs-source-dirs: src
 

--- a/persistent-test/src/SchemaTest.hs
+++ b/persistent-test/src/SchemaTest.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE UndecidableInstances #-}
+module SchemaTest (specsWith, migration, cleanDB) where
+
+import Database.Persist.Sql
+import Database.Persist.TH
+
+import Init
+
+share [mkPersist sqlSettings { mpsGeneric = True }, mkMigrate "migration"] [persistLowerCase|
+SchemaEntity schema="foo"
+    foo Int
+    Primary foo
+|]
+
+cleanDB
+    ::
+    ( PersistQueryWrite backend
+    , MonadIO m
+    , PersistStoreWrite (BaseBackend backend)
+    )
+    => ReaderT backend m ()
+cleanDB = deleteWhere ([] :: [Filter (SchemaEntityGeneric backend)])
+
+specsWith
+    :: Runner backend m
+    => RunDb backend m
+    -> Spec
+specsWith runConn = describe "entity with non-null schema" $
+    it "inserts and selects work as expected" $ asIO $ runConn $ do
+        -- Ensure we can write to the database
+        x <- insert $
+            SchemaEntity
+                { schemaEntityFoo = 42
+                }
+        Just _ <- get x
+        return ()

--- a/persistent-test/src/SchemaTest.hs
+++ b/persistent-test/src/SchemaTest.hs
@@ -23,8 +23,8 @@ cleanDB
 cleanDB = deleteWhere ([] :: [Filter (SchemaEntityGeneric backend)])
 
 specsWith
-    :: Runner backend m
-    => RunDb backend m
+    :: Runner SqlBackend m
+    => RunDb SqlBackend m
     -> Spec
 specsWith runConn = describe "entity with non-null schema" $
     it "inserts and selects work as expected" $ asIO $ runConn $ do
@@ -33,5 +33,7 @@ specsWith runConn = describe "entity with non-null schema" $
             SchemaEntity
                 { schemaEntityFoo = 42
                 }
-        Just _ <- get x
+        Just schemaEntity <- get x
+        rawFoo  <- rawSql "SELECT foo FROM foo.schema_entity" []
+        liftIO $ rawFoo @?= [Single (42 :: Int)]
         return ()

--- a/persistent-test/src/SchemaTest.hs
+++ b/persistent-test/src/SchemaTest.hs
@@ -8,7 +8,7 @@ import Database.Persist.TH
 import Init
 
 share [mkPersist sqlSettings { mpsGeneric = True }, mkMigrate "migration"] [persistLowerCase|
-SchemaEntity schema="foo"
+SchemaEntity schema=foo
     foo Int
     Primary foo
 |]

--- a/persistent-test/src/SchemaTest.hs
+++ b/persistent-test/src/SchemaTest.hs
@@ -9,8 +9,8 @@ import Init
 
 share [mkPersist sqlSettings { mpsGeneric = True }, mkMigrate "migration"] [persistLowerCase|
 SchemaEntity schema=foo
-    foo Int
-    Primary foo
+    bar Int
+    Primary bar
 |]
 
 cleanDB
@@ -31,9 +31,10 @@ specsWith runConn = describe "entity with non-null schema" $
         -- Ensure we can write to the database
         x <- insert $
             SchemaEntity
-                { schemaEntityFoo = 42
+                { schemaEntityBar = 42
                 }
         Just schemaEntity <- get x
-        rawFoo  <- rawSql "SELECT foo FROM foo.schema_entity" []
-        liftIO $ rawFoo @?= [Single (42 :: Int)]
+        rawBar  <- rawSql "SELECT bar FROM foo.schema_entity" []
+        liftIO $ rawBar @?= [Single (42 :: Int)]
+        liftIO $ schemaEntityBar schemaEntity @== 42
         return ()

--- a/persistent-test/src/SchemaTest.hs
+++ b/persistent-test/src/SchemaTest.hs
@@ -11,6 +11,10 @@ share [mkPersist sqlSettings { mpsGeneric = True }, mkMigrate "migration"] [pers
 SchemaEntity schema=foo
     bar Int
     Primary bar
+
+DefaultSchemaEntity sql=schema_entity
+    bar Int
+    Primary bar
 |]
 
 cleanDB
@@ -20,13 +24,15 @@ cleanDB
     , PersistStoreWrite (BaseBackend backend)
     )
     => ReaderT backend m ()
-cleanDB = deleteWhere ([] :: [Filter (SchemaEntityGeneric backend)])
+cleanDB = do
+  deleteWhere ([] :: [Filter (SchemaEntityGeneric backend)])
+  deleteWhere ([] :: [Filter (DefaultSchemaEntityGeneric backend)])
 
 specsWith
     :: Runner SqlBackend m
     => RunDb SqlBackend m
     -> Spec
-specsWith runConn = describe "entity with non-null schema" $
+specsWith runConn = describe "entity with non-null schema" $ do
     it "inserts and selects work as expected" $ asIO $ runConn $ do
         -- Ensure we can write to the database
         x <- insert $
@@ -37,4 +43,16 @@ specsWith runConn = describe "entity with non-null schema" $
         rawBar  <- rawSql "SELECT bar FROM foo.schema_entity" []
         liftIO $ rawBar @?= [Single (42 :: Int)]
         liftIO $ schemaEntityBar schemaEntity @== 42
+        return ()
+    it "is not ambiguous when both tables exist" $ asIO $ runConn $ do
+        _ <- insert $
+            SchemaEntity
+                { schemaEntityBar = 42
+                }
+        _ <- insert $
+            DefaultSchemaEntity
+                { defaultSchemaEntityBar = 43
+                }
+        rawBar  <- rawSql "SELECT bar FROM schema_entity" []
+        liftIO $ rawBar @?= [Single (43 :: Int)]
         return ()

--- a/persistent/Database/Persist/EntityDef.hs
+++ b/persistent/Database/Persist/EntityDef.hs
@@ -84,7 +84,9 @@ getEntityHaskellName = entityHaskell
 getEntityDBName
     :: EntityDef
     -> EntityNameDB
-getEntityDBName = entityDB
+getEntityDBName entityDef = case entitySchema entityDef of
+    Nothing -> entityDB entityDef
+    Just schema -> EntityNameDB $ schema <> "." <> unEntityNameDB (entityDB entityDef)
 
 getEntityExtra :: EntityDef -> Map Text [[Text]]
 getEntityExtra = entityExtra

--- a/persistent/Database/Persist/EntityDef.hs
+++ b/persistent/Database/Persist/EntityDef.hs
@@ -19,6 +19,7 @@ module Database.Persist.EntityDef
     , getEntityKeyFields
     , getEntityComments
     , getEntityExtra
+    , getEntitySchema
     , isEntitySum
     , entityPrimary
     , entitiesPrimary
@@ -27,6 +28,7 @@ module Database.Persist.EntityDef
     , setEntityId
     , setEntityIdDef
     , setEntityDBName
+    , setEntitySchema
     , overEntityFields
       -- * Related Types
     , EntityIdDef(..)
@@ -88,6 +90,9 @@ getEntityDBName = entityDB
 
 getEntityExtra :: EntityDef -> Map Text [[Text]]
 getEntityExtra = entityExtra
+
+getEntitySchema :: EntityDef -> Maybe SchemaNameDB
+getEntitySchema = entitySchema
 
 -- |
 --
@@ -194,6 +199,9 @@ getEntityKeyFields = entityKeyFields
 -- @since 2.13.0.0
 setEntityFields :: [FieldDef] -> EntityDef -> EntityDef
 setEntityFields fd ed = ed { entityFields = fd }
+
+setEntitySchema :: Maybe SchemaNameDB -> EntityDef -> EntityDef
+setEntitySchema sn ed = ed { entitySchema = sn }
 
 -- | Perform a mapping function over all of the entity fields, as determined by
 -- 'getEntityFieldsDatabase'.

--- a/persistent/Database/Persist/EntityDef.hs
+++ b/persistent/Database/Persist/EntityDef.hs
@@ -84,9 +84,7 @@ getEntityHaskellName = entityHaskell
 getEntityDBName
     :: EntityDef
     -> EntityNameDB
-getEntityDBName entityDef = case entitySchema entityDef of
-    Nothing -> entityDB entityDef
-    Just schema -> EntityNameDB $ schema <> "." <> unEntityNameDB (entityDB entityDef)
+getEntityDBName = entityDB
 
 getEntityExtra :: EntityDef -> Map Text [[Text]]
 getEntityExtra = entityExtra

--- a/persistent/Database/Persist/Names.hs
+++ b/persistent/Database/Persist/Names.hs
@@ -70,3 +70,9 @@ instance DatabaseName ConstraintNameDB where
 -- @since 2.12.0.0
 newtype ConstraintNameHS = ConstraintNameHS { unConstraintNameHS :: Text }
   deriving (Show, Eq, Read, Ord, Lift)
+
+newtype SchemaNameDB = SchemaNameDB { unSchemaNameDB :: Text }
+  deriving (Show, Eq, Read, Ord, Lift)
+
+instance DatabaseName SchemaNameDB where
+  escapeWith f (SchemaNameDB n) = f n

--- a/persistent/Database/Persist/Quasi.hs
+++ b/persistent/Database/Persist/Quasi.hs
@@ -186,11 +186,21 @@ User sql=big_user_table
 This will alter the generated SQL to be:
 
 @
-CREATE TABEL big_user_table (
+CREATE TABLE big_user_table (
     id      SERIAL PRIMARY KEY,
     name    VARCHAR,
     age     INT
 );
+@
+
+= Table Schema
+
+You can use a @schema=some_schema@ annotation to specify the table's schema name.
+This can be placed before or after the entity's @sql=custom@ annotation, if it has one.
+
+@
+Foo schema=bar
+    baz        Int
 @
 
 = Customizing Types/Tables

--- a/persistent/Database/Persist/Quasi/Internal.hs
+++ b/persistent/Database/Persist/Quasi/Internal.hs
@@ -310,6 +310,7 @@ parseLines ps = do
 data ParsedEntityDef = ParsedEntityDef
     { parsedEntityDefComments :: [Text]
     , parsedEntityDefEntityName :: EntityNameHS
+    , parsedEntityDefSchemaName :: Maybe SchemaNameDB
     , parsedEntityDefIsSum :: Bool
     , parsedEntityDefEntityAttributes :: [Attr]
     , parsedEntityDefFieldAttributes :: [[Token]]
@@ -329,6 +330,7 @@ toParsedEntityDef :: LinesWithComments -> ParsedEntityDef
 toParsedEntityDef lwc = ParsedEntityDef
     { parsedEntityDefComments = lwcComments lwc
     , parsedEntityDefEntityName = entNameHS
+    , parsedEntityDefSchemaName = schemaName
     , parsedEntityDefIsSum = isSum
     , parsedEntityDefEntityAttributes = entAttribs
     , parsedEntityDefFieldAttributes = attribs
@@ -348,6 +350,9 @@ toParsedEntityDef lwc = ParsedEntityDef
 
     (attribs, extras) =
         parseEntityFields fieldLines
+
+    schemaName =
+      fmap SchemaNameDB $ listToMaybe $ mapMaybe (T.stripPrefix "schema=") entAttribs
 
 isDocComment :: Token -> Maybe Text
 isDocComment tok =
@@ -712,8 +717,7 @@ mkUnboundEntityDef ps parsedEntDef =
                     case parsedEntityDefComments parsedEntDef of
                         [] -> Nothing
                         comments -> Just (T.unlines comments)
-                , -- TODO: start parsing the schema attribute and write it here.
-                  entitySchema = Nothing
+                , entitySchema = parsedEntityDefSchemaName parsedEntDef
                 }
         }
   where
@@ -1392,14 +1396,9 @@ takeForeign ps entityName = takeRefTable
                                 EntityNameHS refTableName
                             , foreignRefTableDBName =
                                 EntityNameDB $ psToDBName ps refTableName
-                            , -- TODO: The existing foreign key syntax for
-                              -- UnboundForeignDef is not sufficiently rich to
-                              -- allow specifying the schema of the foreign
-                              -- relation. We need to add the ability to parse
-                              -- schema=foo directives inline for foreign keys
-                              -- and insert those values here.
-                              foreignRefSchemaDBName =
+                            , foreignRefSchemaDBName =
                                 Nothing
+                            -- ^ This will be determined in the TH phase ('fixForeignRefSchemaDBName').
                             , foreignConstraintNameHaskell =
                                 constraintName
                             , foreignConstraintNameDBName =

--- a/persistent/Database/Persist/Quasi/Internal.hs
+++ b/persistent/Database/Persist/Quasi/Internal.hs
@@ -712,6 +712,8 @@ mkUnboundEntityDef ps parsedEntDef =
                     case parsedEntityDefComments parsedEntDef of
                         [] -> Nothing
                         comments -> Just (T.unlines comments)
+                , -- TODO: start parsing the schema attribute and write it here.
+                  entitySchema = Nothing
                 }
         }
   where

--- a/persistent/Database/Persist/Quasi/Internal.hs
+++ b/persistent/Database/Persist/Quasi/Internal.hs
@@ -1392,6 +1392,14 @@ takeForeign ps entityName = takeRefTable
                                 EntityNameHS refTableName
                             , foreignRefTableDBName =
                                 EntityNameDB $ psToDBName ps refTableName
+                            , -- TODO: The existing foreign key syntax for
+                              -- UnboundForeignDef is not sufficiently rich to
+                              -- allow specifying the schema of the foreign
+                              -- relation. We need to add the ability to parse
+                              -- schema=foo directives inline for foreign keys
+                              -- and insert those values here.
+                              foreignRefSchemaDBName =
+                                Nothing
                             , foreignConstraintNameHaskell =
                                 constraintName
                             , foreignConstraintNameDBName =

--- a/persistent/Database/Persist/Sql/Types.hs
+++ b/persistent/Database/Persist/Sql/Types.hs
@@ -39,6 +39,7 @@ data ColumnReference = ColumnReference
     -- ^ The table name that the
     --
     -- @since 2.11.0.0
+    , crSchemaName :: !(Maybe SchemaNameDB)
     , crConstraintName :: !ConstraintNameDB
     -- ^ The name of the foreign key constraint.
     --
@@ -137,4 +138,3 @@ defaultConnectionPoolConfig = ConnectionPoolConfig 1 600 10
 -- processing).
 newtype Single a = Single {unSingle :: a}
     deriving (Eq, Ord, Show, Read)
-

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -331,11 +331,15 @@ liftAndFixKeys mps emEntities entityMap unboundEnt =
                     $(lift fixForeignNullable)
                 , foreignRefTableDBName =
                     $(lift fixForeignRefTableDBName)
+                , foreignRefSchemaDBName =
+                    $(lift fixForeignRefSchemaDBName)
                 }
             |]
           where
             fixForeignRefTableDBName =
                 getEntityDBName (unboundEntityDef parentDef)
+            fixForeignRefSchemaDBName = 
+                getEntitySchema (unboundEntityDef parentDef)
             foreignFieldNames =
                 case unboundForeignFields of
                     FieldListImpliedId ffns ->

--- a/persistent/Database/Persist/TH.hs
+++ b/persistent/Database/Persist/TH.hs
@@ -335,7 +335,7 @@ liftAndFixKeys mps emEntities entityMap unboundEnt =
             |]
           where
             fixForeignRefTableDBName =
-                entityDB (unboundEntityDef parentDef)
+                getEntityDBName (unboundEntityDef parentDef)
             foreignFieldNames =
                 case unboundForeignFields of
                     FieldListImpliedId ffns ->
@@ -1968,7 +1968,7 @@ fromValues entDef funName constructExpr fields = do
     return [ suc, normalClause [VarP x] patternMatchFailure ]
   where
     tableName =
-        unEntityNameDB (entityDB (unboundEntityDef entDef))
+        unEntityNameDB (getEntityDBName (unboundEntityDef entDef))
     patternSuccess =
         case fields of
             [] -> do

--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -153,7 +153,7 @@ data EntityDef = EntityDef
     -- ^ Whether or not this entity represents a sum type in the database.
     , entityComments :: !(Maybe Text)
     -- ^ Optional comments on the entity.
-    , entitySchema :: !(Maybe Text)
+    , entitySchema :: !(Maybe SchemaNameDB)
     -- ^ The schema the entity belongs to.
     --
     -- @since 2.10.0

--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -554,6 +554,7 @@ type ForeignFieldDef = (FieldNameHS, FieldNameDB)
 data ForeignDef = ForeignDef
     { foreignRefTableHaskell       :: !EntityNameHS
     , foreignRefTableDBName        :: !EntityNameDB
+    , foreignRefSchemaDBName       :: !(Maybe SchemaNameDB)
     , foreignConstraintNameHaskell :: !ConstraintNameHS
     , foreignConstraintNameDBName  :: !ConstraintNameDB
     , foreignFieldCascade          :: !FieldCascade

--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -153,6 +153,8 @@ data EntityDef = EntityDef
     -- ^ Whether or not this entity represents a sum type in the database.
     , entityComments :: !(Maybe Text)
     -- ^ Optional comments on the entity.
+    , entitySchema :: !(Maybe Text)
+    -- ^ The schema the entity belongs to.
     --
     -- @since 2.10.0
     }

--- a/persistent/test/Database/Persist/QuasiSpec.hs
+++ b/persistent/test/Database/Persist/QuasiSpec.hs
@@ -332,6 +332,7 @@ Notification
                 [ ForeignDef
                     { foreignRefTableHaskell = EntityNameHS "User"
                     , foreignRefTableDBName = EntityNameDB "user"
+                    , foreignRefSchemaDBName = Nothing
                     , foreignConstraintNameHaskell = ConstraintNameHS "fk_noti_user"
                     , foreignConstraintNameDBName = ConstraintNameDB "notificationfk_noti_user"
                     , foreignFieldCascade = FieldCascade Nothing Nothing

--- a/persistent/test/Database/Persist/TH/ForeignRefSpec.hs
+++ b/persistent/test/Database/Persist/TH/ForeignRefSpec.hs
@@ -49,6 +49,7 @@ mkPersist sqlSettings [persistLowerCase|
 
 HasCustomName sql=custom_name
     name Text
+    Primary name
 
 ForeignTarget
     name Text
@@ -79,7 +80,7 @@ ChildImplicit
     name Text
     parent ParentImplicitId OnDeleteCascade OnUpdateCascade
 
-ParentExplicit
+ParentExplicit schema=adult
     name Text
     Primary name
 
@@ -176,3 +177,12 @@ spec = describe "ForeignRefSpec" $ do
                             , "got: "
                             , show as
                             ]
+
+    describe "Foreign Schema Name" $ do
+        let
+            [childForeignDef] =
+                entityForeigns $ entityDef $ Proxy @ChildExplicit
+        it "should have the correct schema name" $ do
+            (foreignRefSchemaDBName childForeignDef)
+                `shouldBe`
+                    (Just $ SchemaNameDB "adult")

--- a/persistent/test/Database/Persist/THSpec.hs
+++ b/persistent/test/Database/Persist/THSpec.hs
@@ -371,6 +371,7 @@ spec = describe "THSpec" $ do
                             , entityExtra = mempty
                             , entitySum = False
                             , entityComments = Nothing
+                            , entitySchema = Nothing
                             }
         it "has the cascade on the field def" $ do
             fieldCascade subject `shouldBe` expected

--- a/persistent/test/Database/Persist/THSpec.hs
+++ b/persistent/test/Database/Persist/THSpec.hs
@@ -71,14 +71,13 @@ import qualified Database.Persist.TH.SharedPrimaryKeySpec as SharedPrimaryKeySpe
 import qualified Database.Persist.TH.SumSpec as SumSpec
 import qualified Database.Persist.TH.ToFromPersistValuesSpec as ToFromPersistValuesSpec
 import qualified Database.Persist.TH.TypeLitFieldDefsSpec as TypeLitFieldDefsSpec
-
 -- test to ensure we can have types ending in Id that don't trash the TH
 -- machinery
 type TextId = Text
 
 share [mkPersistWith  sqlSettings { mpsGeneric = False, mpsDeriveInstances = [''Generic] } [entityDef @JsonEncodingSpec.JsonEncoding Proxy]] [persistUpperCase|
 
-Person json
+Person json schema=some_schema
     name Text
     age Int Maybe
     foo Foo
@@ -507,6 +506,13 @@ spec = describe "THSpec" $ do
         it "has a good safe to insert class instance" $ do
             let proxy = Proxy :: SafeToInsert CustomIdName => Proxy CustomIdName
             proxy `shouldBe` Proxy
+    describe "Entity Schema" $ do
+        let personDef =
+                entityDef (Proxy :: Proxy Person)
+        it "reads the entity schema" $ do
+            (entitySchema personDef)
+                `shouldBe`
+                    (Just $ SchemaNameDB "some_schema")
 
 (&) :: a -> (a -> b) -> b
 x & f = f x


### PR DESCRIPTION
Addresses https://github.com/yesodweb/persistent/issues/93
I worked on this together with @benjonesy.

This PR is in draft form, we're going to do a little more work on it still.

# Design challenges and decisions

## "Schema" means many things to many backends

In this PR, we use the word "schema" to refer to various devices that backends offer for namespacing tables.

- :heavy_check_mark: In PostgreSQL, a schema exists in between the level of a table and a database.
- :heavy_check_mark: In MySQL and SQLite, schemas and databases are synonymous concepts.
- :x: MongoDB and Redis do not have a concept analogous to schemas.

The semantics of schemas in the three relational backends are quite different, so Persistent's schema support will inherit these differences in semantics. For example, MySQL can enforce foreign key references across databases, but PostgreSQL and SQLite cannot. So a Persistent model with a cross-schema foreign key reference may lead to runtime errors with PostgreSQL and SQLite backends, but it will work fine with the MySQL backend.

## Schemas may or may not exist

We considered designing this PR so that Persistent would create schemas for the user if they did not already exist. But we chose not to do that. This means that local development with Persistent using schemas will require some manual SQL migrations to create the schemas that the user wants. But for conventional use-cases, schema creation will be a rare event, so this is not very onerous for developers. Below are some issues one would have to solve to make Persistent automate schema creation for the developer:

### Three-stage migrations

RIght now, the `CREATe TABLE` DDL statements are sorted to the top of the migration output, so that the (potentially recursive) foreign-key constraints are created only after all of the tables they reference exist. If we also wanted Persistent to ensure the existence of schemas, we would need to sort backend-appropriate versions of `CREATE SCHEMA` statements above the `CREATe TABLE` statements.

### Granting permissions in MySQL

Before a connection can use a newly created database in MySQL, one must run a `GRANT` statement to give the current user the requisite DDL operations to run `CREATe TABLE` statements. We would somehow need to make Persistent aware of the 

### File name and directory in SQLite

SQLite's invocation for creating a new database also specifies the file name and location for that database's `.db` file. Persistent would need to be opinionated about this directory scheme, or we would have to add a configuration option, if we wanted to support schema creation in SQLite.

# PR Template checklist

Before submitting your PR, check that you've:
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [ ] Ran `stylish-haskell` on any changed files.
- [ ] Adhered to the code style (see the `.editorconfig` file for details)

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
