### PR TITLE
chore: fix `flake.nix` workable

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,0 @@
-use flake . --accept-flake-config
-dotenv_if_exists .env.local

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+use flake . --accept-flake-config
+dotenv_if_exists .env.local

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ cabal.sandbox.config
 dist-newstyle/
 .ghc.environment.*
 
+# for direnv
+.envrc
+
 # nix relation
 .direnv/
 .env.local

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,11 @@ cabal.sandbox.config
 dist-newstyle/
 .ghc.environment.*
 
+# nix relation
+.direnv/
+.env.local
+result/
+
 ## Docker image ignores
 /.cabal/
 /.stackage/

--- a/cabal.project
+++ b/cabal.project
@@ -8,6 +8,10 @@ packages:
   persistent-redis
   persistent-qq
 
+-- required by nix.
+package postgresql-libpq
+  flags: +use-pkg-config
+
 constraints:
   -- https://github.com/mongodb-haskell/mongodb/pull/152
   mongoDB < 2.7.1.3 

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -17,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1660396586,
-        "narHash": "sha256-ePuWn7z/J5p2lO7YokOG1o01M0pDDVL3VrStaPpS5Ig=",
+        "lastModified": 1740367490,
+        "narHash": "sha256-WGaHVAjcrv+Cun7zPlI41SerRtfknGQap281+AakSAw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e105167e98817ba9fe079c6c3c544c6ef188e276",
+        "rev": "0196c0175e9191c474c26ab5548db27ef5d34b05",
         "type": "github"
       },
       "original": {
@@ -35,6 +38,21 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,105 @@
 {
   "nodes": {
+    "HTTP": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
+    "cabal-32": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-34": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1645834128,
+        "narHash": "sha256-wG3d+dOt14z8+ydz4SL7pwGfe7SiimxcD/LOuPCV6xM=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "5ff598c67f53f7c4f48e31d722ba37172230c462",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-36": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1669081697,
+        "narHash": "sha256-I5or+V7LZvMxfbYgZATU4awzkicBwwok4mVoje+sGmU=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "8fd619e33d34924a94e691c5fea2c42f0fc7f144",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cardano-shell": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1672831974,
+        "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "45f2638735f8cdc40fe302742b79f248d23eb368",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "hkm/gitlab-fix",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -18,26 +118,429 @@
         "type": "github"
       }
     },
-    "nixpkgs": {
+    "ghc-8.6.5-iohk": {
+      "flake": false,
       "locked": {
-        "lastModified": 1740367490,
-        "narHash": "sha256-WGaHVAjcrv+Cun7zPlI41SerRtfknGQap281+AakSAw=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "0196c0175e9191c474c26ab5548db27ef5d34b05",
+        "lastModified": 1600920045,
+        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
+        "owner": "input-output-hk",
+        "repo": "ghc",
+        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
+        "owner": "input-output-hk",
+        "ref": "release/8.6.5-iohk",
+        "repo": "ghc",
+        "type": "github"
+      }
+    },
+    "hackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1740615848,
+        "narHash": "sha256-YhhduYJuXQtNzM5H/g6g4neJtYax4sZFnPY+lBP/bZQ=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "fc0b2e94f27de17fca8e63f15fbb8987e23ff9ae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage-for-stackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1740615838,
+        "narHash": "sha256-Lg6E0uRfGzOEUjhiE/UAj1IQkPwFnG264wPtV+sYcpY=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "4a4aea6de97835226109669f083d27319354ab25",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "for-stackage",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "haskellNix": {
+      "inputs": {
+        "HTTP": "HTTP",
+        "cabal-32": "cabal-32",
+        "cabal-34": "cabal-34",
+        "cabal-36": "cabal-36",
+        "cardano-shell": "cardano-shell",
+        "flake-compat": "flake-compat",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
+        "hackage": "hackage",
+        "hackage-for-stackage": "hackage-for-stackage",
+        "hls-1.10": "hls-1.10",
+        "hls-2.0": "hls-2.0",
+        "hls-2.2": "hls-2.2",
+        "hls-2.3": "hls-2.3",
+        "hls-2.4": "hls-2.4",
+        "hls-2.5": "hls-2.5",
+        "hls-2.6": "hls-2.6",
+        "hls-2.7": "hls-2.7",
+        "hls-2.8": "hls-2.8",
+        "hls-2.9": "hls-2.9",
+        "hpc-coveralls": "hpc-coveralls",
+        "iserv-proxy": "iserv-proxy",
+        "nixpkgs": [
+          "haskellNix",
+          "nixpkgs-unstable"
+        ],
+        "nixpkgs-2305": "nixpkgs-2305",
+        "nixpkgs-2311": "nixpkgs-2311",
+        "nixpkgs-2405": "nixpkgs-2405",
+        "nixpkgs-2411": "nixpkgs-2411",
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "old-ghc-nix": "old-ghc-nix",
+        "stackage": "stackage"
+      },
+      "locked": {
+        "lastModified": 1740617510,
+        "narHash": "sha256-dZEpPNJLyUErO5WO0+HTOX5/ywZuibyy4Byp7g8rQJ8=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "cdcce3719c3f47402e9e447961ca66e063d65ea7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "hls-1.10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1680000865,
+        "narHash": "sha256-rc7iiUAcrHxwRM/s0ErEsSPxOR3u8t7DvFeWlMycWgo=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b08691db779f7a35ff322b71e72a12f6e3376fd9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "1.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.0": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1687698105,
+        "narHash": "sha256-OHXlgRzs/kuJH8q7Sxh507H+0Rb8b7VOiPAjcY9sM1k=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "783905f211ac63edf982dd1889c671653327e441",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.0.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1693064058,
+        "narHash": "sha256-8DGIyz5GjuCFmohY6Fa79hHA/p1iIqubfJUTGQElbNk=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b30f4b6cf5822f3112c35d14a0cba51f3fe23b85",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.2.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1695910642,
+        "narHash": "sha256-tR58doOs3DncFehHwCLczJgntyG/zlsSd7DgDgMPOkI=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "458ccdb55c9ea22cd5d13ec3051aaefb295321be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.3.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1699862708,
+        "narHash": "sha256-YHXSkdz53zd0fYGIYOgLt6HrA0eaRJi9mXVqDgmvrjk=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "54507ef7e85fa8e9d0eb9a669832a3287ffccd57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.4.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1701080174,
+        "narHash": "sha256-fyiR9TaHGJIIR0UmcCb73Xv9TJq3ht2ioxQ2mT7kVdc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "27f8c3d3892e38edaef5bea3870161815c4d014c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.5.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1705325287,
+        "narHash": "sha256-+P87oLdlPyMw8Mgoul7HMWdEvWP/fNlo8jyNtwME8E8=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "6e0b342fa0327e628610f2711f8c3e4eaaa08b1e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.6.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1708965829,
+        "narHash": "sha256-LfJ+TBcBFq/XKoiNI7pc4VoHg4WmuzsFxYJ3Fu+Jf+M=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "50322b0a4aefb27adc5ec42f5055aaa8f8e38001",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.7.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.8": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1715153580,
+        "narHash": "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "dd1be1beb16700de59e0d6801957290bcf956a0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.8.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.9": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1720003792,
+        "narHash": "sha256-qnDx8Pk0UxtoPr7BimEsAZh9g2WuTuMB/kGqnmdryKs=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "0c1817cb2babef0765e4e72dd297c013e8e3d12b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.9.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hpc-coveralls": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
+    "iserv-proxy": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1717479972,
+        "narHash": "sha256-7vE3RQycHI1YT9LHJ1/fUaeln2vIpYm6Mmn8FTpYeVo=",
+        "owner": "stable-haskell",
+        "repo": "iserv-proxy",
+        "rev": "2ed34002247213fc435d0062350b91bab920626e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "stable-haskell",
+        "ref": "iserv-syms",
+        "repo": "iserv-proxy",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2305": {
+      "locked": {
+        "lastModified": 1705033721,
+        "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
+        "rev": "a1982c92d8980a0114372973cbdfe0a307f1bdea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2311": {
+      "locked": {
+        "lastModified": 1719957072,
+        "narHash": "sha256-gvFhEf5nszouwLAkT9nWsDzocUTqLWHuL++dvNjMp9I=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7144d6241f02d171d25fba3edeaf15e0f2592105",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2405": {
+      "locked": {
+        "lastModified": 1735564410,
+        "narHash": "sha256-HB/FA0+1gpSs8+/boEavrGJH+Eq08/R2wWNph1sM1Dg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1e7a8f391f1a490460760065fa0630b5520f9cf8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2411": {
+      "locked": {
+        "lastModified": 1737255904,
+        "narHash": "sha256-r3fxHvh+M/mBgCZXOACzRFPsJdix2QSsKazb7VCXXo0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "eacdab35066b0bb1c9413c96898e326b76398a81",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1737110817,
+        "narHash": "sha256-DSenga8XjPaUV5KUFW/i3rNkN7jm9XmguW+qQ1ZJTR4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "041c867bad68dfe34b78b2813028a2e2ea70a23c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "old-ghc-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "haskellNix": "haskellNix",
+        "nixpkgs": [
+          "haskellNix",
+          "nixpkgs-unstable"
+        ]
+      }
+    },
+    "stackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1740615115,
+        "narHash": "sha256-8nv8fvnW6axl7ogjOfMQGJ2LhgT7JMcgq1P2yMFynyY=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "dca0ea6196058fbbd367f32f76d184ef550676c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -7,8 +7,6 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  nixConfig.allow-import-from-derivation = true; # cabal2nix uses IFD
-
   outputs = { self, nixpkgs, flake-utils }:
     let
       ghcVer = "ghc902";
@@ -91,4 +89,15 @@
           });
       };
     };
+
+  nixConfig = {
+    extra-substituters = [
+      "https://cache.nixos.org/"
+      "https://cache.iog.io" # use GHC binary cache.
+    ];
+    extra-trusted-public-keys = [
+      "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
+    ];
+    allow-import-from-derivation = "true";
+  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,15 @@
                 };
                 buildInputs = with pkgs; [ postgresql ];
               };
+              modules = [{
+                packages."mysql".components.library = with pkgs; {
+                  configureFlags = [
+                    "--with-mysql_config=${mariadb-connector-c.dev}/bin/mysql_config"
+                  ];
+                  includes = [ openssl zlib ];
+                  libs = [ openssl zlib ];
+                };
+              }];
             };
           })
         ];

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
                   ghcid = "latest";
                   haskell-language-server = "latest";
                 };
-                buildInputs = with pkgs; [ postgresql ];
+                buildInputs = with pkgs; [ mariadb postgresql redis sqlite ];
               };
               modules = [{
                 packages."mysql".components.library = with pkgs; {

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,7 @@
             project = final.haskell-nix.project' {
               src = ./.;
               compiler-nix-name = "ghc966";
+              projectFileName = "cabal.project";
               shell = {
                 tools = {
                   cabal = "latest";

--- a/flake.nix
+++ b/flake.nix
@@ -3,101 +3,47 @@
     "Persistence interface for Haskell allowing multiple storage methods.";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    haskellNix.url = "github:input-output-hk/haskell.nix";
+    nixpkgs.follows = "haskellNix/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
-    let
-      ghcVer = "ghc902";
-      makeHaskellOverlay = overlay: final: prev: {
-        haskell = prev.haskell // {
-          packages = prev.haskell.packages // {
-            ${ghcVer} = prev.haskell.packages."${ghcVer}".override (oldArgs: {
-              overrides =
-                prev.lib.composeExtensions (oldArgs.overrides or (_: _: { }))
-                (overlay prev);
-            });
-          };
+  outputs = { self, nixpkgs, flake-utils, haskellNix }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system overlays;
+          inherit (haskellNix) config;
         };
-      };
-
-      out = system:
-        let
-          pkgs = import nixpkgs {
-            inherit system;
-            overlays = [ self.overlays.default ];
-            config.allowBroken = true;
-          };
-
-        in {
-          packages = rec {
-            default = persistent;
-            inherit (pkgs.haskell.packages.${ghcVer})
-              persistent persistent-qq persistent-template persistent-mysql
-              persistent-test persistent-postgresql persistent-sqlite;
-          };
-
-          checks = self.packages.${system};
-
-          # for debugging
-          # inherit pkgs;
-
-          devShells.default =
-            let haskellPackages = pkgs.haskell.packages.${ghcVer};
-            in haskellPackages.shellFor {
-              packages = p:
-                with pkgs.haskell.packages.${ghcVer}; [
-                  persistent
-                  persistent-qq
-                  persistent-template
-                  persistent-redis
-                  persistent-mongoDB
-                  persistent-mysql
-                  persistent-test
-                  persistent-postgresql
-                  persistent-sqlite
-                ];
-              withHoogle = true;
-              buildInputs = with haskellPackages;
-                [ haskell-language-server fourmolu ghcid cabal-install ]
-                ++ (with pkgs; [ sqlite ]);
-              # Change the prompt to show that you are in a devShell
-              # shellHook = "export PS1='\\e[1;34mdev > \\e[0m'";
+        overlays = [
+          haskellNix.overlay
+          (final: prev: {
+            project = final.haskell-nix.project' {
+              src = ./.;
+              compiler-nix-name = "ghc966";
+              shell = {
+                tools = {
+                  cabal = "latest";
+                  cabal-install = "latest";
+                  fourmolu = "latest";
+                  ghcid = "latest";
+                  haskell-language-server = "latest";
+                };
+                buildInputs = with pkgs; [ sqlite ];
+              };
             };
-        };
-    in flake-utils.lib.eachDefaultSystem out // {
-      # this stuff is *not* per-system
-      overlays = {
-        default = makeHaskellOverlay (prev: hfinal: hprev:
-          let
-            hlib = prev.haskell.lib;
-            # this makeLocal business is rather a hack to deal with keeping the
-            # overrides from nixpkgs for these packages for e.g.
-            # persistent-sqlite using the nix-provided sqlite.
-            makeLocal = n: hlib.overrideSrc hprev.${n} { src = ./. + "/${n}"; };
-          in {
-            persistent = makeLocal "persistent";
-            persistent-test = makeLocal "persistent-test";
-            persistent-sqlite = makeLocal "persistent-sqlite";
-            persistent-postgresql = makeLocal "persistent-postgresql";
-            persistent-mysql = makeLocal "persistent-mysql";
-            persistent-redis = makeLocal "persistent-redis";
-            persistent-mongoDB = makeLocal "persistent-mongoDB";
-            persistent-qq = makeLocal "persistent-qq";
-            persistent-template = makeLocal "persistent-template";
-          });
-      };
-    };
+          })
+        ];
+        flake = pkgs.project.flake { };
+      in flake);
 
   nixConfig = {
     extra-substituters = [
       "https://cache.nixos.org/"
       "https://cache.iog.io" # use GHC binary cache.
     ];
-    extra-trusted-public-keys = [
-      "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
-    ];
+    extra-trusted-public-keys =
+      [ "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=" ];
     allow-import-from-derivation = "true";
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,6 @@
 {
-  description = "Persistence interface for Haskell allowing multiple storage methods.";
+  description =
+    "Persistence interface for Haskell allowing multiple storage methods.";
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
@@ -17,7 +18,7 @@
             ${ghcVer} = prev.haskell.packages."${ghcVer}".override (oldArgs: {
               overrides =
                 prev.lib.composeExtensions (oldArgs.overrides or (_: _: { }))
-                  (overlay prev);
+                (overlay prev);
             });
           };
         };
@@ -31,18 +32,12 @@
             config.allowBroken = true;
           };
 
-        in
-        {
+        in {
           packages = rec {
             default = persistent;
             inherit (pkgs.haskell.packages.${ghcVer})
-              persistent
-              persistent-qq
-              persistent-template
-              persistent-mysql
-              persistent-test
-              persistent-postgresql
-              persistent-sqlite;
+              persistent persistent-qq persistent-template persistent-mysql
+              persistent-test persistent-postgresql persistent-sqlite;
           };
 
           checks = self.packages.${system};
@@ -52,10 +47,9 @@
 
           devShells.default =
             let haskellPackages = pkgs.haskell.packages.${ghcVer};
-            in
-            haskellPackages.shellFor {
-              packages = p: with pkgs.haskell.packages.${ghcVer};
-                [
+            in haskellPackages.shellFor {
+              packages = p:
+                with pkgs.haskell.packages.${ghcVer}; [
                   persistent
                   persistent-qq
                   persistent-template
@@ -67,20 +61,14 @@
                   persistent-sqlite
                 ];
               withHoogle = true;
-              buildInputs = with haskellPackages; [
-                haskell-language-server
-                fourmolu
-                ghcid
-                cabal-install
-              ] ++ (with pkgs; [
-                sqlite
-              ]);
+              buildInputs = with haskellPackages;
+                [ haskell-language-server fourmolu ghcid cabal-install ]
+                ++ (with pkgs; [ sqlite ]);
               # Change the prompt to show that you are in a devShell
               # shellHook = "export PS1='\\e[1;34mdev > \\e[0m'";
             };
         };
-    in
-    flake-utils.lib.eachDefaultSystem out // {
+    in flake-utils.lib.eachDefaultSystem out // {
       # this stuff is *not* per-system
       overlays = {
         default = makeHaskellOverlay (prev: hfinal: hprev:
@@ -90,8 +78,7 @@
             # overrides from nixpkgs for these packages for e.g.
             # persistent-sqlite using the nix-provided sqlite.
             makeLocal = n: hlib.overrideSrc hprev.${n} { src = ./. + "/${n}"; };
-          in
-          {
+          in {
             persistent = makeLocal "persistent";
             persistent-test = makeLocal "persistent-test";
             persistent-sqlite = makeLocal "persistent-sqlite";

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
                   ghcid = "latest";
                   haskell-language-server = "latest";
                 };
-                buildInputs = with pkgs; [ sqlite ];
+                buildInputs = with pkgs; [ postgresql ];
               };
             };
           })

--- a/persistent-mongoDB/persistent-mongoDB.cabal
+++ b/persistent-mongoDB/persistent-mongoDB.cabal
@@ -41,8 +41,8 @@ library
     ghc-options:     -Wall
     default-language: Haskell2010
 
-   if flag(high_precision_date)
-     cpp-options: -DHIGH_PRECISION_DATE
+    if flag(high_precision_date)
+      cpp-options: -DHIGH_PRECISION_DATE
 
 test-suite test
     type:            exitcode-stdio-1.0

--- a/persistent-mongoDB/persistent-mongoDB.cabal
+++ b/persistent-mongoDB/persistent-mongoDB.cabal
@@ -76,4 +76,4 @@ test-suite test
 
 source-repository head
   type:     git
-  location: git://github.com/yesodweb/persistent.git
+  location: https://github.com/yesodweb/persistent.git

--- a/persistent-mysql/persistent-mysql.cabal
+++ b/persistent-mysql/persistent-mysql.cabal
@@ -48,7 +48,7 @@ library
 
 source-repository head
   type:     git
-  location: git://github.com/yesodweb/persistent.git
+  location: https://github.com/yesodweb/persistent.git
 
 test-suite test
     type:            exitcode-stdio-1.0

--- a/persistent-postgresql/persistent-postgresql.cabal
+++ b/persistent-postgresql/persistent-postgresql.cabal
@@ -43,7 +43,7 @@ library
 
 source-repository head
   type:     git
-  location: git://github.com/yesodweb/persistent.git
+  location: https://github.com/yesodweb/persistent.git
 
 test-suite test
     type:            exitcode-stdio-1.0

--- a/persistent-sqlite/persistent-sqlite.cabal
+++ b/persistent-sqlite/persistent-sqlite.cabal
@@ -96,7 +96,7 @@ library
 
 source-repository head
   type:     git
-  location: git://github.com/yesodweb/persistent.git
+  location: https://github.com/yesodweb/persistent.git
 
 executable sanity
     if flag(build-sanity-exe)

--- a/persistent-template/persistent-template.cabal
+++ b/persistent-template/persistent-template.cabal
@@ -22,4 +22,4 @@ library
 
 source-repository head
   type:     git
-  location: git://github.com/yesodweb/persistent.git
+  location: https://github.com/yesodweb/persistent.git

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -106,4 +106,4 @@ library
 
 source-repository head
   type:     git
-  location: git://github.com/yesodweb/persistent.git
+  location: https://github.com/yesodweb/persistent.git

--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -89,20 +89,20 @@ library
       , unliftio-core
       , unordered-containers
 
-  default-language: Haskell2010
-  default-extensions:
-      ExistentialQuantification
-      FlexibleContexts
-      FlexibleInstances
-      MultiParamTypeClasses
-      OverloadedStrings
-      QuasiQuotes
-      TemplateHaskell
-      TypeFamilies
-      StandaloneDeriving
-      DerivingStrategies
-      GeneralizedNewtypeDeriving
-      DataKinds
+    default-language: Haskell2010
+    default-extensions:
+        ExistentialQuantification
+        FlexibleContexts
+        FlexibleInstances
+        MultiParamTypeClasses
+        OverloadedStrings
+        QuasiQuotes
+        TemplateHaskell
+        TypeFamilies
+        StandaloneDeriving
+        DerivingStrategies
+        GeneralizedNewtypeDeriving
+        DataKinds
 
 source-repository head
   type:     git

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -202,7 +202,7 @@ test-suite test
 
 source-repository head
   type:     git
-  location: git://github.com/yesodweb/persistent.git
+  location: https://github.com/yesodweb/persistent.git
 
 benchmark persistent-th-bench
     ghc-options:      -O2


### PR DESCRIPTION
The Nix Flakes environment was not buildable at all,
so I fixed it to be functional.
Since it was not buildable at all,
I rewrote it to use haskell.nix,
which can automatically analogize rules from cabal files.

If Nix can build databases and other environments in one shot,
it should be useful for developing persistent with a lot of external tools and complexity.
In fact, I am going to try a bit of persistent and wasm collaboration in the future,
but without the nix environment,
I had a hard time working with a smooth reproducible build,
so I regenerated the flake.nix environment first.

---

This pull request includes various changes to configuration files to improve the setup and dependencies for the Haskell project. The most important changes include updates to the `flake.nix` configuration, the addition of new packages in `cabal.project`, and updates to repository URLs in multiple `.cabal` files.

### Configuration Updates:

* [`.envrc`](diffhunk://#diff-d33e979799a45c7c51752e9c8d96a3e452015d1a40b1e4b6ec6a98e92c4d8430R1-R2): Added new commands to use `flake` and load environment variables from `.env.local`.
* [`flake.nix`](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0L2-R57): Updated the configuration to use `haskellNix` and added new overlays and build inputs for better project management.

### Dependency Management:

* [`cabal.project`](diffhunk://#diff-b8ed06757045fac949c89f2139a862498ad2b6d1f82c61a31e7c91d6cf0eaa70R11-R14): Added `postgresql-libpq` package with specific flags required by `nix`.

### Repository URL Updates:

* [`persistent-mongoDB/persistent-mongoDB.cabal`](diffhunk://#diff-f95c6bf63d03108bed87c574b7c121207b714c11c40ba5797f7eebcbcdb64a75L79-R79): Changed the repository URL to use HTTPS instead of git protocol.
* [`persistent-mysql/persistent-mysql.cabal`](diffhunk://#diff-39473a1862aa368215d0896092ff19409d72f8526b4932dd2683687ca2286a82L51-R51): Changed the repository URL to use HTTPS instead of git protocol.
* [`persistent-postgresql/persistent-postgresql.cabal`](diffhunk://#diff-49748438e4fe598a89579556a5f006d15e9089a28fb7e4f9c32e9977af3dcc72L46-R46): Changed the repository URL to use HTTPS instead of git protocol.
* [`persistent-sqlite/persistent-sqlite.cabal`](diffhunk://#diff-2178d3840acb84d66f70b734a5e7b6c85f00405d0d6e04d67cc0b1142cf08c6fL99-R99): Changed the repository URL to use HTTPS instead of git protocol.
* [`persistent-template/persistent-template.cabal`](diffhunk://#diff-60261f9522ca5e34be56abd5e5fcf5187f61085f99932d797a26e286042fceabL25-R25): Changed the repository URL to use HTTPS instead of git protocol.
* [`persistent-test/persistent-test.cabal`](diffhunk://#diff-20935bd77fd09f384379c84c75fde736e7a2731beec955c6968adbb6d02ad4e1L109-R109): Changed the repository URL to use HTTPS instead of git protocol.
* [`persistent/persistent.cabal`](diffhunk://#diff-0400a119a2d7148805e4465cc15f273ea93ea2c377fe7093342dafd4f0d9d850L205-R205): Changed the repository URL to use HTTPS instead of git protocol.