### PR TITLE
use Megaparsec for first-pass parsing of entity definitions

### DIFF
--- a/persistent-test/persistent-test.cabal
+++ b/persistent-test/persistent-test.cabal
@@ -77,7 +77,7 @@ library
     , monad-logger          >=0.3.25
     , mtl
     , path-pieces           >=0.2
-    , persistent            >=2.14   && <2.16
+    , persistent            >=2.14   && <2.17
     , QuickCheck            >=2.9
     , quickcheck-instances  >=0.3
     , random                >=1.1

--- a/persistent-test/src/PersistentTest.hs
+++ b/persistent-test/src/PersistentTest.hs
@@ -651,7 +651,7 @@ specsWith runDb = describe "persistent" $ do
     it "provides comments on entity def" $ do
       getEntityComments edef
         `shouldBe`
-          Just "This is a doc comment for a relationship.\nYou need to put the pipe character for each line of documentation.\nBut you can resume the doc comments afterwards.\n"
+          Just "This is a doc comment for a relationship.\nOnly the first line requires a pipe.\nPipes are optional on subsequent lines."
     it "provides comments on the field" $ do
       let [nameField, _] = getEntityFields edef
       fieldComments nameField

--- a/persistent-test/src/PersistentTest.hs
+++ b/persistent-test/src/PersistentTest.hs
@@ -651,7 +651,7 @@ specsWith runDb = describe "persistent" $ do
     it "provides comments on entity def" $ do
       getEntityComments edef
         `shouldBe`
-          Just "This is a doc comment for a relationship.\nOnly the first line requires a pipe.\nPipes are optional on subsequent lines."
+          Just "This is a doc comment for a relationship.\nOnly the first line requires a pipe.\nPipes are optional on subsequent lines.\n"
     it "provides comments on the field" $ do
       let [nameField, _] = getEntityFields edef
       fieldComments nameField

--- a/persistent-test/src/PersistentTestModels.hs
+++ b/persistent-test/src/PersistentTestModels.hs
@@ -110,9 +110,8 @@ share [mkPersist persistSettings { mpsGeneric = True },  mkMigrate "testMigrate"
     deriving Eq Show
 
   -- | This is a doc comment for a relationship.
-  -- | You need to put the pipe character for each line of documentation.
-  -- Lines without a pipe are omitted.
-  -- | But you can resume the doc comments afterwards.
+  -- Only the first line requires a pipe.
+  -- | Pipes are optional on subsequent lines.
   Relationship
       -- | Fields should be documentable.
       name String

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,6 +1,6 @@
 # Changelog for persistent
 
-# 2.16.0.0
+# 2.16.0.0 [unreleased]
 
 * [#1584](https://github.com/yesodweb/persistent/pull/1584)
     * Rename `Span` to `SourceSpan`

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog for persistent
 
+# 2.15.1.1
+
+* [#1584](https://github.com/yesodweb/persistent/pull/1584)
+    * Parse entity definitions using Megaparsec.
+    * Support Haddock-style multiline pre-comments.
+
 # 2.15.1.0
 
 * [#1519](https://github.com/yesodweb/persistent/pull/1519/files/9865a295f4545d30e55aacb6efc25f27f758e8ad#diff-5af2883367baae8f7f266df6a89fc2d1defb7572d94ed069e05c8135a883bc45)

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,8 +1,9 @@
 # Changelog for persistent
 
-# 2.15.1.1
+# 2.16.0.0
 
 * [#1584](https://github.com/yesodweb/persistent/pull/1584)
+    * Rename `Span` to `SourceSpan`
     * Parse entity definitions using Megaparsec.
     * Support Haddock-style multiline pre-comments.
 

--- a/persistent/Database/Persist/EntityDef.hs
+++ b/persistent/Database/Persist/EntityDef.hs
@@ -19,7 +19,7 @@ module Database.Persist.EntityDef
     , getEntityKeyFields
     , getEntityComments
     , getEntityExtra
-    , getEntitySourceSpan
+    , getEntitySpan
     , isEntitySum
     , entityPrimary
     , entitiesPrimary
@@ -209,12 +209,12 @@ overEntityFields
 overEntityFields f ed =
     setEntityFields (f (getEntityFieldsDatabase ed)) ed
 
--- | Gets the 'SourceSpan' of the definition of the entity.
+-- | Gets the 'Source' of the definition of the entity.
 --
 -- Note that as of this writing the span covers the entire file or quasiquote
 -- where the item is defined due to parsing limitations. This may be changed in
 -- a future release to be more accurate.
 --
--- @since 2.16.0.0
-getEntitySourceSpan :: EntityDef -> Maybe SourceSpan
-getEntitySourceSpan = entitySourceSpan
+-- @since 2.15.0.0
+getEntitySpan :: EntityDef -> Maybe SourceSpan
+getEntitySpan = entitySpan

--- a/persistent/Database/Persist/EntityDef.hs
+++ b/persistent/Database/Persist/EntityDef.hs
@@ -19,7 +19,7 @@ module Database.Persist.EntityDef
     , getEntityKeyFields
     , getEntityComments
     , getEntityExtra
-    , getEntitySpan
+    , getEntitySourceSpan
     , isEntitySum
     , entityPrimary
     , entitiesPrimary
@@ -43,7 +43,7 @@ import Database.Persist.FieldDef
 
 import Database.Persist.Names
 import Database.Persist.Types.Base
-       (ForeignDef, Span, UniqueDef(..), entityKeyFields)
+       (ForeignDef, SourceSpan, UniqueDef(..), entityKeyFields)
 
 -- | Retrieve the list of 'UniqueDef' from an 'EntityDef'. This does not include
 -- a @Primary@ key, if one is defined. A future version of @persistent@ will
@@ -209,12 +209,12 @@ overEntityFields
 overEntityFields f ed =
     setEntityFields (f (getEntityFieldsDatabase ed)) ed
 
--- | Gets the 'Span' of the definition of the entity.
+-- | Gets the 'SourceSpan' of the definition of the entity.
 --
 -- Note that as of this writing the span covers the entire file or quasiquote
 -- where the item is defined due to parsing limitations. This may be changed in
 -- a future release to be more accurate.
 --
--- @since 2.15.0.0
-getEntitySpan :: EntityDef -> Maybe Span
-getEntitySpan = entitySpan
+-- @since 2.16.0.0
+getEntitySourceSpan :: EntityDef -> Maybe SourceSpan
+getEntitySourceSpan = entitySourceSpan

--- a/persistent/Database/Persist/Quasi/Internal.hs
+++ b/persistent/Database/Persist/Quasi/Internal.hs
@@ -226,7 +226,7 @@ parse
   :: PersistSettings
   -> [(Maybe SourceLoc, Text)]
   -> CumulativeParseResult [UnboundEntityDef]
-parse ps inputs = foldMap toCumulativeParseResult $ map (uncurry parseChunk) inputs
+parse ps = foldMap $ toCumulativeParseResult . uncurry parseChunk
   where
     parseChunk :: Maybe SourceLoc -> Text -> ParseResult [UnboundEntityDef]
     parseChunk mSourceLoc source = (fmap . fmap) (mkUnboundEntityDef ps) (parseSource mSourceLoc source)

--- a/persistent/Database/Persist/Quasi/Internal.hs
+++ b/persistent/Database/Persist/Quasi/Internal.hs
@@ -309,10 +309,10 @@ data UnboundEntityDef
     -- the field?" yet, so we defer those to the Template Haskell execution.
     --
     -- @since 2.13.0.0
-    , unboundEntityDefSourceSpan :: Maybe SourceSpan
+    , unboundEntityDefSpan :: Maybe SourceSpan
     -- ^ The source code span of this entity in the models file.
     --
-    -- @since 2.16.0.0
+    -- @since 2.15.0.0
     }
     deriving (Eq, Ord, Show, Lift)
 
@@ -336,7 +336,7 @@ unbindEntityDef ed =
             ed
         , unboundEntityFields =
             map unbindFieldDef (entityFields ed)
-        , unboundEntityDefSourceSpan = entitySourceSpan ed
+        , unboundEntityDefSpan = entitySpan ed
         }
 
 -- | Returns the @['UnboundFieldDef']@ for an 'UnboundEntityDef'. This returns
@@ -547,7 +547,7 @@ mkUnboundEntityDef ps parsedEntDef =
                     DefaultKey (FieldNameDB $ psIdName ps)
         , unboundEntityFields =
             cols
-        , unboundEntityDefSourceSpan = parsedEntityDefSourceSpan parsedEntDef
+        , unboundEntityDefSpan = parsedEntityDefSpan parsedEntDef
         , unboundEntityDef =
             EntityDef
                 { entityHaskell = entNameHS
@@ -571,7 +571,7 @@ mkUnboundEntityDef ps parsedEntDef =
                     case parsedEntityDefComments parsedEntDef of
                         [] -> Nothing
                         comments -> Just (T.unlines comments)
-                , entitySourceSpan = parsedEntityDefSourceSpan parsedEntDef
+                , entitySpan = parsedEntityDefSpan parsedEntDef
                 }
         }
   where

--- a/persistent/Database/Persist/Quasi/Internal.hs
+++ b/persistent/Database/Persist/Quasi/Internal.hs
@@ -24,7 +24,6 @@ module Database.Persist.Quasi.Internal
     , takeColsEx
     , CumulativeParseResult (..)
     , renderErrors
-    , cumulativeData
 
       -- * UnboundEntityDef
     , UnboundEntityDef (..)

--- a/persistent/Database/Persist/Quasi/Internal.hs
+++ b/persistent/Database/Persist/Quasi/Internal.hs
@@ -24,6 +24,7 @@ module Database.Persist.Quasi.Internal
     , takeColsEx
     , CumulativeParseResult (..)
     , renderErrors
+    , cumulativeData
 
       -- * UnboundEntityDef
     , UnboundEntityDef (..)
@@ -226,10 +227,11 @@ parse
   :: PersistSettings
   -> [(Maybe SourceLoc, Text)]
   -> CumulativeParseResult [UnboundEntityDef]
-parse ps = foldMap $ toCumulativeParseResult . uncurry parseChunk
+parse ps chunks = toCumulativeParseResult $ map parseChunk chunks
   where
-    parseChunk :: Maybe SourceLoc -> Text -> ParseResult [UnboundEntityDef]
-    parseChunk mSourceLoc source = (fmap . fmap) (mkUnboundEntityDef ps) (parseSource mSourceLoc source)
+    parseChunk :: (Maybe SourceLoc, Text) -> ParseResult [UnboundEntityDef]
+    parseChunk (mSourceLoc, source) =
+      (fmap . fmap) (mkUnboundEntityDef ps) (parseSource mSourceLoc source)
 
 entityNamesFromParsedDef
     :: PersistSettings -> ParsedEntityDef -> (EntityNameHS, EntityNameDB)

--- a/persistent/Database/Persist/Quasi/Internal.hs
+++ b/persistent/Database/Persist/Quasi/Internal.hs
@@ -1,11 +1,9 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE StrictData #-}
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
 
@@ -21,58 +19,53 @@ module Database.Persist.Quasi.Internal
     , lowerCaseSettings
     , toFKNameInfixed
     , Token (..)
-    , Line (..)
-    , SourceLoc(..)
+    , SourceLoc (..)
     , sourceLocFromTHLoc
-    , preparse
-    , parseLine
     , parseFieldType
-    , associateLines
-    , LinesWithComments(..)
-    , parseEntityFields
     , takeColsEx
-    -- * UnboundEntityDef
-    , UnboundEntityDef(..)
+
+      -- * UnboundEntityDef
+    , UnboundEntityDef (..)
     , getUnboundEntityNameHS
     , unbindEntityDef
     , getUnboundFieldDefs
-    , UnboundForeignDef(..)
+    , UnboundForeignDef (..)
     , getSqlNameOr
-    , UnboundFieldDef(..)
-    , UnboundCompositeDef(..)
-    , UnboundIdDef(..)
+    , UnboundFieldDef (..)
+    , UnboundCompositeDef (..)
+    , UnboundIdDef (..)
     , unbindFieldDef
     , isUnboundFieldNullable
     , unboundIdDefToFieldDef
-    , PrimarySpec(..)
+    , PrimarySpec (..)
     , mkAutoIdField'
-    , UnboundForeignFieldList(..)
-    , ForeignFieldReference(..)
+    , UnboundForeignFieldList (..)
+    , ForeignFieldReference (..)
     , mkKeyConType
     , isHaskellUnboundField
-    , FieldTypeLit(..)
+    , FieldTypeLit (..)
     ) where
 
 import Prelude hiding (lines)
 
-import Control.Applicative (Alternative((<|>)))
+import Control.Applicative (Alternative ((<|>)))
 import Control.Monad
 import Data.Char (isDigit, isLower, isSpace, isUpper, toLower)
 import Data.List (find, foldl')
-import Data.List.NonEmpty (NonEmpty(..))
+import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NEL
-import qualified Data.Map as M
 import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
 import Data.Monoid (mappend)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Database.Persist.EntityDef.Internal
+import Database.Persist.Quasi.Internal.ModelParser
 import Database.Persist.Types
 import Database.Persist.Types.Base
-import Language.Haskell.TH.Syntax (Lift, Loc(..))
+import Language.Haskell.TH.Syntax (Lift, Loc (..))
 import qualified Text.Read as R
 
-data ParseState a = PSDone | PSFail String | PSSuccess a Text deriving Show
+data ParseState a = PSDone | PSFail String | PSSuccess a Text deriving (Show)
 
 parseFieldType :: Text -> Either String FieldType
 parseFieldType t0 =
@@ -85,19 +78,22 @@ parseFieldType t0 =
     parseApplyFT :: Text -> ParseState FieldType
     parseApplyFT t =
         case goMany id t of
-            PSSuccess (ft:fts) t' -> PSSuccess (foldl' FTApp ft fts) t'
+            PSSuccess (ft : fts) t' -> PSSuccess (foldl' FTApp ft fts) t'
             PSSuccess [] _ -> PSFail "empty"
             PSFail err -> PSFail err
             PSDone -> PSDone
 
-    parseEnclosed :: Char -> (FieldType -> FieldType) -> Text -> ParseState FieldType
+    parseEnclosed
+        :: Char -> (FieldType -> FieldType) -> Text -> ParseState FieldType
     parseEnclosed end ftMod t =
-      let (a, b) = T.break (== end) t
-      in case parseApplyFT a of
-          PSSuccess ft t' -> case (T.dropWhile isSpace t', T.uncons b) of
-              ("", Just (c, t'')) | c == end -> PSSuccess (ftMod ft) (t'' `Data.Monoid.mappend` t')
-              (x, y) -> PSFail $ show (b, x, y)
-          x -> PSFail $ show x
+        let
+            (a, b) = T.break (== end) t
+         in
+            case parseApplyFT a of
+                PSSuccess ft t' -> case (T.dropWhile isSpace t', T.uncons b) of
+                    ("", Just (c, t'')) | c == end -> PSSuccess (ftMod ft) (t'' `Data.Monoid.mappend` t')
+                    (x, y) -> PSFail $ show (b, x, y)
+                x -> PSFail $ show x
 
     parse1 :: Text -> ParseState FieldType
     parse1 t = fromMaybe (PSFail (show t)) $ do
@@ -105,11 +101,11 @@ parseFieldType t0 =
             Nothing -> pure PSDone
             Just (x, xs) ->
                 parseSpace x xs
-                <|> parseParenEnclosed x xs
-                <|> parseList x xs
-                <|> parseNumericLit x xs
-                <|> parseTextLit x xs
-                <|> parseTypeCon x xs
+                    <|> parseParenEnclosed x xs
+                    <|> parseList x xs
+                    <|> parseNumericLit x xs
+                    <|> parseTextLit x xs
+                    <|> parseTypeCon x xs
 
     parseSpace :: Char -> Text -> Maybe (ParseState FieldType)
     parseSpace c t = do
@@ -127,26 +123,29 @@ parseFieldType t0 =
     parseTextLit :: Char -> Text -> Maybe (ParseState FieldType)
     parseTextLit c t = do
         guard (c == '"')
-        let (a, b) = T.break (== '"') t
+        let
+            (a, b) = T.break (== '"') t
             lit = FTLit (TextTypeLit a)
         pure $ PSSuccess lit (T.drop 1 b)
 
     parseNumericLit :: Char -> Text -> Maybe (ParseState FieldType)
     parseNumericLit c t = do
         guard (isDigit c && T.all isDigit t)
-        let (a, b) = breakAtNextSpace t
+        let
+            (a, b) = breakAtNextSpace t
         lit <- FTLit . IntTypeLit <$> readMaybe (T.cons c a)
         pure $ PSSuccess lit b
 
     parseTypeCon c t = do
         guard (isUpper c || c == '\'')
-        let (a, b) = breakAtNextSpace t
+        let
+            (a, b) = breakAtNextSpace t
         pure $ PSSuccess (parseFieldTypePiece c a) b
 
     goMany :: ([FieldType] -> a) -> Text -> ParseState a
     goMany front t =
         case parse1 t of
-            PSSuccess x t' -> goMany (front . (x:)) t'
+            PSSuccess x t' -> goMany (front . (x :)) t'
             PSFail err -> PSFail err
             PSDone -> PSSuccess (front []) t
 
@@ -160,11 +159,13 @@ parseFieldTypePiece fstChar rest =
         '\'' ->
             FTTypePromoted rest
         _ ->
-            let t = T.cons fstChar rest
-             in case T.breakOnEnd "." t of
-                (_, "") -> FTTypeCon Nothing t
-                ("", _) -> FTTypeCon Nothing t
-                (a, b) -> FTTypeCon (Just $ T.init a) b
+            let
+                t = T.cons fstChar rest
+             in
+                case T.breakOnEnd "." t of
+                    (_, "") -> FTTypeCon Nothing t
+                    ("", _) -> FTTypeCon Nothing t
+                    (a, b) -> FTTypeCon (Just $ T.init a) b
 
 data PersistSettings = PersistSettings
     { psToDBName :: !(Text -> Text)
@@ -187,279 +188,90 @@ data PersistSettings = PersistSettings
     }
 
 defaultPersistSettings, upperCaseSettings, lowerCaseSettings :: PersistSettings
-defaultPersistSettings = PersistSettings
-    { psToDBName = id
-    , psToFKName = \(EntityNameHS entName) (ConstraintNameHS conName) -> entName <> conName
-    , psStrictFields = True
-    , psIdName       = "id"
-    }
-
+defaultPersistSettings =
+    PersistSettings
+        { psToDBName = id
+        , psToFKName = \(EntityNameHS entName) (ConstraintNameHS conName) -> entName <> conName
+        , psStrictFields = True
+        , psIdName = "id"
+        }
 upperCaseSettings = defaultPersistSettings
-
-lowerCaseSettings = defaultPersistSettings
-    { psToDBName =
-        let go c
-                | isUpper c = T.pack ['_', toLower c]
-                | otherwise = T.singleton c
-         in T.dropWhile (== '_') . T.concatMap go
-    }
+lowerCaseSettings =
+    defaultPersistSettings
+        { psToDBName =
+            let
+                go c
+                    | isUpper c = T.pack ['_', toLower c]
+                    | otherwise = T.singleton c
+             in
+                T.dropWhile (== '_') . T.concatMap go
+        }
 
 toFKNameInfixed :: Text -> EntityNameHS -> ConstraintNameHS -> Text
 toFKNameInfixed inf (EntityNameHS entName) (ConstraintNameHS conName) =
     entName <> inf <> conName
 
--- | Source location: file and line/col information. This is half of a 'Span'.
-data SourceLoc = SourceLoc
-    { locFile :: Text
-    , locStartLine :: Int
-    , locStartCol :: Int
-    } deriving (Show, Lift)
-
 sourceLocFromTHLoc :: Loc -> SourceLoc
-sourceLocFromTHLoc Loc {loc_filename=filename, loc_start=start} =
-    SourceLoc {locFile = T.pack filename, locStartLine = fst start, locStartCol = snd start}
-
+sourceLocFromTHLoc Loc{loc_filename = filename, loc_start = start} =
+    SourceLoc
+        { locFile = T.pack filename
+        , locStartLine = fst start
+        , locStartCol = snd start
+        }
 
 -- | Parses a quasi-quoted syntax into a list of entity definitions.
 parse :: PersistSettings -> [(Maybe SourceLoc, Text)] -> [UnboundEntityDef]
-parse ps blocks =
-    mconcat $ handleBlock <$> blocks
-    where
-        handleBlock (mLoc, block) =
-            maybe []
-                (\(numLines, lns) -> parseLines ps (approximateSpan numLines block <$> mLoc) lns)
-                (preparse block)
-        -- FIXME: put an actually truthful span into here
-        -- We can't give a better result if we push any of this down into the
-        -- parser at the moment since the parser throws out location info by
-        -- e.g. discarding comment lines completely without keeping track of
-        -- where it is. The realistic fix to this is rewriting the parser in
-        -- Megaparsec, which is a reasonable idea that should actually be done.
-        approximateSpan numLines block loc =
-            Span
-            { spanFile = locFile loc
-            , spanStartLine = locStartLine loc
-            , spanStartCol = locStartCol loc
-            , spanEndLine = locStartLine loc + numLines - 1
-            -- Last line's length plus one (since we are one-past-the-end)
-            , spanEndCol = (+ 1) . T.length . T.takeWhileEnd (/= '\n') $ block
-            }
-
-preparse :: Text -> Maybe (Int, NonEmpty Line)
-preparse txt = do
-    lns <- NEL.nonEmpty (T.lines txt)
-    let rawLineCount = length lns
-    (rawLineCount,) <$> NEL.nonEmpty (mapMaybe parseLine (NEL.toList lns))
-
-parseLine :: Text -> Maybe Line
-parseLine txt = do
-    Line (parseIndentationAmount txt) <$> NEL.nonEmpty (tokenize txt)
-
--- | A token used by the parser.
-data Token = Token Text    -- ^ @Token tok@ is token @tok@ already unquoted.
-           | DocComment Text -- ^ @DocComment@ is a documentation comment, unmodified.
-  deriving (Show, Eq)
-
-tokenText :: Token -> Text
-tokenText tok =
-    case tok of
-        Token t -> t
-        DocComment t -> "-- | " <> t
-
-parseIndentationAmount :: Text -> Int
-parseIndentationAmount txt =
-    let (spaces, _) = T.span isSpace txt
-     in T.length spaces
-
--- | Tokenize a string.
-tokenize :: Text -> [Token]
-tokenize t
-    | T.null t = []
-    | Just txt <- T.stripPrefix "-- |" t = [DocComment (T.stripStart txt)]
-    | "--" `T.isPrefixOf` t = [] -- Comment until the end of the line.
-    | "#" `T.isPrefixOf` t = [] -- Also comment to the end of the line, needed for a CPP bug (#110)
-    | T.head t == '"' = quotes (T.tail t) id
-    | T.head t == '(' = parens 1 (T.tail t) id
-    | isSpace (T.head t) =
-        tokenize (T.dropWhile isSpace t)
-
-    -- support mid-token quotes and parens
-    | Just (beforeEquals, afterEquals) <- findMidToken t
-    , not (T.any isSpace beforeEquals)
-    , Token next : rest <- tokenize afterEquals =
-        Token (T.concat [beforeEquals, "=", next]) : rest
-
-    | otherwise =
-        let (token, rest) = T.break isSpace t
-         in Token token : tokenize rest
+parse ps = foldMap $ uncurry parseChunk
   where
-    findMidToken :: Text -> Maybe (Text, Text)
-    findMidToken t' =
-        case T.break (== '=') t' of
-            (x, T.drop 1 -> y)
-                | "\"" `T.isPrefixOf` y || "(" `T.isPrefixOf` y -> Just (x, y)
-            _ -> Nothing
+    parseChunk :: Maybe SourceLoc -> Text -> [UnboundEntityDef]
+    parseChunk mSourceLoc source = fmap (mkUnboundEntityDef ps) (parseSource mSourceLoc source)
 
-    quotes :: Text -> ([Text] -> [Text]) -> [Token]
-    quotes t' front
-        | T.null t' = error $ T.unpack $ T.concat $
-            "Unterminated quoted string starting with " : front []
-        | T.head t' == '"' = Token (T.concat $ front []) : tokenize (T.tail t')
-        | T.head t' == '\\' && T.length t' > 1 =
-            quotes (T.drop 2 t') (front . (T.take 1 (T.drop 1 t'):))
-        | otherwise =
-            let (x, y) = T.break (`elem` ['\\','\"']) t'
-             in quotes y (front . (x:))
-
-    parens :: Int -> Text -> ([Text] -> [Text]) -> [Token]
-    parens count t' front
-        | T.null t' = error $ T.unpack $ T.concat $
-            "Unterminated parens string starting with " : front []
-        | T.head t' == ')' =
-            if count == (1 :: Int)
-                then Token (T.concat $ front []) : tokenize (T.tail t')
-                else parens (count - 1) (T.tail t') (front . (")":))
-        | T.head t' == '(' =
-            parens (count + 1) (T.tail t') (front . ("(":))
-        | T.head t' == '\\' && T.length t' > 1 =
-            parens count (T.drop 2 t') (front . (T.take 1 (T.drop 1 t'):))
-        | otherwise =
-            let (x, y) = T.break (`elem` ['\\','(',')']) t'
-             in parens count y (front . (x:))
-
--- | A line of parsed tokens
-data Line = Line
-    { lineIndent   :: Int
-    , tokens       :: NonEmpty Token
-    } deriving (Eq, Show)
-
-lineText :: Line -> NonEmpty Text
-lineText = fmap tokenText . tokens
-
-lowestIndent :: NonEmpty Line -> Int
-lowestIndent = minimum . fmap lineIndent
-
--- | Divide lines into blocks and make entity definitions.
-parseLines :: PersistSettings -> Maybe Span -> NonEmpty Line -> [UnboundEntityDef]
-parseLines ps mSpan = do
-    fmap (mkUnboundEntityDef ps . toParsedEntityDef mSpan) . associateLines
-
-data ParsedEntityDef = ParsedEntityDef
-    { parsedEntityDefComments :: [Text]
-    , parsedEntityDefEntityName :: EntityNameHS
-    , parsedEntityDefIsSum :: Bool
-    , parsedEntityDefEntityAttributes :: [Attr]
-    , parsedEntityDefFieldAttributes :: [[Token]]
-    , parsedEntityDefExtras :: M.Map Text [ExtraLine]
-    , parsedEntityDefSpan :: Maybe Span
-    }
-
-entityNamesFromParsedDef :: PersistSettings -> ParsedEntityDef -> (EntityNameHS, EntityNameDB)
+entityNamesFromParsedDef
+    :: PersistSettings -> ParsedEntityDef -> (EntityNameHS, EntityNameDB)
 entityNamesFromParsedDef ps parsedEntDef = (entNameHS, entNameDB)
   where
     entNameHS =
         parsedEntityDefEntityName parsedEntDef
 
     entNameDB =
-        EntityNameDB $ getDbName ps (unEntityNameHS entNameHS) (parsedEntityDefEntityAttributes parsedEntDef)
+        EntityNameDB $
+            getDbName
+                ps
+                (unEntityNameHS entNameHS)
+                (parsedEntityDefEntityAttributes parsedEntDef)
 
-toParsedEntityDef :: Maybe Span -> LinesWithComments -> ParsedEntityDef
-toParsedEntityDef mSpan lwc = ParsedEntityDef
-    { parsedEntityDefComments = lwcComments lwc
-    , parsedEntityDefEntityName = entNameHS
-    , parsedEntityDefIsSum = isSum
-    , parsedEntityDefEntityAttributes = entAttribs
-    , parsedEntityDefFieldAttributes = attribs
-    , parsedEntityDefExtras = extras
-    , parsedEntityDefSpan = mSpan
+-- | This type represents an @Id@ declaration in the QuasiQuoted syntax.
+--
+-- > Id
+--
+-- This uses the implied settings, and is equivalent to omitting the @Id@
+-- statement entirely.
+--
+-- > Id Text
+--
+-- This will set the field type of the ID to be 'Text'.
+--
+-- > Id Text sql=foo_id
+--
+-- This will set the field type of the Id to be 'Text' and the SQL DB name to be @foo_id@.
+--
+-- > Id FooId
+--
+-- This results in a shared primary key - the @FooId@ refers to a @Foo@ table.
+--
+-- > Id FooId OnDelete Cascade
+--
+-- You can set a cascade behavior on an ID column.
+--
+-- @since 2.13.0.0
+data UnboundIdDef = UnboundIdDef
+    { unboundIdEntityName :: EntityNameHS
+    , unboundIdDBName :: !FieldNameDB
+    , unboundIdAttrs :: [FieldAttr]
+    , unboundIdCascade :: FieldCascade
+    , unboundIdType :: Maybe FieldType
     }
-  where
-    entityLine :| fieldLines =
-        lwcLines lwc
-
-    (entityName :| entAttribs) =
-        lineText entityLine
-
-    (isSum, entNameHS) =
-        case T.uncons entityName of
-            Just ('+', x) -> (True, EntityNameHS x)
-            _ -> (False, EntityNameHS entityName)
-
-    (attribs, extras) =
-        parseEntityFields fieldLines
-
-isDocComment :: Token -> Maybe Text
-isDocComment tok =
-    case tok of
-        DocComment txt -> Just txt
-        _ -> Nothing
-
-data LinesWithComments = LinesWithComments
-    { lwcLines :: NonEmpty Line
-    , lwcComments :: [Text]
-    } deriving (Eq, Show)
-
-instance Semigroup LinesWithComments where
-    a <> b =
-        LinesWithComments
-            { lwcLines =
-                foldr NEL.cons (lwcLines b) (lwcLines a)
-            , lwcComments =
-                lwcComments a `mappend` lwcComments b
-            }
-
-appendLwc :: LinesWithComments -> LinesWithComments -> LinesWithComments
-appendLwc = (<>)
-
-newLine :: Line -> LinesWithComments
-newLine l = LinesWithComments (pure l) []
-
-firstLine :: LinesWithComments -> Line
-firstLine = NEL.head . lwcLines
-
-consLine :: Line -> LinesWithComments -> LinesWithComments
-consLine l lwc = lwc { lwcLines = NEL.cons l (lwcLines lwc) }
-
-consComment :: Text -> LinesWithComments -> LinesWithComments
-consComment l lwc = lwc { lwcComments = l : lwcComments lwc }
-
-associateLines :: NonEmpty Line -> [LinesWithComments]
-associateLines lines =
-    foldr combine [] $
-    foldr toLinesWithComments [] lines
-  where
-    toLinesWithComments :: Line -> [LinesWithComments] -> [LinesWithComments]
-    toLinesWithComments line linesWithComments =
-        case linesWithComments of
-            [] ->
-                [newLine line]
-            (lwc : lwcs) ->
-                case isDocComment (NEL.head (tokens line)) of
-                    Just comment
-                        | lineIndent line == lowestIndent lines ->
-                        consComment comment lwc : lwcs
-                    _ ->
-                        if lineIndent line <= lineIndent (firstLine lwc)
-                            && lineIndent (firstLine lwc) /= lowestIndent lines
-                        then
-                            consLine line lwc : lwcs
-                        else
-                            newLine line : lwc : lwcs
-
-    combine :: LinesWithComments -> [LinesWithComments] -> [LinesWithComments]
-    combine lwc [] =
-        [lwc]
-    combine lwc (lwc' : lwcs) =
-        let minIndent = minimumIndentOf lwc
-            otherIndent = minimumIndentOf lwc'
-         in
-            if minIndent < otherIndent then
-                appendLwc lwc lwc' : lwcs
-            else
-                lwc : lwc' : lwcs
-
-    minimumIndentOf :: LinesWithComments -> Int
-    minimumIndentOf = lowestIndent . lwcLines
+    deriving (Eq, Ord, Show, Lift)
 
 -- | An 'EntityDef' produced by the QuasiQuoter. It contains information that
 -- the QuasiQuoter is capable of knowing about the entities. It is inherently
@@ -631,24 +443,25 @@ data UnboundFieldDef
 --
 -- @since 2.13.0.0
 unbindFieldDef :: FieldDef -> UnboundFieldDef
-unbindFieldDef fd = UnboundFieldDef
-    { unboundFieldNameHS =
-        fieldHaskell fd
-    , unboundFieldNameDB =
-        fieldDB fd
-    , unboundFieldAttrs =
-        fieldAttrs fd
-    , unboundFieldType =
-        fieldType fd
-    , unboundFieldStrict =
-        fieldStrict fd
-    , unboundFieldCascade =
-        fieldCascade fd
-    , unboundFieldComments =
-        fieldComments fd
-    , unboundFieldGenerated =
-        fieldGenerated fd
-    }
+unbindFieldDef fd =
+    UnboundFieldDef
+        { unboundFieldNameHS =
+            fieldHaskell fd
+        , unboundFieldNameDB =
+            fieldDB fd
+        , unboundFieldAttrs =
+            fieldAttrs fd
+        , unboundFieldType =
+            fieldType fd
+        , unboundFieldStrict =
+            fieldStrict fd
+        , unboundFieldCascade =
+            fieldCascade fd
+        , unboundFieldComments =
+            fieldComments fd
+        , unboundFieldGenerated =
+            fieldGenerated fd
+        }
 
 isUnboundFieldNullable :: UnboundFieldDef -> IsNullable
 isUnboundFieldNullable =
@@ -663,55 +476,56 @@ isUnboundFieldNullable =
 --
 -- @since 2.13.0.0
 data PrimarySpec
-    = NaturalKey UnboundCompositeDef
-    -- ^ A 'NaturalKey' contains columns that are defined on the datatype
-    -- itself. This is defined using the @Primary@ keyword and given a non-empty
-    -- list of columns.
-    --
-    -- @
-    -- User
-    --     name    Text
-    --     email   Text
-    --
-    --     Primary name email
-    -- @
-    --
-    -- A natural key may also contain only a single column. A natural key with
-    -- multiple columns is called a 'composite key'.
-    --
-    -- @since 2.13.0.0
-    | SurrogateKey UnboundIdDef
-    -- ^ A surrogate key is not part of the domain model for a database table.
-    -- You can specify a custom surro
-    --
-    -- You can specify a custom surrogate key using the @Id@ syntax.
-    --
-    -- @
-    -- User
-    --     Id    Text
-    --     name  Text
-    -- @
-    --
-    -- Note that you must provide a @default=@ expression when using this in
-    -- order to use 'insert' or related functions. The 'insertKey' function can
-    -- be used instead, as it allows you to specify a key directly. Fixing this
-    -- issue is tracked in #1247 on GitHub.
-    --
-    -- @since 2.13.0.0
-    | DefaultKey FieldNameDB
-    -- ^ The default key for the entity using the settings in
-    -- 'MkPersistSettings'.
-    --
-    -- This is implicit - a table without an @Id@ or @Primary@ declaration will
-    -- have a 'DefaultKey'.
-    --
-    -- @since 2.13.0.0
+    = -- | A 'NaturalKey' contains columns that are defined on the datatype
+      -- itself. This is defined using the @Primary@ keyword and given a non-empty
+      -- list of columns.
+      --
+      -- @
+      -- User
+      --     name    Text
+      --     email   Text
+      --
+      --     Primary name email
+      -- @
+      --
+      -- A natural key may also contain only a single column. A natural key with
+      -- multiple columns is called a 'composite key'.
+      --
+      -- @since 2.13.0.0
+      NaturalKey UnboundCompositeDef
+    | -- | A surrogate key is not part of the domain model for a database table.
+      -- You can specify a custom surro
+      --
+      -- You can specify a custom surrogate key using the @Id@ syntax.
+      --
+      -- @
+      -- User
+      --     Id    Text
+      --     name  Text
+      -- @
+      --
+      -- Note that you must provide a @default=@ expression when using this in
+      -- order to use 'insert' or related functions. The 'insertKey' function can
+      -- be used instead, as it allows you to specify a key directly. Fixing this
+      -- issue is tracked in #1247 on GitHub.
+      --
+      -- @since 2.13.0.0
+      SurrogateKey UnboundIdDef
+    | -- | The default key for the entity using the settings in
+      -- 'MkPersistSettings'.
+      --
+      -- This is implicit - a table without an @Id@ or @Primary@ declaration will
+      -- have a 'DefaultKey'.
+      --
+      -- @since 2.13.0.0
+      DefaultKey FieldNameDB
     deriving (Eq, Ord, Show, Lift)
 
 -- | Construct an entity definition.
 mkUnboundEntityDef
     :: PersistSettings
-    -> ParsedEntityDef -- ^ parsed entity definition
+    -> ParsedEntityDef
+    -- ^ parsed entity definition
     -> UnboundEntityDef
 mkUnboundEntityDef ps parsedEntDef =
     UnboundEntityDef
@@ -719,14 +533,14 @@ mkUnboundEntityDef ps parsedEntDef =
             entityConstraintDefsForeignsList entityConstraintDefs
         , unboundPrimarySpec =
             case (idField, primaryComposite) of
-                (Just {}, Just {}) ->
+                (Just{}, Just{}) ->
                     error "Specified both an ID field and a Primary field"
                 (Just a, Nothing) ->
                     if unboundIdType a == Just (mkKeyConType (unboundIdEntityName a))
-                    then
-                        DefaultKey (FieldNameDB $ psIdName ps)
-                    else
-                        SurrogateKey a
+                        then
+                            DefaultKey (FieldNameDB $ psIdName ps)
+                        else
+                            SurrogateKey a
                 (Nothing, Just a) ->
                     NaturalKey a
                 (Nothing, Nothing) ->
@@ -738,12 +552,12 @@ mkUnboundEntityDef ps parsedEntDef =
             EntityDef
                 { entityHaskell = entNameHS
                 , entityDB = entNameDB
-                -- idField is the user-specified Id
-                -- otherwise useAutoIdField
-                -- but, adjust it if the user specified a Primary
-                , entityId =
+                , -- idField is the user-specified Id
+                  -- otherwise useAutoIdField
+                  -- but, adjust it if the user specified a Primary
+                  entityId =
                     EntityIdField $
-                    maybe autoIdField (unboundIdDefToFieldDef (defaultIdName ps) entNameHS) idField
+                        maybe autoIdField (unboundIdDefToFieldDef (defaultIdName ps) entNameHS) idField
                 , entityAttrs =
                     parsedEntityDefEntityAttributes parsedEntDef
                 , entityFields =
@@ -767,12 +581,24 @@ mkUnboundEntityDef ps parsedEntDef =
     attribs =
         parsedEntityDefFieldAttributes parsedEntDef
 
+    fieldComments =
+        parsedEntityDefFieldComments parsedEntDef
+
+    cols :: [UnboundFieldDef]
+    cols = foldMap (f . commentedField ps) (zip attribs fieldComments)
+      where
+        f = \case
+            Just unb -> [unb]
+            _ -> []
+
     textAttribs :: [[Text]]
     textAttribs =
-        fmap tokenText <$> attribs
+        fmap tokenContent <$> attribs
 
     entityConstraintDefs =
-        foldMap (maybe mempty (takeConstraint ps entNameHS cols) . NEL.nonEmpty) textAttribs
+        foldMap
+            (maybe mempty (takeConstraint ps entNameHS cols) . NEL.nonEmpty)
+            textAttribs
 
     idField =
         case entityConstraintDefsIdField entityConstraintDefs of
@@ -786,9 +612,6 @@ mkUnboundEntityDef ps parsedEntDef =
             SetOnce a -> Just a
             NotSet -> Nothing
 
-    cols :: [UnboundFieldDef]
-    cols = reverse . fst . foldr (associateComments ps) ([], []) $ reverse attribs
-
     autoIdField :: FieldDef
     autoIdField =
         mkAutoIdField ps entNameHS idSqlType
@@ -796,6 +619,12 @@ mkUnboundEntityDef ps parsedEntDef =
     idSqlType :: SqlType
     idSqlType =
         maybe SqlInt64 (const $ SqlOther "Primary Key") primaryComposite
+
+commentedField
+    :: PersistSettings -> ([Token], Maybe Text) -> Maybe UnboundFieldDef
+commentedField ps (tokens, mCommentText) = do
+    unb <- takeColsEx ps (tokenContent <$> tokens)
+    pure $ unb{unboundFieldComments = mCommentText}
 
 defaultIdName :: PersistSettings -> FieldNameDB
 defaultIdName = FieldNameDB . psIdName
@@ -864,35 +693,10 @@ unbindIdDef entityName fd =
             Just $ fieldType fd
         }
 
-associateComments
-    :: PersistSettings
-    -> [Token]
-    -> ([UnboundFieldDef], [Text])
-    -> ([UnboundFieldDef], [Text])
-associateComments ps x (!acc, !comments) =
-    case listToMaybe x of
-        Just (DocComment comment) ->
-            (acc, comment : comments)
-        _ ->
-            case (setFieldComments (reverse comments) <$> takeColsEx ps (tokenText <$> x)) of
-              Just sm ->
-                  (sm : acc, [])
-              Nothing ->
-                  (acc, [])
-
-setFieldComments :: [Text] -> UnboundFieldDef -> UnboundFieldDef
-setFieldComments xs fld =
-    case xs of
-        [] -> fld
-        _ -> fld { unboundFieldComments = Just (T.unlines xs) }
-
 mkAutoIdField :: PersistSettings -> EntityNameHS -> SqlType -> FieldDef
 mkAutoIdField ps =
     mkAutoIdField' (FieldNameDB $ psIdName ps)
 
--- | Creates a default ID field.
---
--- @since 2.13.0.0
 mkAutoIdField' :: FieldNameDB -> EntityNameHS -> SqlType -> FieldDef
 mkAutoIdField' dbName entName idSqlType =
     FieldDef
@@ -900,8 +704,7 @@ mkAutoIdField' dbName entName idSqlType =
         , fieldDB = dbName
         , fieldType = FTTypeCon Nothing $ keyConName entName
         , fieldSqlType = idSqlType
-        , fieldReference =
-            NoReference
+        , fieldReference = NoReference
         , fieldAttrs = []
         , fieldStrict = True
         , fieldComments = Nothing
@@ -912,23 +715,6 @@ mkAutoIdField' dbName entName idSqlType =
 
 keyConName :: EntityNameHS -> Text
 keyConName entName = unEntityNameHS entName `mappend` "Id"
-
-parseEntityFields
-    :: [Line]
-    -> ([[Token]], M.Map Text [ExtraLine])
-parseEntityFields lns =
-    case lns of
-        [] -> ([], M.empty)
-        (line : rest) ->
-            case NEL.toList (tokens line) of
-                [Token name]
-                  | isCapitalizedText name ->
-                    let (children, rest') = span ((> lineIndent line) . lineIndent) rest
-                        (x, y) = parseEntityFields rest'
-                     in (x, M.insert name (NEL.toList . lineText <$> children) y)
-                ts ->
-                    let (x, y) = parseEntityFields rest
-                     in (ts:x, y)
 
 isCapitalizedText :: Text -> Bool
 isCapitalizedText t =
@@ -944,29 +730,31 @@ takeCols
     -> PersistSettings
     -> [Text]
     -> Maybe UnboundFieldDef
-takeCols _ _ ("deriving":_) = Nothing
-takeCols onErr ps (n':typ:rest')
+takeCols _ _ ("deriving" : _) = Nothing
+takeCols onErr ps (n' : typ : rest')
     | not (T.null n) && isLower (T.head n) =
         case parseFieldType typ of
             Left err -> onErr typ err
-            Right ft -> Just UnboundFieldDef
-                { unboundFieldNameHS =
-                    FieldNameHS n
-                , unboundFieldNameDB =
-                    getDbName' ps n fieldAttrs_
-                , unboundFieldType =
-                    ft
-                , unboundFieldAttrs =
-                    fieldAttrs_
-                , unboundFieldStrict =
-                    fromMaybe (psStrictFields ps) mstrict
-                , unboundFieldComments =
-                    Nothing
-                , unboundFieldCascade =
-                    cascade_
-                , unboundFieldGenerated =
-                    generated_
-                }
+            Right ft ->
+                Just
+                    UnboundFieldDef
+                        { unboundFieldNameHS =
+                            FieldNameHS n
+                        , unboundFieldNameDB =
+                            getDbName' ps n fieldAttrs_
+                        , unboundFieldType =
+                            ft
+                        , unboundFieldAttrs =
+                            fieldAttrs_
+                        , unboundFieldStrict =
+                            fromMaybe (psStrictFields ps) mstrict
+                        , unboundFieldComments =
+                            Nothing
+                        , unboundFieldCascade =
+                            cascade_
+                        , unboundFieldGenerated =
+                            generated_
+                        }
   where
     fieldAttrs_ = parseFieldAttrs attrs_
     generated_ = parseGenerated attrs_
@@ -975,7 +763,6 @@ takeCols onErr ps (n':typ:rest')
         | Just x <- T.stripPrefix "!" n' = (Just True, x)
         | Just x <- T.stripPrefix "~" n' = (Just False, x)
         | otherwise = (Nothing, n')
-
 takeCols _ _ _ = Nothing
 
 parseGenerated :: [Text] -> Maybe Text
@@ -1006,9 +793,9 @@ getSqlNameOr def =
                 Nothing
 
 data SetOnceAtMost a
-  = NotSet
-  | SetOnce a
-  | SetMoreThanOnce
+    = NotSet
+    | SetOnce a
+    | SetMoreThanOnce
 
 instance Semigroup (SetOnceAtMost a) where
     a <> b =
@@ -1032,10 +819,14 @@ data EntityConstraintDefs = EntityConstraintDefs
 instance Semigroup EntityConstraintDefs where
     a <> b =
         EntityConstraintDefs
-            { entityConstraintDefsIdField = entityConstraintDefsIdField a <> entityConstraintDefsIdField b
-            , entityConstraintDefsPrimaryComposite = entityConstraintDefsPrimaryComposite a <> entityConstraintDefsPrimaryComposite b
-            , entityConstraintDefsUniques = entityConstraintDefsUniques a <> entityConstraintDefsUniques b
-            , entityConstraintDefsForeigns = entityConstraintDefsForeigns a <> entityConstraintDefsForeigns b
+            { entityConstraintDefsIdField =
+                entityConstraintDefsIdField a <> entityConstraintDefsIdField b
+            , entityConstraintDefsPrimaryComposite =
+                entityConstraintDefsPrimaryComposite a <> entityConstraintDefsPrimaryComposite b
+            , entityConstraintDefsUniques =
+                entityConstraintDefsUniques a <> entityConstraintDefsUniques b
+            , entityConstraintDefsForeigns =
+                entityConstraintDefsForeigns a <> entityConstraintDefsForeigns b
             }
 
 instance Monoid EntityConstraintDefs where
@@ -1070,7 +861,7 @@ takeConstraint ps entityName defs (n :| rest) =
             let
                 unboundComposite =
                     takeComposite (unboundFieldNameHS <$> defs) rest
-            in
+             in
                 mempty
                     { entityConstraintDefsPrimaryComposite =
                         SetOnce unboundComposite
@@ -1082,46 +873,14 @@ takeConstraint ps entityName defs (n :| rest) =
                 { entityConstraintDefsIdField =
                     SetOnce (takeId ps entityName rest)
                 }
-        _ | isCapitalizedText n ->
-            mempty
-                { entityConstraintDefsUniques =
-                    pure <$> takeUniq ps "" defs (n : rest)
-                }
+        _
+            | isCapitalizedText n ->
+                mempty
+                    { entityConstraintDefsUniques =
+                        pure <$> takeUniq ps "" defs (n : rest)
+                    }
         _ ->
             mempty
-
--- | This type represents an @Id@ declaration in the QuasiQuoted syntax.
---
--- > Id
---
--- This uses the implied settings, and is equivalent to omitting the @Id@
--- statement entirely.
---
--- > Id Text
---
--- This will set the field type of the ID to be 'Text'.
---
--- > Id Text sql=foo_id
---
--- This will set the field type of the Id to be 'Text' and the SQL DB name to be @foo_id@.
---
--- > Id FooId
---
--- This results in a shared primary key - the @FooId@ refers to a @Foo@ table.
---
--- > Id FooId OnDelete Cascade
---
--- You can set a cascade behavior on an ID column.
---
--- @since 2.13.0.0
-data UnboundIdDef = UnboundIdDef
-    { unboundIdEntityName :: EntityNameHS
-    , unboundIdDBName :: !FieldNameDB
-    , unboundIdAttrs :: [FieldAttr]
-    , unboundIdCascade :: FieldCascade
-    , unboundIdType :: Maybe FieldType
-    }
-    deriving (Eq, Ord, Show, Lift)
 
 -- TODO: this is hacky (the double takeCols, the setFieldDef stuff, and setIdName.
 -- need to re-work takeCols function
@@ -1168,8 +927,9 @@ data UnboundCompositeDef = UnboundCompositeDef
     }
     deriving (Eq, Ord, Show, Lift)
 
-compositeToUniqueDef :: EntityNameHS -> [UnboundFieldDef] -> UnboundCompositeDef -> UniqueDef
-compositeToUniqueDef entityName fields UnboundCompositeDef {..} =
+compositeToUniqueDef
+    :: EntityNameHS -> [UnboundFieldDef] -> UnboundCompositeDef -> UniqueDef
+compositeToUniqueDef entityName fields UnboundCompositeDef{..} =
     UniqueDef
         { uniqueHaskell =
             ConstraintNameHS (unEntityNameHS entityName <> "PrimaryKey")
@@ -1187,11 +947,9 @@ compositeToUniqueDef entityName fields UnboundCompositeDef {..} =
                 error "Unable to find `hsName` in fields"
             (a : _) ->
                 a
-    matchHsName hsName UnboundFieldDef {..} = do
+    matchHsName hsName UnboundFieldDef{..} = do
         guard $ unboundFieldNameHS == hsName
         pure unboundFieldNameDB
-
-
 
 takeComposite
     :: [FieldNameHS]
@@ -1213,7 +971,7 @@ takeComposite fields pkcols =
                 xs
     (cols, attrs) = break ("!" `T.isPrefixOf`) pkcols
     getDef [] t = error $ "Unknown column in primary key constraint: " ++ show t
-    getDef (d:ds) t
+    getDef (d : ds) t
         | d == FieldNameHS t =
             -- TODO: check for nullability in later step
             -- if nullable (fieldAttrs d) /= NotNullable
@@ -1235,23 +993,24 @@ takeUniq
 takeUniq ps tableName defs (n : rest)
     | isCapitalizedText n = do
         fields <- mfields
-        pure UniqueDef
-            { uniqueHaskell =
-                ConstraintNameHS n
-            , uniqueDBName =
-                dbName
-            , uniqueFields =
-                fmap (\a -> (FieldNameHS a, getDBName defs a)) fields
-            , uniqueAttrs =
-                attrs
-            }
+        pure
+            UniqueDef
+                { uniqueHaskell =
+                    ConstraintNameHS n
+                , uniqueDBName =
+                    dbName
+                , uniqueFields =
+                    fmap (\a -> (FieldNameHS a, getDBName defs a)) fields
+                , uniqueAttrs =
+                    attrs
+                }
   where
     isAttr a =
-      "!" `T.isPrefixOf` a
+        "!" `T.isPrefixOf` a
     isSqlName a =
-      "sql=" `T.isPrefixOf` a
+        "sql=" `T.isPrefixOf` a
     isNonField a =
-       isAttr a || isSqlName a
+        isAttr a || isSqlName a
     (fieldsList, nonFields) =
         break isNonField rest
     mfields =
@@ -1260,39 +1019,44 @@ takeUniq ps tableName defs (n : rest)
     attrs = filter isAttr nonFields
 
     usualDbName =
-      ConstraintNameDB $ psToDBName ps (tableName `T.append` n)
+        ConstraintNameDB $ psToDBName ps (tableName `T.append` n)
     sqlName :: Maybe ConstraintNameDB
     sqlName =
-      case find isSqlName nonFields of
-        Nothing ->
-          Nothing
-        (Just t) ->
-          case drop 1 $ T.splitOn "=" t of
-            (x : _) -> Just (ConstraintNameDB x)
-            _ -> Nothing
+        case find isSqlName nonFields of
+            Nothing ->
+                Nothing
+            (Just t) ->
+                case drop 1 $ T.splitOn "=" t of
+                    (x : _) -> Just (ConstraintNameDB x)
+                    _ -> Nothing
     dbName = fromMaybe usualDbName sqlName
 
     getDBName [] t = error $ T.unpack (unknownUniqueColumnError t defs n)
-    getDBName (d:ds) t
+    getDBName (d : ds) t
         | unboundFieldNameHS d == FieldNameHS t =
             unboundFieldNameDB d
         | otherwise =
             getDBName ds t
-
 takeUniq _ tableName _ xs =
-  error $ "invalid unique constraint on table["
-          ++ show tableName
-          ++ "] expecting an uppercase constraint name xs="
-          ++ show xs
+    error $
+        "invalid unique constraint on table["
+            ++ show tableName
+            ++ "] expecting an uppercase constraint name xs="
+            ++ show xs
 
 unknownUniqueColumnError :: Text -> [UnboundFieldDef] -> Text -> Text
 unknownUniqueColumnError t defs n =
-    "Unknown column in \"" <> n <> "\" constraint: \"" <> t <> "\""
-        <> " possible fields: " <> T.pack (show (toFieldName <$> defs))
-    where
-        toFieldName :: UnboundFieldDef -> Text
-        toFieldName fd =
-            unFieldNameHS (unboundFieldNameHS fd)
+    "Unknown column in \""
+        <> n
+        <> "\" constraint: \""
+        <> t
+        <> "\""
+        <> " possible fields: "
+        <> T.pack (show (toFieldName <$> defs))
+  where
+    toFieldName :: UnboundFieldDef -> Text
+    toFieldName fd =
+        unFieldNameHS (unboundFieldNameHS fd)
 
 -- | Define an explicit foreign key reference.
 --
@@ -1329,38 +1093,38 @@ data UnboundForeignDef
 
 -- | A list of fields present on the foreign reference.
 data UnboundForeignFieldList
-    = FieldListImpliedId (NonEmpty FieldNameHS)
-    -- ^ If no @References@ keyword is supplied, then it is assumed that you are
-    -- referring to the @Primary@ key or @Id@ of the target entity.
-    --
-    -- @since 2.13.0.0
-    | FieldListHasReferences (NonEmpty ForeignFieldReference)
-    -- ^ You can specify the exact columns you're referring to here, if they
-    -- aren't part of a primary key. Most databases expect a unique index on the
-    -- columns you refer to, but Persistent doesnt' check that.
-    --
-    -- @
-    -- User
-    --     Id           UUID default="uuid_generate_v1mc()"
-    --     name         Text
-    --
-    --     UniqueName name
-    --
-    -- Dog
-    --     ownerName    Text
-    --
-    --     Foreign User fk_dog_user ownerName References name
-    -- @
-    --
-    -- @since 2.13.0.0
+    = -- | If no @References@ keyword is supplied, then it is assumed that you are
+      -- referring to the @Primary@ key or @Id@ of the target entity.
+      --
+      -- @since 2.13.0.0
+      FieldListImpliedId (NonEmpty FieldNameHS)
+    | -- | You can specify the exact columns you're referring to here, if they
+      -- aren't part of a primary key. Most databases expect a unique index on the
+      -- columns you refer to, but Persistent doesnt' check that.
+      --
+      -- @
+      -- User
+      --     Id           UUID default="uuid_generate_v1mc()"
+      --     name         Text
+      --
+      --     UniqueName name
+      --
+      -- Dog
+      --     ownerName    Text
+      --
+      --     Foreign User fk_dog_user ownerName References name
+      -- @
+      --
+      -- @since 2.13.0.0
+      FieldListHasReferences (NonEmpty ForeignFieldReference)
     deriving (Eq, Ord, Show, Lift)
 
 -- | A pairing of the 'FieldNameHS' for the source table to the 'FieldNameHS'
 -- for the target table.
 --
 -- @since 2.13.0.0
-data ForeignFieldReference =
-    ForeignFieldReference
+data ForeignFieldReference
+    = ForeignFieldReference
     { ffrSourceField :: FieldNameHS
     -- ^ The column on the source table.
     --
@@ -1381,7 +1145,7 @@ unbindForeignDef fd =
             fd
         }
   where
-    mk ((fH, _), (pH, _))  =
+    mk ((fH, _), (pH, _)) =
         ForeignFieldReference
             { ffrSourceField = fH
             , ffrTargetField = pH
@@ -1401,12 +1165,12 @@ mkUnboundForeignFieldList (fmap FieldNameHS -> source) (fmap FieldNameHS -> targ
                     Right $ FieldListImpliedId sources
                 Just targets ->
                     if length targets /= length sources
-                    then
-                        Left "Target and source length differe on foreign reference."
-                    else
-                        Right
-                        $ FieldListHasReferences
-                        $ NEL.zipWith ForeignFieldReference sources targets
+                        then
+                            Left "Target and source length differe on foreign reference."
+                        else
+                            Right $
+                                FieldListHasReferences $
+                                    NEL.zipWith ForeignFieldReference sources targets
 
 takeForeign
     :: PersistSettings
@@ -1416,16 +1180,19 @@ takeForeign
 takeForeign ps entityName = takeRefTable
   where
     errorPrefix :: String
-    errorPrefix = "invalid foreign key constraint on table[" ++ show (unEntityNameHS entityName) ++ "] "
+    errorPrefix =
+        "invalid foreign key constraint on table["
+            ++ show (unEntityNameHS entityName)
+            ++ "] "
 
     takeRefTable :: [Text] -> UnboundForeignDef
     takeRefTable [] =
         error $ errorPrefix ++ " expecting foreign table name"
-    takeRefTable (refTableName:restLine) =
+    takeRefTable (refTableName : restLine) =
         go restLine Nothing Nothing
       where
         go :: [Text] -> Maybe CascadeAction -> Maybe CascadeAction -> UnboundForeignDef
-        go (constraintNameText:rest) onDelete onUpdate
+        go (constraintNameText : rest) onDelete onUpdate
             | not (T.null constraintNameText) && isLower (T.head constraintNameText) =
                 UnboundForeignDef
                     { unboundForeignFields =
@@ -1471,32 +1238,37 @@ takeForeign ps entityName = takeRefTable
                                 | flen == plen ->
                                     (ffs, pfs)
                             (flen, plen) ->
-                                error $ errorPrefix ++ concat
-                                    [ "Found " , show flen
-                                    , " foreign fields but "
-                                    , show plen, " parent fields"
-                                    ]
-
+                                error $
+                                    errorPrefix
+                                        ++ concat
+                                            [ "Found "
+                                            , show flen
+                                            , " foreign fields but "
+                                            , show plen
+                                            , " parent fields"
+                                            ]
         go ((parseCascadeAction CascadeDelete -> Just cascadingAction) : rest) onDelete' onUpdate =
             case onDelete' of
                 Nothing ->
                     go rest (Just cascadingAction) onUpdate
                 Just _ ->
                     error $ errorPrefix ++ "found more than one OnDelete actions"
-
         go ((parseCascadeAction CascadeUpdate -> Just cascadingAction) : rest) onDelete onUpdate' =
             case onUpdate' of
                 Nothing ->
                     go rest onDelete (Just cascadingAction)
                 Just _ ->
                     error $ errorPrefix ++ "found more than one OnUpdate actions"
+        go xs _ _ =
+            error $
+                errorPrefix
+                    ++ "expecting a lower case constraint name or a cascading action xs="
+                    ++ show xs
 
-        go xs _ _ = error $ errorPrefix ++ "expecting a lower case constraint name or a cascading action xs=" ++ show xs
-
-toFKConstraintNameDB :: PersistSettings -> EntityNameHS -> ConstraintNameHS -> ConstraintNameDB
+toFKConstraintNameDB
+    :: PersistSettings -> EntityNameHS -> ConstraintNameHS -> ConstraintNameDB
 toFKConstraintNameDB ps entityName constraintName =
     ConstraintNameDB $ psToDBName ps (psToFKName ps entityName constraintName)
-
 data CascadePrefix = CascadeUpdate | CascadeDelete
 
 parseCascade :: [Text] -> (FieldCascade, [Text])
@@ -1547,7 +1319,7 @@ parseCascadeAction prfx text = do
             CascadeDelete -> "Delete"
 
 takeDerives :: [Text] -> Maybe [Text]
-takeDerives ("deriving":rest) = Just rest
+takeDerives ("deriving" : rest) = Just rest
 takeDerives _ = Nothing
 
 -- | Returns 'True' if the 'UnboundFieldDef' does not have a 'MigrationOnly' or
@@ -1556,8 +1328,8 @@ takeDerives _ = Nothing
 -- @since 2.13.0.0
 isHaskellUnboundField :: UnboundFieldDef -> Bool
 isHaskellUnboundField fd =
-    FieldAttrMigrationOnly `notElem` unboundFieldAttrs fd &&
-    FieldAttrSafeToRemove `notElem` unboundFieldAttrs fd
+    FieldAttrMigrationOnly `notElem` unboundFieldAttrs fd
+        && FieldAttrSafeToRemove `notElem` unboundFieldAttrs fd
 
 -- |  Return the 'EntityNameHS' for an 'UnboundEntityDef'.
 --
@@ -1565,5 +1337,5 @@ isHaskellUnboundField fd =
 getUnboundEntityNameHS :: UnboundEntityDef -> EntityNameHS
 getUnboundEntityNameHS = entityHaskell . unboundEntityDef
 
-readMaybe :: Read a => Text -> Maybe a
+readMaybe :: (Read a) => Text -> Maybe a
 readMaybe = R.readMaybe . T.unpack

--- a/persistent/Database/Persist/Quasi/Internal/ModelParser.hs
+++ b/persistent/Database/Persist/Quasi/Internal/ModelParser.hs
@@ -46,11 +46,14 @@ type Parser = Parsec Void String
 
 type ParseResult a = Either (ParseErrorBundle String Void) a
 
+-- @since 2.16.0.0
 data CumulativeParseResult a = CumulativeParseResult
     { cumulativeErrors :: [ParseErrorBundle String Void]
     , cumulativeData :: a
     }
 
+-- | Populates a CumulativeParseResult with a single error or datum
+-- @since 2.16.0.0
 toCumulativeParseResult
     :: (Monoid a)
     => ParseResult a
@@ -66,6 +69,8 @@ toCumulativeParseResult (Right res) =
         , cumulativeData = res
         }
 
+-- | Converts the errors in a CumulativeParseResult to a String
+-- @since 2.16.0.0
 renderErrors :: CumulativeParseResult a -> Maybe String
 renderErrors cpr =
     case cumulativeErrors cpr of

--- a/persistent/Database/Persist/Quasi/Internal/ModelParser.hs
+++ b/persistent/Database/Persist/Quasi/Internal/ModelParser.hs
@@ -21,6 +21,7 @@ module Database.Persist.Quasi.Internal.ModelParser
     , memberBlockAttrs
     ) where
 
+import Prelude hiding (lines, unlines)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NEL
 import qualified Data.Map as M
@@ -28,12 +29,12 @@ import Data.Maybe
 import Data.Text (Text, pack, unlines, unpack)
 import Data.Void
 import Database.Persist.Types
+import Database.Persist.Types.Span
 import Language.Haskell.TH.Syntax (Lift)
 import Replace.Megaparsec (sepCap)
 import Text.Megaparsec hiding (Token)
 import Text.Megaparsec.Char
 import qualified Text.Megaparsec.Char.Lexer as L
-import Prelude hiding (lines, unlines)
 
 type Parser = Parsec Void String
 

--- a/persistent/Database/Persist/Quasi/Internal/ModelParser.hs
+++ b/persistent/Database/Persist/Quasi/Internal/ModelParser.hs
@@ -434,7 +434,7 @@ blockAttr = do
     ref <- indentLevelBacktrack indentationConsumer
     dcb <- docCommentBlock
     pos <- getSourcePos
-    line <- indented indentationConsumer ref $ some anyNonCommentToken
+    line <- indented indentationConsumer ref $ some anyNonCommentToken <* eol
     pure $
         MemberBlockAttr
             BlockAttr

--- a/persistent/Database/Persist/Quasi/Internal/ModelParser.hs
+++ b/persistent/Database/Persist/Quasi/Internal/ModelParser.hs
@@ -144,16 +144,16 @@ equality = label "equality expression" $ do
         _ <- char '='
         rhs <-
             choice
-                [ try quotationInner
+                [ try quotation'
                 , try sqlLiteral
-                , try parenthetical'
+                , try parentheticalInner
                 , some $ contentChar <|> char '(' <|> char ')'
                 ]
         pure $ Equality (pack lhs) (pack rhs)
   where
-    quotationInner = do
-        str <- quotation'
-        pure $ "\"" <> str <> "\""
+    parentheticalInner = do
+        str <- parenthetical'
+        pure . init . drop 1 $ str
 
 sqlTypeName :: Parser String
 sqlTypeName = some $ choice [ alphaNumChar

--- a/persistent/Database/Persist/Quasi/Internal/ModelParser.hs
+++ b/persistent/Database/Persist/Quasi/Internal/ModelParser.hs
@@ -100,6 +100,7 @@ contentChar =
         , char '~'
         , char '-'
         , char ':'
+        , char ','
         , do
             backslash <- char '\\'
             nextChar <- lookAhead anySingle

--- a/persistent/Database/Persist/Quasi/Internal/ModelParser.hs
+++ b/persistent/Database/Persist/Quasi/Internal/ModelParser.hs
@@ -97,6 +97,10 @@ contentChar =
         , char '_'
         , char '\''
         , char '"'
+        , char '!'
+        , char '~'
+        , char '-'
+        , char ':'
         , try escapedParen
         , char '\\'
         ]

--- a/persistent/Database/Persist/Quasi/Internal/ModelParser.hs
+++ b/persistent/Database/Persist/Quasi/Internal/ModelParser.hs
@@ -170,7 +170,7 @@ sqlLiteral = label "SQL literal" $ do
   pure $ mconcat [ "'"
                  , quote
                  , "'"
-                 , maybe "" id st
+                 , fromMaybe "" st
                  ]
 
 quotation :: Parser Token

--- a/persistent/Database/Persist/Quasi/Internal/ModelParser.hs
+++ b/persistent/Database/Persist/Quasi/Internal/ModelParser.hs
@@ -15,7 +15,7 @@ module Database.Persist.Quasi.Internal.ModelParser
     , parsedEntityDefEntityAttributes
     , parsedEntityDefFieldAttributes
     , parsedEntityDefExtras
-    , parsedEntityDefSourceSpan
+    , parsedEntityDefSpan
     , parseSource
     , memberBlockAttrs
     ) where
@@ -282,7 +282,7 @@ data ParsedEntityDef = ParsedEntityDef
     , parsedEntityDefEntityAttributes :: [Attr]
     , parsedEntityDefFieldAttributes :: [([Token], Maybe Text)]
     , parsedEntityDefExtras :: M.Map Text [ExtraLine]
-    , parsedEntityDefSourceSpan :: Maybe SourceSpan
+    , parsedEntityDefSpan :: Maybe SourceSpan
     }
     deriving (Show)
 
@@ -478,7 +478,7 @@ toParsedEntityDef mSourceLoc eb =
         , parsedEntityDefEntityAttributes = entityAttributes
         , parsedEntityDefFieldAttributes = parsedFieldAttributes
         , parsedEntityDefExtras = extras
-        , parsedEntityDefSourceSpan = mSpan
+        , parsedEntityDefSpan = mSpan
         }
   where
     comments =

--- a/persistent/Database/Persist/Quasi/Internal/ModelParser.hs
+++ b/persistent/Database/Persist/Quasi/Internal/ModelParser.hs
@@ -1,0 +1,512 @@
+{-# LANGUAGE DeriveLift #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections #-}
+
+module Database.Persist.Quasi.Internal.ModelParser
+    ( SourceLoc (..)
+    , Token (..)
+    , tokenContent
+    , anyToken
+    , ParsedEntityDef
+    , parsedEntityDefComments
+    , parsedEntityDefEntityName
+    , parsedEntityDefIsSum
+    , parsedEntityDefEntityAttributes
+    , parsedEntityDefFieldAttributes
+    , parsedEntityDefFieldComments
+    , parsedEntityDefExtras
+    , parsedEntityDefSpan
+    , parseSource
+    , memberBlockAttrs
+    ) where
+
+import Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.List.NonEmpty as NEL
+import qualified Data.Map as M
+import Data.Maybe
+import Data.Text (Text, pack, unlines, unpack)
+import Data.Void
+import Database.Persist.Types
+import Language.Haskell.TH.Syntax (Lift)
+import Replace.Megaparsec (sepCap)
+import Text.Megaparsec hiding (Token)
+import Text.Megaparsec.Char
+import qualified Text.Megaparsec.Char.Lexer as L
+import Prelude hiding (lines, unlines)
+
+type Parser = Parsec Void String
+
+-- | Source location: file and line/col information. This is half of a 'Span'.
+data SourceLoc = SourceLoc
+    { locFile :: Text
+    , locStartLine :: Int
+    , locStartCol :: Int
+    }
+    deriving (Show, Lift)
+
+data Token
+    = DocComment Text
+    | Comment Text
+    | Quotation Text
+    | Equality Text Text
+    | Parenthetical Text
+    | BlockKey Text
+    | PText Text
+    deriving (Eq, Ord, Show)
+
+tokenContent :: Token -> Text
+tokenContent = \case
+    Comment s -> s
+    DocComment s -> s
+    Quotation s -> s
+    Equality l r -> mconcat [l, "=", r]
+    Parenthetical s -> s
+    PText s -> s
+    BlockKey s -> s
+
+spaceConsumer :: Parser ()
+spaceConsumer =
+    L.space
+        hspace1
+        (L.skipLineComment "--")
+        empty
+
+spaceConsumerN :: Parser ()
+spaceConsumerN =
+    L.space
+        space1
+        (L.skipLineComment "--")
+        empty
+
+escapedParen :: Parser Char
+escapedParen =
+    char '\\'
+        *> choice
+            [ char '('
+            , char ')'
+            ]
+
+contentChar :: Parser Char
+contentChar =
+    choice
+        [ alphaNumChar
+        , char '.'
+        , char '['
+        , char ']'
+        , char '_'
+        , char '\''
+        , char '"'
+        , try escapedParen
+        , char '\\'
+        ]
+
+nonLineSpaceChar :: Parser Char
+nonLineSpaceChar = choice [char ' ', char '\t']
+
+-- This is a replacement for `Text.Megaparsec.Char.Lexer.charLiteral`;
+-- it does nearly the same thing but additionally supports escaped parentheses.
+charLiteral :: Parser Char
+charLiteral = label "literal character" $ do
+    r <- lookAhead (count' 1 10 anySingle)
+    case lexChar r of
+        Just (c, r') -> c <$ skipCount (length r - length r') anySingle
+        Nothing -> unexpected (errorTokens r)
+  where
+    errorTokens ts = Tokens $
+        case NEL.nonEmpty ts of
+            Just nel -> NEL.head nel :| []
+            Nothing -> error "unreachable" -- ts is known to be non-empty
+    lexChar "" =
+        Nothing
+    lexChar ('\\' : '(' : rest) =
+        Just ('(', rest)
+    lexChar ('\\' : ')' : rest) =
+        Just (')', rest)
+    lexChar ('\\' : '\\' : rest) =
+        Just ('\\', rest)
+    lexChar ('\\' : '\'' : rest) =
+        Just ('\'', rest)
+    lexChar ('\\' : '\"' : rest) =
+        Just ('\"', rest)
+    lexChar (a : rest) =
+        Just (a, rest)
+
+equality :: Parser Token
+equality = label "equality expression" $ do
+    L.lexeme spaceConsumer $ do
+        lhs <- some contentChar
+        _ <- char '='
+        rhs <-
+            choice
+                [ try quotationInner
+                , try parenthetical'
+                , some $ contentChar <|> char '(' <|> char ')'
+                ]
+        pure $ Equality (pack lhs) (pack rhs)
+  where
+    quotationInner = do
+        str <- quotation'
+        pure $ "\"" <> str <> "\""
+
+quotation :: Parser Token
+quotation = label "quotation" $ do
+    str <- L.lexeme spaceConsumer quotation'
+    pure . Quotation $ pack str
+
+quotation' :: Parser String
+quotation' = char '"' *> manyTill charLiteral (char '"')
+
+parenthetical :: Parser Token
+parenthetical = label "parenthetical" $ do
+    str <- L.lexeme spaceConsumer parenthetical'
+    pure . Parenthetical . pack . init . drop 1 $ str
+
+parenthetical' :: Parser String
+parenthetical' = do
+    str <- between (char '(') (char ')') q
+    pure $ "(" ++ str ++ ")"
+  where
+    q = mconcat <$> some (c <|> parenthetical')
+    c = (: []) <$> choice [contentChar, nonLineSpaceChar, char '"']
+
+blockKey :: Parser Token
+blockKey = label "block key" $ do
+    fl <- upperChar
+    rl <- many alphaNumChar
+    pure . BlockKey . pack $ fl : rl
+
+ptext :: Parser Token
+ptext = label "plain token" $ do
+    str <- L.lexeme spaceConsumer $ some contentChar
+    pure . PText . pack $ str
+
+docComment :: Parser Token
+docComment = label "doc comment" $ do
+    _ <- string "-- |" <* hspace
+    str <- many (contentChar <|> nonLineSpaceChar)
+    pure . DocComment . pack $ str
+
+comment :: Parser Token
+comment = label "comment" $ do
+    _ <- (string "--" <|> string "#") <* hspace
+    str <- many (contentChar <|> nonLineSpaceChar)
+    pure . Comment . pack $ str
+
+anyToken :: Parser Token
+anyToken =
+    choice
+        [ try equality
+        , docComment
+        , comment
+        , quotation
+        , parenthetical
+        , ptext
+        ]
+
+data ParsedEntityDef = ParsedEntityDef
+    { parsedEntityDefComments :: [Text]
+    , parsedEntityDefEntityName :: EntityNameHS
+    , parsedEntityDefIsSum :: Bool
+    , parsedEntityDefEntityAttributes :: [Attr]
+    , parsedEntityDefFieldAttributes :: [[Token]]
+    , parsedEntityDefFieldComments :: [Maybe Text]
+    , parsedEntityDefExtras :: M.Map Text [ExtraLine]
+    , parsedEntityDefSpan :: Maybe Span
+    }
+    deriving (Show)
+
+data DocCommentBlock = DocCommentBlock
+    { docCommentBlockLines :: [Text]
+    , docCommentBlockPos :: SourcePos
+    }
+    deriving (Show)
+
+data EntityHeader = EntityHeader
+    { entityHeaderSum :: Bool
+    , entityHeaderTableName :: Text
+    , entityHeaderRemainingTokens :: [Token]
+    , entityHeaderPos :: SourcePos
+    }
+    deriving (Show)
+
+data EntityBlock = EntityBlock
+    { entityBlockDocCommentBlock :: Maybe DocCommentBlock
+    , entityBlockEntityHeader :: EntityHeader
+    , entityBlockMembers :: [Member]
+    }
+    deriving (Show)
+
+data ExtraBlockHeader = ExtraBlockHeader
+    { extraBlockHeaderKey :: Text
+    , extraBlockHeaderRemainingTokens :: [Token]
+    , extraBlockHeaderPos :: SourcePos
+    }
+    deriving (Show)
+
+data ExtraBlock = ExtraBlock
+    { extraBlockDocCommentBlock :: Maybe DocCommentBlock
+    , extraBlockExtraBlockHeader :: ExtraBlockHeader
+    , extraBlockMembers :: NonEmpty Member
+    }
+    deriving (Show)
+
+data BlockAttr = BlockAttr
+    { blockAttrDocCommentBlock :: Maybe DocCommentBlock
+    , blockAttrTokens :: [Token]
+    , blockAttrPos :: SourcePos
+    }
+    deriving (Show)
+
+data Member = MemberExtraBlock ExtraBlock | MemberBlockAttr BlockAttr
+    deriving (Show)
+
+-- | The source position at the beginning of the block's final line.
+entityBlockEndPos :: EntityBlock -> SourcePos
+entityBlockEndPos eb = case entityBlockMembers eb of
+    [] -> entityBlockHeaderPos eb
+    _ -> maximum $ fmap memberEndPos (entityBlockMembers eb)
+
+entityBlockHeaderPos :: EntityBlock -> SourcePos
+entityBlockHeaderPos = entityHeaderPos . entityBlockEntityHeader
+
+-- | The source position at the beginning of the member's first line.
+memberPos :: Member -> SourcePos
+memberPos (MemberBlockAttr fs) = blockAttrPos fs
+memberPos (MemberExtraBlock ex) = extraBlockHeaderPos . extraBlockExtraBlockHeader $ ex
+
+-- | The source position at the beginning of the member's final line.
+memberEndPos :: Member -> SourcePos
+memberEndPos (MemberBlockAttr fs) = blockAttrPos fs
+memberEndPos (MemberExtraBlock ex) = memberEndPos . NEL.last . extraBlockMembers $ ex
+
+memberBlockAttrs :: Member -> [BlockAttr]
+memberBlockAttrs (MemberBlockAttr fs) = [fs]
+memberBlockAttrs (MemberExtraBlock ex) = foldMap memberBlockAttrs . extraBlockMembers $ ex
+
+entityBlockBlockAttrs :: EntityBlock -> [BlockAttr]
+entityBlockBlockAttrs eb =
+    foldMap f (entityBlockMembers eb)
+  where
+    f = \case
+        MemberBlockAttr fs -> [fs]
+        _ -> []
+
+entityBlockExtraBlocks :: EntityBlock -> [ExtraBlock]
+entityBlockExtraBlocks eb =
+    foldMap f (entityBlockMembers eb)
+  where
+    f = \case
+        MemberExtraBlock ex -> [ex]
+        _ -> []
+
+extraBlocksAsMap :: [ExtraBlock] -> M.Map Text [ExtraLine]
+extraBlocksAsMap exs = M.fromList $ fmap asPair exs
+  where
+    asPair ex =
+        (extraBlockHeaderKey . extraBlockExtraBlockHeader $ ex, extraLines ex)
+    extraLines ex = foldMap asExtraLine (extraBlockMembers ex)
+    asExtraLine (MemberBlockAttr fs) = [tokenContent <$> blockAttrTokens fs]
+    asExtraLine _ = []
+
+entityHeader :: Parser EntityHeader
+entityHeader = do
+    pos <- getSourcePos
+    plus <- optional (char '+')
+    en <- L.lexeme spaceConsumer blockKey
+    rest <- L.lexeme spaceConsumer (many anyToken)
+    pure
+        EntityHeader
+            { entityHeaderSum = isJust plus
+            , entityHeaderTableName = tokenContent en
+            , entityHeaderRemainingTokens = rest
+            , entityHeaderPos = pos
+            }
+
+extraBlock :: Parser Member
+extraBlock = L.indentBlock spaceConsumerN innerParser
+  where
+    mkExtraBlockMember (header, blockAttrs) =
+        MemberExtraBlock
+            ExtraBlock
+                { extraBlockExtraBlockHeader = header
+                , extraBlockMembers = ensureNonEmpty blockAttrs
+                , extraBlockDocCommentBlock = Nothing
+                }
+    ensureNonEmpty members = case NEL.nonEmpty members of
+        Just nel -> nel
+        Nothing -> error "unreachable" -- members is known to be non-empty
+    innerParser = do
+        header <- extraBlockHeader
+        pure $ L.IndentSome Nothing (return . mkExtraBlockMember . (header,)) blockAttr
+
+extraBlockHeader :: Parser ExtraBlockHeader
+extraBlockHeader = do
+    pos <- getSourcePos
+    tn <- L.lexeme spaceConsumer blockKey
+    rest <- L.lexeme spaceConsumer (many anyToken)
+    pure $
+        ExtraBlockHeader
+            { extraBlockHeaderKey = tokenContent tn
+            , extraBlockHeaderRemainingTokens = rest
+            , extraBlockHeaderPos = pos
+            }
+
+blockAttr :: Parser Member
+blockAttr = do
+    pos <- getSourcePos
+    line <- some anyToken
+    pure $
+        MemberBlockAttr
+            BlockAttr
+                { blockAttrDocCommentBlock = Nothing
+                , blockAttrTokens = line
+                , blockAttrPos = pos
+                }
+
+member :: Parser Member
+member = try extraBlock <|> blockAttr
+
+entityBlock :: Parser EntityBlock
+entityBlock = L.indentBlock spaceConsumerN innerParser
+  where
+    mkEntityBlock (header, members) =
+        EntityBlock
+            { entityBlockEntityHeader = header
+            , entityBlockMembers = members
+            , entityBlockDocCommentBlock = Nothing
+            }
+    innerParser = do
+        header <- entityHeader
+        pure $ L.IndentMany Nothing (return . mkEntityBlock . (header,)) member
+
+entitiesFromDocument :: Parser [EntityBlock]
+entitiesFromDocument = many entityBlock
+
+docCommentBlock :: Parser DocCommentBlock
+docCommentBlock = do
+    pos <- getSourcePos
+    dc <- hspace *> docComment <* space
+    cb <- many $ hspace *> (docComment <|> comment) <* space
+    pure $
+        DocCommentBlock
+            { docCommentBlockLines = [tokenContent dc] <> map tokenContent cb
+            , docCommentBlockPos = pos
+            }
+
+docCommentsFromDocument :: Parser [DocCommentBlock]
+docCommentsFromDocument =
+    fmap snd . extractFrom <$> findAllDcBlocks
+  where
+    findAllDcBlocks = sepCap (match docCommentBlock)
+    extractFrom = \case
+        [] -> []
+        Right x : xs -> x : extractFrom xs
+        Left _ : xs -> extractFrom xs
+
+docCommentBlockText :: DocCommentBlock -> Text
+docCommentBlockText dcb = unlines $ docCommentBlockLines dcb
+
+associateDocComments :: [DocCommentBlock] -> [EntityBlock] -> [EntityBlock]
+associateDocComments _ [] = []
+associateDocComments [] es = es
+associateDocComments (dc : rest) es = associateDocComments rest (applyDocToBestEntity dc es)
+
+commentIsPositionedFor :: DocCommentBlock -> SourcePos -> Bool
+commentIsPositionedFor dc sp =
+    (sourceLine dcpos < sourceLine sp) && (sourceColumn dcpos <= sourceColumn sp)
+  where
+    dcpos = docCommentBlockPos dc
+
+applyDocToBestEntity :: DocCommentBlock -> [EntityBlock] -> [EntityBlock]
+applyDocToBestEntity _ [] = []
+applyDocToBestEntity dc (e : rest) =
+    if commentIsPositionedFor dc (entityBlockEndPos e)
+        then applyDocToEntity dc e : rest
+        else e : applyDocToBestEntity dc rest
+
+applyDocToEntity :: DocCommentBlock -> EntityBlock -> EntityBlock
+applyDocToEntity dc e =
+    if commentIsPositionedFor dc (entityBlockHeaderPos e)
+        then e{entityBlockDocCommentBlock = Just dc}
+        else e{entityBlockMembers = applyDocToBestMember dc (entityBlockMembers e)}
+
+applyDocToBestMember :: DocCommentBlock -> [Member] -> [Member]
+applyDocToBestMember _ [] = []
+applyDocToBestMember dc (m : rest) =
+    if commentIsPositionedFor dc (memberPos m)
+        then applyDocToMember dc m : rest
+        else m : applyDocToBestMember dc rest
+
+applyDocToMember :: DocCommentBlock -> Member -> Member
+applyDocToMember dc (MemberBlockAttr fs) = MemberBlockAttr fs{blockAttrDocCommentBlock = Just dc}
+applyDocToMember dc (MemberExtraBlock ex) =
+    if commentIsPositionedFor
+        dc
+        (extraBlockHeaderPos . extraBlockExtraBlockHeader $ ex)
+        then MemberExtraBlock ex{extraBlockDocCommentBlock = Just dc}
+        else MemberExtraBlock ex{extraBlockMembers = appliedNel}
+  where
+    appliedList = applyDocToBestMember dc $ NEL.toList (extraBlockMembers ex)
+    appliedNel = case appliedList of
+        a : rest -> a :| rest
+        [] -> error "unreachable" -- appliedList is known to be non-empty
+
+parseEntities
+    :: Text -> String -> Either (ParseErrorBundle String Void) [EntityBlock]
+parseEntities fp s = do
+    entities <- runParser entitiesFromDocument (unpack fp) s
+    docComments <- runParser docCommentsFromDocument (unpack fp) s
+    pure $ associateDocComments docComments entities
+
+toParsedEntityDef :: Maybe SourceLoc -> EntityBlock -> ParsedEntityDef
+toParsedEntityDef mSourceLoc eb =
+    ParsedEntityDef
+        { parsedEntityDefComments = comments
+        , parsedEntityDefEntityName = entityNameHS
+        , parsedEntityDefIsSum = isSum
+        , parsedEntityDefEntityAttributes = entityAttributes
+        , parsedEntityDefFieldAttributes = parsedFieldAttributes
+        , parsedEntityDefFieldComments = parsedFieldComments
+        , parsedEntityDefExtras = extras
+        , parsedEntityDefSpan = mSpan
+        }
+  where
+    comments =
+        maybe
+            []
+            docCommentBlockLines
+            (entityBlockDocCommentBlock eb)
+    entityAttributes =
+        tokenContent <$> (entityHeaderRemainingTokens . entityBlockEntityHeader) eb
+    isSum = entityHeaderSum . entityBlockEntityHeader $ eb
+    entityNameHS = EntityNameHS . entityHeaderTableName . entityBlockEntityHeader $ eb
+
+    parsedFieldAttributes = fmap blockAttrTokens (entityBlockBlockAttrs eb)
+    parsedFieldComments =
+        fmap docCommentBlockText
+            <$> fmap blockAttrDocCommentBlock (entityBlockBlockAttrs eb)
+
+    extras = extraBlocksAsMap (entityBlockExtraBlocks eb)
+    filepath = maybe "" locFile mSourceLoc
+    relativeStartLine = maybe 0 locStartLine mSourceLoc
+    relativeStartCol = maybe 0 locStartCol mSourceLoc
+    mSpan =
+        Just
+            Span
+                { spanFile = filepath
+                , spanStartLine =
+                    relativeStartLine + (unPos . sourceLine $ entityBlockHeaderPos eb)
+                , spanEndLine = relativeStartLine + (unPos . sourceLine $ entityBlockEndPos eb)
+                , spanStartCol =
+                    relativeStartCol + (unPos . sourceColumn $ entityBlockHeaderPos eb)
+                , spanEndCol = unPos . sourceColumn $ entityBlockEndPos eb
+                }
+
+parseSource :: Maybe SourceLoc -> Text -> [ParsedEntityDef]
+parseSource mSourceLoc source =
+    case parseEntities filepath (unpack source) of
+        Right blocks -> toParsedEntityDef mSourceLoc <$> blocks
+        Left peb -> error $ errorBundlePretty peb
+  where
+    filepath = maybe "" locFile mSourceLoc

--- a/persistent/Database/Persist/TH/Internal.hs
+++ b/persistent/Database/Persist/TH/Internal.hs
@@ -280,7 +280,7 @@ embedEntityDefsMap existingEnts rawEnts =
 -- In 2.13.0.0, this was changed to splice in @['UnboundEntityDef']@
 -- instead of @['EntityDef']@.
 --
--- @since 2.5.3
+-- @since 2.16.0.0
 parseReferences :: PersistSettings -> [(Maybe SourceLoc, Text)] -> Q Exp
 parseReferences ps s = do
   let cpr = parse ps s

--- a/persistent/Database/Persist/TH/Internal.hs
+++ b/persistent/Database/Persist/TH/Internal.hs
@@ -284,9 +284,9 @@ embedEntityDefsMap existingEnts rawEnts =
 parseReferences :: PersistSettings -> [(Maybe SourceLoc, Text)] -> Q Exp
 parseReferences ps s = do
   let cpr = parse ps s
-  case renderErrors cpr of
-    Nothing -> lift $ cumulativeData cpr
-    Just errorMessage -> fail errorMessage
+  case cpr of
+    Left errs -> fail $ renderErrors errs
+    Right res -> lift res
 
 preprocessUnboundDefs
     :: [EntityDef]

--- a/persistent/Database/Persist/TH/Internal.hs
+++ b/persistent/Database/Persist/TH/Internal.hs
@@ -1057,9 +1057,7 @@ fixEntityDef ued =
             filter isHaskellUnboundField (unboundEntityFields ued)
         }
 
--- | Settings that can be passed to the 'mkPersist' (mps) function to control what code is generated.
--- This is (just) the data type definition, so you will most likely want to use and adapt concrete values
--- like 'sqlSettings'.
+-- | Settings to be passed to the 'mkPersist' function.
 data MkPersistSettings = MkPersistSettings
     { mpsBackend :: Type
     -- ^ Which database backend we\'re using. This type is used for the
@@ -1085,63 +1083,15 @@ data MkPersistSettings = MkPersistSettings
     , mpsPrefixFields :: Bool
     -- ^ Prefix field names with the model name. Default: True.
     --
-    -- Note: this field is deprecated. Use the 'mpsFieldLabelModifier'  and
+    -- Note: this field is deprecated. Use the mpsFieldLabelModifier  and
     -- 'mpsConstraintLabelModifier' instead.
     , mpsFieldLabelModifier :: Text -> Text -> Text
-    -- ^ Customise the field names (and lens names) for generated entity data types.
+    -- ^ Customise the field accessors and lens names using the entity and field
+    -- name.  Both arguments are upper cased.
     --
-    -- Default: appends entity name and field name, equivalent to
+    -- Default: appends entity and field.
     --
-    -- @
-    -- mpsFieldLabelModifier = \\entityName fieldName -> entityName <> fieldName
-    -- @
-    --
-    -- to avoid duplicate record field collisions.
-    --
-    -- For example, with default 'sqlSettings' and
-    --
-    -- @
-    -- 'mkPersistWith' 'sqlSettings' [] ['persistLowerCase'|
-    --     Person
-    --         name   Text
-    --         age    Int
-    -- |]
-    -- @
-    --
-    -- it will generate the entity data type
-    --
-    -- @
-    -- Person {
-    --     personName :: Text,  -- generated field name
-    --     personAge  :: Int    -- generated field name
-    -- }
-    -- @
-    --
-    -- Note: this setting is ignored if the deprecated 'mpsPrefixFields' is set to False.
-    --
-    -- === __Example without entity name__
-    --
-    -- You may not want the entity name prefix for all fields, so use
-    --
-    -- @
-    -- 'mkPersistWith' ('sqlSettings' { mpsFieldLabelModifier = \\\_entityName fieldName -> fieldName }) [] ['persistLowerCase'|
-    --     Person
-    --         name   Text
-    --         age    Int
-    -- |]
-    -- @
-    --
-    -- instead. This will generate the entity data type
-    --
-    -- @
-    -- Person {
-    --     name :: Text,
-    --     age  :: Int
-    -- }
-    -- @
-    --
-    -- When you have multiple entites with the same field name, you might need to
-    -- add @{-# LANGUAGE DuplicateRecordFields #-}@ for your code to compile.
+    -- Note: this setting is ignored if mpsPrefixFields is set to False.
     --
     -- @since 2.11.0.0
     , mpsAvoidHsKeyword :: Text -> Text
@@ -1156,7 +1106,7 @@ data MkPersistSettings = MkPersistSettings
     --
     -- Default: appends entity and field
     --
-    -- Note: this setting is ignored if the deprecated 'mpsPrefixFields' is set to False.
+    -- Note: this setting is ignored if mpsPrefixFields is set to False.
     --
     -- @since 2.11.0.0
     , mpsEntityHaddocks :: Bool

--- a/persistent/Database/Persist/TH/Internal.hs
+++ b/persistent/Database/Persist/TH/Internal.hs
@@ -1057,7 +1057,9 @@ fixEntityDef ued =
             filter isHaskellUnboundField (unboundEntityFields ued)
         }
 
--- | Settings to be passed to the 'mkPersist' function.
+-- | Settings that can be passed to the 'mkPersist' (mps) function to control what code is generated.
+-- This is (just) the data type definition, so you will most likely want to use and adapt concrete values
+-- like 'sqlSettings'.
 data MkPersistSettings = MkPersistSettings
     { mpsBackend :: Type
     -- ^ Which database backend we\'re using. This type is used for the
@@ -1083,15 +1085,63 @@ data MkPersistSettings = MkPersistSettings
     , mpsPrefixFields :: Bool
     -- ^ Prefix field names with the model name. Default: True.
     --
-    -- Note: this field is deprecated. Use the mpsFieldLabelModifier  and
+    -- Note: this field is deprecated. Use the 'mpsFieldLabelModifier'  and
     -- 'mpsConstraintLabelModifier' instead.
     , mpsFieldLabelModifier :: Text -> Text -> Text
-    -- ^ Customise the field accessors and lens names using the entity and field
-    -- name.  Both arguments are upper cased.
+    -- ^ Customise the field names (and lens names) for generated entity data types.
     --
-    -- Default: appends entity and field.
+    -- Default: appends entity name and field name, equivalent to
     --
-    -- Note: this setting is ignored if mpsPrefixFields is set to False.
+    -- @
+    -- mpsFieldLabelModifier = \\entityName fieldName -> entityName <> fieldName
+    -- @
+    --
+    -- to avoid duplicate record field collisions.
+    --
+    -- For example, with default 'sqlSettings' and
+    --
+    -- @
+    -- 'mkPersistWith' 'sqlSettings' [] ['persistLowerCase'|
+    --     Person
+    --         name   Text
+    --         age    Int
+    -- |]
+    -- @
+    --
+    -- it will generate the entity data type
+    --
+    -- @
+    -- Person {
+    --     personName :: Text,  -- generated field name
+    --     personAge  :: Int    -- generated field name
+    -- }
+    -- @
+    --
+    -- Note: this setting is ignored if the deprecated 'mpsPrefixFields' is set to False.
+    --
+    -- === __Example without entity name__
+    --
+    -- You may not want the entity name prefix for all fields, so use
+    --
+    -- @
+    -- 'mkPersistWith' ('sqlSettings' { mpsFieldLabelModifier = \\\_entityName fieldName -> fieldName }) [] ['persistLowerCase'|
+    --     Person
+    --         name   Text
+    --         age    Int
+    -- |]
+    -- @
+    --
+    -- instead. This will generate the entity data type
+    --
+    -- @
+    -- Person {
+    --     name :: Text,
+    --     age  :: Int
+    -- }
+    -- @
+    --
+    -- When you have multiple entites with the same field name, you might need to
+    -- add @{-# LANGUAGE DuplicateRecordFields #-}@ for your code to compile.
     --
     -- @since 2.11.0.0
     , mpsAvoidHsKeyword :: Text -> Text
@@ -1106,7 +1156,7 @@ data MkPersistSettings = MkPersistSettings
     --
     -- Default: appends entity and field
     --
-    -- Note: this setting is ignored if mpsPrefixFields is set to False.
+    -- Note: this setting is ignored if the deprecated 'mpsPrefixFields' is set to False.
     --
     -- @since 2.11.0.0
     , mpsEntityHaddocks :: Bool

--- a/persistent/Database/Persist/TH/Internal.hs
+++ b/persistent/Database/Persist/TH/Internal.hs
@@ -282,7 +282,11 @@ embedEntityDefsMap existingEnts rawEnts =
 --
 -- @since 2.5.3
 parseReferences :: PersistSettings -> [(Maybe SourceLoc, Text)] -> Q Exp
-parseReferences ps s = lift $ parse ps s
+parseReferences ps s = do
+  let cpr = parse ps s
+  case renderErrors cpr of
+    Nothing -> lift $ cumulativeData cpr
+    Just errorMessage -> fail errorMessage
 
 preprocessUnboundDefs
     :: [EntityDef]

--- a/persistent/Database/Persist/Types.hs
+++ b/persistent/Database/Persist/Types.hs
@@ -69,7 +69,6 @@ import Database.Persist.Types.Base
        , PersistValue(..)
        , ReferenceDef(..)
        , SqlType(..)
-       , Span(..)
        , UniqueDef(..)
        , UpdateException(..)
        , WhyNullable(..)

--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -157,14 +157,14 @@ data EntityDef = EntityDef
     -- ^ Optional comments on the entity.
     --
     -- @since 2.10.0
-    , entitySourceSpan :: !(Maybe SourceSpan)
+    , entitySpan :: !(Maybe SourceSpan)
     -- ^ Source code span occupied by this entity. May be absent if it is not
     -- known.
     --
     -- Note that until a refactor is completed, these cover the entire
     -- persistent parser input rather than the particular entity in question.
     --
-    -- @since 2.16.0.0
+    -- @since 2.15.0.0
     }
     deriving (Show, Eq, Read, Ord, Lift)
 

--- a/persistent/Database/Persist/Types/Base.hs
+++ b/persistent/Database/Persist/Types/Base.hs
@@ -13,7 +13,7 @@ module Database.Persist.Types.Base
     , PersistValue(..)
     , fromPersistValueText
     , LiteralType(..)
-    , Span(..)
+    , SourceSpan(..)
     ) where
 
 import Control.Exception (Exception)
@@ -39,7 +39,7 @@ import Instances.TH.Lift ()
 
 import Database.Persist.Names
 import Database.Persist.PersistValue
-import Database.Persist.Types.Span (Span(..))
+import Database.Persist.Types.SourceSpan (SourceSpan(..))
 
 -- | A 'Checkmark' should be used as a field type whenever a
 -- uniqueness constraint should guarantee that a certain kind of
@@ -157,14 +157,14 @@ data EntityDef = EntityDef
     -- ^ Optional comments on the entity.
     --
     -- @since 2.10.0
-    , entitySpan :: !(Maybe Span)
+    , entitySourceSpan :: !(Maybe SourceSpan)
     -- ^ Source code span occupied by this entity. May be absent if it is not
     -- known.
     --
     -- Note that until a refactor is completed, these cover the entire
     -- persistent parser input rather than the particular entity in question.
     --
-    -- @since 2.15.0.0
+    -- @since 2.16.0.0
     }
     deriving (Show, Eq, Read, Ord, Lift)
 

--- a/persistent/Database/Persist/Types/SourceSpan.hs
+++ b/persistent/Database/Persist/Types/SourceSpan.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DeriveLift #-}
 
-module Database.Persist.Types.Span (Span (..)) where
+module Database.Persist.Types.SourceSpan (SourceSpan (..)) where
 
 import Data.Text (Text)
 import Language.Haskell.TH.Syntax (Lift)
@@ -9,12 +9,12 @@ import Language.Haskell.TH.Syntax (Lift)
 -- be one past the final character (i.e. the span (1,1)->(1,1) is zero
 -- characters long).
 --
--- Spans are 1-indexed in both lines and columns.
+-- SourceSpans are 1-indexed in both lines and columns.
 --
 -- Conceptually identical to GHC's @RealSourceSpan@.
 --
--- @since 2.15.0.0
-data Span = Span
+-- @since 2.16.0.0
+data SourceSpan = SourceSpan
     { spanFile :: !Text
     , spanStartLine :: !Int
     , spanStartCol :: !Int

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -99,7 +99,7 @@ library
     Database.Persist.TH
     Database.Persist.TH.Internal
     Database.Persist.Types
-    Database.Persist.Types.Span
+    Database.Persist.Types.SourceSpan
 
   other-modules:
     Database.Persist.Sql.Class

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -36,9 +36,11 @@ library
     , fast-logger           >=2.4
     , http-api-data         >=0.3
     , lift-type             >=0.1.0.0  && <0.2.0.0
+    , megaparsec
     , monad-logger          >=0.3.28
     , mtl
     , path-pieces           >=0.2
+    , replace-megaparsec
     , resource-pool         >=0.2.3
     , resourcet             >=1.1.10
     , scientific
@@ -79,6 +81,7 @@ library
     Database.Persist.PersistValue
     Database.Persist.Quasi
     Database.Persist.Quasi.Internal
+    Database.Persist.Quasi.Internal.ModelParser
     Database.Persist.Sql
     Database.Persist.Sql.Migration
     Database.Persist.Sql.Types.Internal
@@ -135,6 +138,7 @@ test-suite test
     , fast-logger
     , hspec                 >=2.4
     , http-api-data
+    , megaparsec
     , monad-logger
     , mtl
     , path-pieces

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:               persistent
-version:            2.15.1.0
+version:            2.16.0.0
 license:            MIT
 license-file:       LICENSE
 author:             Michael Snoyman <michael@snoyman.com>

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -99,6 +99,7 @@ library
     Database.Persist.TH
     Database.Persist.TH.Internal
     Database.Persist.Types
+    Database.Persist.Types.Span
 
   other-modules:
     Database.Persist.Sql.Class
@@ -110,7 +111,6 @@ library
     Database.Persist.Sql.Run
     Database.Persist.Sql.Types
     Database.Persist.Types.Base
-    Database.Persist.Types.Span
 
   -- These modules only make sense for compilers with access to DerivingVia
   if impl(ghc >=8.6.1)

--- a/persistent/test/Database/Persist/QuasiSpec.hs
+++ b/persistent/test/Database/Persist/QuasiSpec.hs
@@ -130,6 +130,14 @@ spec = describe "Quasi" $ do
                     ( "1:9:\n  |\n1 | \"foo bar\n  |         ^\nunexpected end of input\nexpecting '\"' or literal character\n"
                     )
 
+        it "handles commas in tokens" $
+            tokenize "x=COALESCE(left,right)  \"baz\""
+                `shouldBe` Right
+                    ( [ Equality "x" "COALESCE(left,right)"
+                      , Quotation "baz"
+                      ]
+                    )
+
         it "handles quotes mid-token" $
             tokenize "x=\"foo bar\"  \"baz\""
                 `shouldBe` Right
@@ -138,7 +146,7 @@ spec = describe "Quasi" $ do
                       ]
                     )
 
-        it "handles escaped quote mid-token" $
+        it "handles escaped quotes mid-token" $
             tokenize "x=\\\"foo bar\"  \"baz\""
                 `shouldBe` Right
                     ( [ Equality "x" "\\\"foo"
@@ -404,7 +412,7 @@ User
             let
                 [user] = defs definitions
             evaluate (unboundEntityDef user)
-                `shouldErrorWithMessage` "4:20:\n  |\n4 |     age  (Maybe Int\n  |                    ^\nunexpected newline\nexpecting '!', '\"', ''', '(', ')', '-', '.', ':', '[', '\\', ']', '_', '~', alphanumeric character, end of input, space, or tab\n"
+                `shouldErrorWithMessage` "4:20:\n  |\n4 |     age  (Maybe Int\n  |                    ^\nunexpected newline\nexpecting '!', '\"', ''', '(', ')', ',', '-', '.', ':', '[', '\\', ']', '_', '~', alphanumeric character, end of input, space, or tab\n"
 
         it "errors on duplicate cascade update declarations" $ do
             let

--- a/persistent/test/Database/Persist/QuasiSpec.hs
+++ b/persistent/test/Database/Persist/QuasiSpec.hs
@@ -17,14 +17,12 @@ import qualified Data.Text as T
 import Database.Persist.EntityDef.Internal
 import Database.Persist.Quasi
 import Database.Persist.Quasi.Internal
+import Database.Persist.Quasi.Internal.ModelParser
 import Database.Persist.Types
 import Test.Hspec
 import Test.Hspec.QuickCheck
 import Test.QuickCheck
 import Text.Shakespeare.Text (st)
-
-import Database.Persist.Quasi.Internal
-import Database.Persist.Quasi.Internal.ModelParser
 import Text.Megaparsec (errorBundlePretty, runParser, some)
 
 defs :: T.Text -> [UnboundEntityDef]
@@ -36,8 +34,8 @@ defs t = case renderErrors cpr of
 
 defsSnake :: T.Text -> [UnboundEntityDef]
 defsSnake t = case renderErrors cpr of
-  Nothing -> cumulativeData cpr
-  Just msg -> error msg
+    Nothing -> cumulativeData cpr
+    Just msg -> error msg
   where
     cpr = parse (setPsUseSnakeCaseForeignKeys lowerCaseSettings) [(Nothing, t)]
 
@@ -94,7 +92,9 @@ spec = describe "Quasi" $ do
 
     describe "tokenization" $ do
         let
-            tokenize = runParser (some anyToken) ""
+            tokenize s = do
+                (d, c) <- runConfiguredParser [] (some anyToken) "" s
+                pure d
         it "handles normal words" $
             tokenize "foo   bar  baz"
                 `shouldBe` Right
@@ -256,32 +256,6 @@ spec = describe "Quasi" $ do
                       ]
                     )
 
-        it "recognizes pipe comments" $
-            tokenize "-- | this is a comment"
-                `shouldBe` Right
-                    ( [ DocComment "this is a comment"
-                      ]
-                    )
-
-        it "recognizes empty pipe comments" $
-            tokenize "-- |"
-                `shouldBe` Right
-                    ( [ DocComment ""
-                      ]
-                    )
-        it "recognizes non-pipe comments" $
-            tokenize "-- this is a comment"
-                `shouldBe` Right
-                    ( [ Comment "this is a comment"
-                      ]
-                    )
-        it "recognizes empty non-pipe comments" $
-            tokenize "-- "
-                `shouldBe` Right
-                    ( [ Comment ""
-                      ]
-                    )
-
     describe "parse" $ do
         let
             subject =
@@ -341,12 +315,12 @@ Car
 
         it "should parse the `entityUniques` field" $ do
             let
-                simplifyUnique unique =
-                    (uniqueHaskell unique, uniqueFields unique)
+              simplifyUnique unique =
+                (uniqueHaskell unique, uniqueFields unique)
             (simplifyUnique <$> entityUniques (unboundEntityDef bicycle)) `shouldBe` []
             (simplifyUnique <$> entityUniques (unboundEntityDef car))
-                `shouldBe` [ (ConstraintNameHS "UniqueModel", [(FieldNameHS "model", FieldNameDB "model")])
-                           ]
+              `shouldBe` [ (ConstraintNameHS "UniqueModel", [(FieldNameHS "model", FieldNameDB "model")])
+                         ]
             (simplifyUnique <$> entityUniques (unboundEntityDef vehicle)) `shouldBe` []
 
         it "should parse the `entityForeigns` field" $ do
@@ -408,12 +382,6 @@ Notification
             entityComments (unboundEntityDef bicycle) `shouldBe` Nothing
             entityComments (unboundEntityDef car) `shouldBe` Just "This is a Car\n"
             entityComments (unboundEntityDef vehicle) `shouldBe` Nothing
-
-        it "treats tabs as spaces" $ do
-          let
-            str = T.pack "User\n\tId Text\n\tname Text\n\tage Int"
-            [user] = defs str
-          getUnboundEntityNameHS user `shouldBe` EntityNameHS "User"
 
         it "should error on malformed input, unterminated parens" $ do
             let
@@ -640,10 +608,11 @@ Notification
                 let
                     flippedFK (EntityNameHS entName) (ConstraintNameHS conName) =
                         conName <> entName
-                    cpr = parse (setPsToFKName flippedFK lowerCaseSettings) [(Nothing, validDefinitions)]
+                    cpr =
+                        parse (setPsToFKName flippedFK lowerCaseSettings) [(Nothing, validDefinitions)]
                     [_user, notification] = case renderErrors cpr of
-                      Nothing -> cumulativeData cpr
-                      Just msg -> error msg
+                        Nothing -> cumulativeData cpr
+                        Just msg -> error msg
                     [notificationForeignDef] =
                         unboundForeignDef <$> unboundForeignDefs notification
                 foreignConstraintNameDBName notificationForeignDef
@@ -716,10 +685,11 @@ Notification
                     `shouldErrorWithMessage` "invalid foreign key constraint on table[\"Notification\"] Found 2 foreign fields but 1 parent fields"
 
             it
-                "should throw error when there is more than one delete cascade on the declaration" $ do
-                let
-                    definitions =
-                        [st|
+                "should throw error when there is more than one delete cascade on the declaration"
+                $ do
+                    let
+                        definitions =
+                            [st|
 User
     name            Text
     emailFirst      Text
@@ -733,16 +703,17 @@ Notification
     sentToSecond    Text
     Foreign User OnDeleteCascade OnDeleteCascade
 |]
-                let
-                    [_user, notification] = defsSnake definitions
-                mapM (evaluate . unboundForeignFields) (unboundForeignDefs notification)
-                    `shouldErrorWithMessage` "invalid foreign key constraint on table[\"Notification\"] found more than one OnDelete actions"
+                    let
+                        [_user, notification] = defsSnake definitions
+                    mapM (evaluate . unboundForeignFields) (unboundForeignDefs notification)
+                        `shouldErrorWithMessage` "invalid foreign key constraint on table[\"Notification\"] found more than one OnDelete actions"
 
             it
-                "should throw error when there is more than one update cascade on the declaration" $ do
-                let
-                    definitions =
-                        [st|
+                "should throw error when there is more than one update cascade on the declaration"
+                $ do
+                    let
+                        definitions =
+                            [st|
 User
     name            Text
     emailFirst      Text
@@ -756,20 +727,21 @@ Notification
     sentToSecond    Text
     Foreign User OnUpdateCascade OnUpdateCascade
 |]
-                let
-                    [_user, notification] = defsSnake definitions
-                mapM (evaluate . unboundForeignFields) (unboundForeignDefs notification)
-                    `shouldErrorWithMessage` "invalid foreign key constraint on table[\"Notification\"] found more than one OnUpdate actions"
+                    let
+                        [_user, notification] = defsSnake definitions
+                    mapM (evaluate . unboundForeignFields) (unboundForeignDefs notification)
+                        `shouldErrorWithMessage` "invalid foreign key constraint on table[\"Notification\"] found more than one OnUpdate actions"
 
             it
-                "should allow you to enable snake cased foriegn keys via a preset configuration function" $ do
-                let
-                    [_user, notification] =
-                        defsSnake validDefinitions
-                    [notificationForeignDef] =
-                        unboundForeignDef <$> unboundForeignDefs notification
-                foreignConstraintNameDBName notificationForeignDef
-                    `shouldBe` ConstraintNameDB "notification_fk_noti_user"
+                "should allow you to enable snake cased foriegn keys via a preset configuration function"
+                $ do
+                    let
+                        [_user, notification] =
+                            defsSnake validDefinitions
+                        [notificationForeignDef] =
+                            unboundForeignDef <$> unboundForeignDefs notification
+                    foreignConstraintNameDBName notificationForeignDef
+                        `shouldBe` ConstraintNameDB "notification_fk_noti_user"
 
         describe "ticked types" $ do
             it "should be able to parse ticked types" $ do

--- a/persistent/test/Database/Persist/QuasiSpec.hs
+++ b/persistent/test/Database/Persist/QuasiSpec.hs
@@ -115,6 +115,20 @@ spec = describe "Quasi" $ do
                         ]
                     )
 
+        it "handles SQL literals with no specified type" $
+          tokenize "attr='[\"ab\\'cd\", 1, 2]'" `shouldBe`
+              Right
+                  (
+                    [Equality "attr" "'[\"ab'cd\", 1, 2]'"]
+                  )
+
+        it "handles SQL literals with a specified type" $
+          tokenize "attr='{\"\\'a\\'\": [1, 2.2, \"\\'3\\'\"]}'::type_name" `shouldBe`
+              Right
+                  (
+                    [Equality "attr" "'{\"'a'\": [1, 2.2, \"'3'\"]}'::type_name"]
+                  )
+
         it "should error if quotes are unterminated" $ do
             first errorBundlePretty (tokenize "\"foo bar") `shouldBe`
               Left("1:9:\n  |\n1 | \"foo bar\n  |         ^\nunexpected end of input\nexpecting '\"' or literal character\n")
@@ -401,7 +415,7 @@ User
             let [user] = defs definitions
             evaluate (unboundEntityDef user)
                 `shouldErrorWithMessage`
-                    "4:20:\n  |\n4 |     age  (Maybe Int\n  |                    ^\nunexpected newline\nexpecting '!', '\"', ''', '(', ')', '.', '[', '\\', ']', '_', '~', alphanumeric character, space, or tab\n"
+                    "4:20:\n  |\n4 |     age  (Maybe Int\n  |                    ^\nunexpected newline\nexpecting '!', '\"', ''', '(', ')', '-', '.', ':', '[', '\\', ']', '_', '~', alphanumeric character, space, or tab\n"
 
         it "errors on duplicate cascade update declarations" $ do
             let definitions = [st|

--- a/persistent/test/Database/Persist/QuasiSpec.hs
+++ b/persistent/test/Database/Persist/QuasiSpec.hs
@@ -93,7 +93,7 @@ spec = describe "Quasi" $ do
     describe "tokenization" $ do
         let
             tokenize s = do
-                (d, c) <- runConfiguredParser [] (some anyToken) "" s
+                (d, c) <- runConfiguredParser initialExtraState (some anyToken) "" s
                 pure d
         it "handles normal words" $
             tokenize "foo   bar  baz"

--- a/persistent/test/Database/Persist/QuasiSpec.hs
+++ b/persistent/test/Database/Persist/QuasiSpec.hs
@@ -342,6 +342,8 @@ User
     name            Text
     emailFirst      Text
     emailSecond     Text
+    !yes            Int
+    ~no             Int
 
     UniqueEmail emailFirst emailSecond
 
@@ -399,7 +401,7 @@ User
             let [user] = defs definitions
             evaluate (unboundEntityDef user)
                 `shouldErrorWithMessage`
-                    "4:20:\n  |\n4 |     age  (Maybe Int\n  |                    ^\nunexpected newline\nexpecting '\"', ''', '(', ')', '.', '[', '\\', ']', '_', alphanumeric character, space, or tab\n"
+                    "4:20:\n  |\n4 |     age  (Maybe Int\n  |                    ^\nunexpected newline\nexpecting '!', '\"', ''', '(', ')', '.', '[', '\\', ']', '_', '~', alphanumeric character, space, or tab\n"
 
         it "errors on duplicate cascade update declarations" $ do
             let definitions = [st|

--- a/persistent/test/Database/Persist/QuasiSpec.hs
+++ b/persistent/test/Database/Persist/QuasiSpec.hs
@@ -420,7 +420,7 @@ User
             let
                 [user] = defs definitions
             evaluate (unboundEntityDef user)
-                `shouldErrorWithMessage` "4:20:\n  |\n4 |     age  (Maybe Int\n  |                    ^\nunexpected newline\nexpecting '!', '\"', ''', '(', ')', ',', '-', '.', ':', '[', '\\', ']', '_', '~', alphanumeric character, end of input, space, or tab\n"
+                `shouldErrorWithMessage` "4:20:\n  |\n4 |     age  (Maybe Int\n  |                    ^\nunexpected newline\nexpecting '!', '\"', ''', '(', ')', ',', '-', '.', ':', '[', '\\', ']', '_', '~', alphanumeric character, space, or tab\n"
 
         it "errors on duplicate cascade update declarations" $ do
             let

--- a/persistent/test/Database/Persist/QuasiSpec.hs
+++ b/persistent/test/Database/Persist/QuasiSpec.hs
@@ -137,7 +137,7 @@ spec = describe "Quasi" $ do
             tokenize "x=\"foo bar\"  \"baz\"" `shouldBe`
                 Right
                     (
-                        [ Equality "x" "\"foo bar\""
+                        [ Equality "x" "foo bar"
                         , Quotation "baz"
                         ]
                     )
@@ -165,7 +165,7 @@ spec = describe "Quasi" $ do
             tokenize "x=(foo bar)  (baz)" `shouldBe`
                 Right
                     (
-                        [ Equality "x" "(foo bar)"
+                        [ Equality "x" "foo bar"
                         , Parenthetical "baz"
                         ]
                     )
@@ -201,7 +201,7 @@ spec = describe "Quasi" $ do
             tokenize "y=\"baz\\\"\"" `shouldBe`
                 Right
                     (
-                        [ Equality "y" "\"baz\"\""
+                        [ Equality "y" "baz\""
                         ]
                     )
 
@@ -253,7 +253,7 @@ spec = describe "Quasi" $ do
                     (
                         [ PText "foo"
                         , PText "bar"
-                        , Equality "baz" "(bin\")"
+                        , Equality "baz" "bin\""
                         ]
                     )
 

--- a/persistent/test/Database/Persist/QuasiSpec.hs
+++ b/persistent/test/Database/Persist/QuasiSpec.hs
@@ -10,7 +10,7 @@ import Prelude hiding (lines)
 import Control.Exception
 import Data.Bifunctor
 import Data.List hiding (lines)
-import Data.List.NonEmpty (NonEmpty(..), (<|))
+import Data.List.NonEmpty (NonEmpty (..), (<|))
 import qualified Data.List.NonEmpty as NEL
 import qualified Data.Map as Map
 import qualified Data.Text as T
@@ -25,7 +25,7 @@ import Text.Shakespeare.Text (st)
 
 import Database.Persist.Quasi.Internal
 import Database.Persist.Quasi.Internal.ModelParser
-import Text.Megaparsec (runParser, some, errorBundlePretty)
+import Text.Megaparsec (errorBundlePretty, runParser, some)
 
 defs :: T.Text -> [UnboundEntityDef]
 defs t = parse lowerCaseSettings [(Nothing, t)]
@@ -33,22 +33,21 @@ defs t = parse lowerCaseSettings [(Nothing, t)]
 defsSnake :: T.Text -> [UnboundEntityDef]
 defsSnake t = parse (setPsUseSnakeCaseForeignKeys lowerCaseSettings) [(Nothing, t)]
 
-
 spec :: Spec
 spec = describe "Quasi" $ do
     describe "takeColsEx" $ do
-        let subject = takeColsEx upperCaseSettings
+        let
+            subject = takeColsEx upperCaseSettings
         it "fails on a single word" $ do
             subject ["asdf"]
-                `shouldBe`
-                    Nothing
+                `shouldBe` Nothing
         it "errors on invalid input" $ do
             evaluate (subject ["name", "int"])
-              `shouldErrorWithMessage` "Invalid field type \"int\" PSFail \"int\""
+                `shouldErrorWithMessage` "Invalid field type \"int\" PSFail \"int\""
         it "works if it has a name and a type" $ do
             subject ["asdf", "Int"]
-                `shouldBe`
-                    Just UnboundFieldDef
+                `shouldBe` Just
+                    UnboundFieldDef
                         { unboundFieldNameHS = FieldNameHS "asdf"
                         , unboundFieldNameDB = FieldNameDB "asdf"
                         , unboundFieldType = FTTypeCon Nothing "Int"
@@ -60,8 +59,8 @@ spec = describe "Quasi" $ do
                         }
         it "works if it has a name, type, and cascade" $ do
             subject ["asdf", "Int", "OnDeleteCascade", "OnUpdateCascade"]
-                `shouldBe`
-                    Just UnboundFieldDef
+                `shouldBe` Just
+                    UnboundFieldDef
                         { unboundFieldNameHS = FieldNameHS "asdf"
                         , unboundFieldNameDB = FieldNameDB "asdf"
                         , unboundFieldType = FTTypeCon Nothing "Int"
@@ -73,8 +72,8 @@ spec = describe "Quasi" $ do
                         }
         it "never tries to make a refernece" $ do
             subject ["asdf", "UserId", "OnDeleteCascade"]
-                `shouldBe`
-                    Just UnboundFieldDef
+                `shouldBe` Just
+                    UnboundFieldDef
                         { unboundFieldNameHS = FieldNameHS "asdf"
                         , unboundFieldNameDB = FieldNameDB "asdf"
                         , unboundFieldType = FTTypeCon Nothing "UserId"
@@ -86,209 +85,190 @@ spec = describe "Quasi" $ do
                         }
 
     describe "tokenization" $ do
-        let tokenize = runParser (some anyToken) ""
+        let
+            tokenize = runParser (some anyToken) ""
         it "handles normal words" $
-            tokenize "foo   bar  baz" `shouldBe`
-                Right
-                    (
-                      [ PText "foo"
+            tokenize "foo   bar  baz"
+                `shouldBe` Right
+                    ( [ PText "foo"
                       , PText "bar"
                       , PText "baz"
                       ]
                     )
 
         it "handles numbers" $
-           tokenize "one (Finite 1)" `shouldBe`
-                Right
-                    (
-                        [ PText "one"
-                        , Parenthetical "Finite 1"
-                        ]
+            tokenize "one (Finite 1)"
+                `shouldBe` Right
+                    ( [ PText "one"
+                      , Parenthetical "Finite 1"
+                      ]
                     )
 
         it "handles quotes" $
-            tokenize "\"foo bar\" \"baz\"" `shouldBe`
-                Right
-                    (
-                        [ Quotation "foo bar"
-                        , Quotation "baz"
-                        ]
+            tokenize "\"foo bar\" \"baz\""
+                `shouldBe` Right
+                    ( [ Quotation "foo bar"
+                      , Quotation "baz"
+                      ]
                     )
 
         it "handles SQL literals with no specified type" $
-          tokenize "attr='[\"ab\\'cd\", 1, 2]'" `shouldBe`
-              Right
-                  (
-                    [Equality "attr" "'[\"ab'cd\", 1, 2]'"]
-                  )
+            tokenize "attr='[\"ab\\'cd\", 1, 2]'"
+                `shouldBe` Right
+                    ( [Equality "attr" "'[\"ab'cd\", 1, 2]'"]
+                    )
 
         it "handles SQL literals with a specified type" $
-          tokenize "attr='{\"\\'a\\'\": [1, 2.2, \"\\'3\\'\"]}'::type_name" `shouldBe`
-              Right
-                  (
-                    [Equality "attr" "'{\"'a'\": [1, 2.2, \"'3'\"]}'::type_name"]
-                  )
+            tokenize "attr='{\"\\'a\\'\": [1, 2.2, \"\\'3\\'\"]}'::type_name"
+                `shouldBe` Right
+                    ( [Equality "attr" "'{\"'a'\": [1, 2.2, \"'3'\"]}'::type_name"]
+                    )
 
         it "should error if quotes are unterminated" $ do
-            first errorBundlePretty (tokenize "\"foo bar") `shouldBe`
-              Left("1:9:\n  |\n1 | \"foo bar\n  |         ^\nunexpected end of input\nexpecting '\"' or literal character\n")
+            first errorBundlePretty (tokenize "\"foo bar")
+                `shouldBe` Left
+                    ( "1:9:\n  |\n1 | \"foo bar\n  |         ^\nunexpected end of input\nexpecting '\"' or literal character\n"
+                    )
 
         it "handles quotes mid-token" $
-            tokenize "x=\"foo bar\"  \"baz\"" `shouldBe`
-                Right
-                    (
-                        [ Equality "x" "foo bar"
-                        , Quotation "baz"
-                        ]
+            tokenize "x=\"foo bar\"  \"baz\""
+                `shouldBe` Right
+                    ( [ Equality "x" "foo bar"
+                      , Quotation "baz"
+                      ]
                     )
 
         it "handles escaped quote mid-token" $
-            tokenize "x=\\\"foo bar\"  \"baz\"" `shouldBe`
-                Right
-                    (
-                        [ Equality "x" "\\\"foo"
-                        , PText "bar\""
-                        , Quotation "baz"
-                        ]
+            tokenize "x=\\\"foo bar\"  \"baz\""
+                `shouldBe` Right
+                    ( [ Equality "x" "\\\"foo"
+                      , PText "bar\""
+                      , Quotation "baz"
+                      ]
                     )
 
         it "handles unnested parentheses" $
-            tokenize "(foo bar)  (baz)" `shouldBe`
-                Right
-                    (
-                        [ Parenthetical "foo bar"
-                        , Parenthetical "baz"
-                        ]
+            tokenize "(foo bar)  (baz)"
+                `shouldBe` Right
+                    ( [ Parenthetical "foo bar"
+                      , Parenthetical "baz"
+                      ]
                     )
 
         it "handles unnested parentheses mid-token" $
-            tokenize "x=(foo bar)  (baz)" `shouldBe`
-                Right
-                    (
-                        [ Equality "x" "foo bar"
-                        , Parenthetical "baz"
-                        ]
+            tokenize "x=(foo bar)  (baz)"
+                `shouldBe` Right
+                    ( [ Equality "x" "foo bar"
+                      , Parenthetical "baz"
+                      ]
                     )
 
         it "handles nested parentheses" $
-            tokenize "(foo (bar))  (baz)" `shouldBe`
-                Right
-                    (
-                        [ Parenthetical "foo (bar)"
-                        , Parenthetical "baz"
-                        ]
+            tokenize "(foo (bar))  (baz)"
+                `shouldBe` Right
+                    ( [ Parenthetical "foo (bar)"
+                      , Parenthetical "baz"
+                      ]
                     )
 
         it "handles escaped quotation marks in plain tokens" $
-            tokenize "foo bar\\\"baz" `shouldBe`
-                Right
-                    (
-                        [ PText "foo"
-                        , PText "bar\\\"baz"
-                        ]
+            tokenize "foo bar\\\"baz"
+                `shouldBe` Right
+                    ( [ PText "foo"
+                      , PText "bar\\\"baz"
+                      ]
                     )
 
         it "handles escaped quotation marks in quotations" $
-            tokenize "foo \"bar\\\"baz\"" `shouldBe`
-                Right
-                    (
-                        [ PText "foo"
-                        , Quotation "bar\"baz"
-                        ]
+            tokenize "foo \"bar\\\"baz\""
+                `shouldBe` Right
+                    ( [ PText "foo"
+                      , Quotation "bar\"baz"
+                      ]
                     )
 
         it "handles escaped quotation marks in equalities" $
-            tokenize "y=\"baz\\\"\"" `shouldBe`
-                Right
-                    (
-                        [ Equality "y" "baz\""
-                        ]
+            tokenize "y=\"baz\\\"\""
+                `shouldBe` Right
+                    ( [ Equality "y" "baz\""
+                      ]
                     )
 
         it "handles escaped quotation marks in parentheticals" $
-            tokenize "(foo \\\"bar)" `shouldBe`
-                Right
-                    (
-                        [ Parenthetical "foo \\\"bar"
-                        ]
+            tokenize "(foo \\\"bar)"
+                `shouldBe` Right
+                    ( [ Parenthetical "foo \\\"bar"
+                      ]
                     )
 
         it "handles escaped parentheses in quotations" $
-            tokenize "foo \"bar\\(baz\"" `shouldBe`
-                Right
-                    (
-                        [ PText "foo"
-                        , Quotation "bar(baz"
-                        ]
+            tokenize "foo \"bar\\(baz\""
+                `shouldBe` Right
+                    ( [ PText "foo"
+                      , Quotation "bar(baz"
+                      ]
                     )
 
         it "handles escaped parentheses in plain tokens" $
-            tokenize "foo bar\\(baz" `shouldBe`
-                Right
-                    (
-                        [ PText "foo"
-                        , PText "bar(baz"
-                        ]
+            tokenize "foo bar\\(baz"
+                `shouldBe` Right
+                    ( [ PText "foo"
+                      , PText "bar(baz"
+                      ]
                     )
 
         it "handles escaped parentheses in parentheticals" $
-            tokenize "(foo \\(bar)" `shouldBe`
-                Right
-                    (
-                        [ Parenthetical "foo (bar"
-                        ]
+            tokenize "(foo \\(bar)"
+                `shouldBe` Right
+                    ( [ Parenthetical "foo (bar"
+                      ]
                     )
 
         it "handles escaped parentheses in equalities" $
-            tokenize "y=baz\\(" `shouldBe`
-                Right
-                    (
-                        [ Equality "y" "baz("
-                        ]
+            tokenize "y=baz\\("
+                `shouldBe` Right
+                    ( [ Equality "y" "baz("
+                      ]
                     )
 
         it "handles mid-token quote in later token" $
-            tokenize "foo bar baz=(bin\")" `shouldBe`
-                Right
-                    (
-                        [ PText "foo"
-                        , PText "bar"
-                        , Equality "baz" "bin\""
-                        ]
+            tokenize "foo bar baz=(bin\")"
+                `shouldBe` Right
+                    ( [ PText "foo"
+                      , PText "bar"
+                      , Equality "baz" "bin\""
+                      ]
                     )
 
         it "recognizes pipe comments" $
-          tokenize "-- | this is a comment" `shouldBe`
-          Right
-          (
-            [ DocComment "this is a comment"
-            ]
-          )
+            tokenize "-- | this is a comment"
+                `shouldBe` Right
+                    ( [ DocComment "this is a comment"
+                      ]
+                    )
 
         it "recognizes empty pipe comments" $
-            tokenize "-- |" `shouldBe`
-                Right
-                    (
-                        [ DocComment ""
-                        ]
+            tokenize "-- |"
+                `shouldBe` Right
+                    ( [ DocComment ""
+                      ]
                     )
         it "recognizes non-pipe comments" $
-            tokenize "-- this is a comment" `shouldBe`
-                Right
-                    (
-                        [ Comment "this is a comment"
-                        ]
+            tokenize "-- this is a comment"
+                `shouldBe` Right
+                    ( [ Comment "this is a comment"
+                      ]
                     )
         it "recognizes empty non-pipe comments" $
-          tokenize "-- " `shouldBe`
-              Right
-                  (
-                      [ Comment ""
+            tokenize "-- "
+                `shouldBe` Right
+                    ( [ Comment ""
                       ]
-                  )
+                    )
 
     describe "parse" $ do
-        let subject =
+        let
+            subject =
                 [st|
 Bicycle -- | this is a bike
     brand String -- | the brand of the bike
@@ -309,7 +289,8 @@ Car
     car CarId         -- | the car reference
 
                     |]
-        let [bicycle, car, vehicle] = defs subject
+        let
+            [bicycle, car, vehicle] = defs subject
 
         it "should parse the `entityHaskell` field" $ do
             getUnboundEntityNameHS bicycle `shouldBe` EntityNameHS "Bicycle"
@@ -327,31 +308,36 @@ Car
             entityAttrs (unboundEntityDef vehicle) `shouldBe` []
 
         it "should parse the `unboundEntityFields` field" $ do
-            let simplifyField field =
+            let
+                simplifyField field =
                     (unboundFieldNameHS field, unboundFieldNameDB field, unboundFieldComments field)
-            (simplifyField <$> unboundEntityFields bicycle) `shouldBe`
-                [ (FieldNameHS "brand", FieldNameDB "brand", Nothing)
-                ]
-            (simplifyField <$> unboundEntityFields car) `shouldBe`
-                [ (FieldNameHS "make", FieldNameDB "make", Just "the make of the Car\n")
-                , (FieldNameHS "model", FieldNameDB "model", Just "the model of the Car\n")
-                ]
-            (simplifyField <$> unboundEntityFields vehicle) `shouldBe`
-                [ (FieldNameHS "bicycle", FieldNameDB "bicycle", Nothing)
-                , (FieldNameHS "car", FieldNameDB "car", Nothing)
-                ]
+            (simplifyField <$> unboundEntityFields bicycle)
+                `shouldBe` [ (FieldNameHS "brand", FieldNameDB "brand", Nothing)
+                           ]
+            (simplifyField <$> unboundEntityFields car)
+                `shouldBe` [ (FieldNameHS "make", FieldNameDB "make", Just "the make of the Car\n")
+                           , (FieldNameHS "model", FieldNameDB "model", Just "the model of the Car\n")
+                           ]
+            (simplifyField <$> unboundEntityFields vehicle)
+                `shouldBe` [ (FieldNameHS "bicycle", FieldNameDB "bicycle", Nothing)
+                           , (FieldNameHS "car", FieldNameDB "car", Nothing)
+                           ]
 
         it "should parse the `entityUniques` field" $ do
-            let simplifyUnique unique =
+            let
+                simplifyUnique unique =
                     (uniqueHaskell unique, uniqueFields unique)
             (simplifyUnique <$> entityUniques (unboundEntityDef bicycle)) `shouldBe` []
-            (simplifyUnique <$> entityUniques (unboundEntityDef car)) `shouldBe`
-                [ (ConstraintNameHS "UniqueModel", [(FieldNameHS "model", FieldNameDB "model")])
-                ]
+            (simplifyUnique <$> entityUniques (unboundEntityDef car))
+                `shouldBe` [ (ConstraintNameHS "UniqueModel", [(FieldNameHS "model", FieldNameDB "model")])
+                           ]
             (simplifyUnique <$> entityUniques (unboundEntityDef vehicle)) `shouldBe` []
 
         it "should parse the `entityForeigns` field" $ do
-            let [user, notification] = defs [st|
+            let
+                [user, notification] =
+                    defs
+                        [st|
 User
     name            Text
     emailFirst      Text
@@ -369,22 +355,22 @@ Notification
     Foreign User fk_noti_user sentToFirst sentToSecond References emailFirst emailSecond
 |]
             unboundForeignDefs user `shouldBe` []
-            map unboundForeignDef (unboundForeignDefs notification) `shouldBe`
-                [ ForeignDef
-                    { foreignRefTableHaskell = EntityNameHS "User"
-                    , foreignRefTableDBName = EntityNameDB "user"
-                    , foreignConstraintNameHaskell = ConstraintNameHS "fk_noti_user"
-                    , foreignConstraintNameDBName = ConstraintNameDB "notificationfk_noti_user"
-                    , foreignFieldCascade = FieldCascade Nothing Nothing
-                    , foreignFields =
-                        []
-                        -- the foreign fields are not set yet in an unbound
-                        -- entity def
-                    , foreignAttrs = []
-                    , foreignNullable = False
-                    , foreignToPrimary = False
-                    }
-                ]
+            map unboundForeignDef (unboundForeignDefs notification)
+                `shouldBe` [ ForeignDef
+                                { foreignRefTableHaskell = EntityNameHS "User"
+                                , foreignRefTableDBName = EntityNameDB "user"
+                                , foreignConstraintNameHaskell = ConstraintNameHS "fk_noti_user"
+                                , foreignConstraintNameDBName = ConstraintNameDB "notificationfk_noti_user"
+                                , foreignFieldCascade = FieldCascade Nothing Nothing
+                                , foreignFields =
+                                    []
+                                , -- the foreign fields are not set yet in an unbound
+                                  -- entity def
+                                  foreignAttrs = []
+                                , foreignNullable = False
+                                , foreignToPrimary = False
+                                }
+                           ]
 
         it "should parse the `entityDerives` field" $ do
             entityDerives (unboundEntityDef bicycle) `shouldBe` ["Eq"]
@@ -392,7 +378,8 @@ Notification
             entityDerives (unboundEntityDef vehicle) `shouldBe` []
 
         it "should parse the `entityEntities` field" $ do
-            entityExtra (unboundEntityDef bicycle) `shouldBe` Map.singleton "ExtraBike" [["foo", "bar"], ["baz"]]
+            entityExtra (unboundEntityDef bicycle)
+                `shouldBe` Map.singleton "ExtraBike" [["foo", "bar"], ["baz"]]
             entityExtra (unboundEntityDef car) `shouldBe` mempty
             entityExtra (unboundEntityDef vehicle) `shouldBe` mempty
 
@@ -407,105 +394,124 @@ Notification
             entityComments (unboundEntityDef vehicle) `shouldBe` Nothing
 
         it "should error on malformed input, unterminated parens" $ do
-            let definitions = [st|
+            let
+                definitions =
+                    [st|
 User
     name Text
     age  (Maybe Int
 |]
-            let [user] = defs definitions
+            let
+                [user] = defs definitions
             evaluate (unboundEntityDef user)
-                `shouldErrorWithMessage`
-                    "4:20:\n  |\n4 |     age  (Maybe Int\n  |                    ^\nunexpected newline\nexpecting '!', '\"', ''', '(', ')', '-', '.', ':', '[', '\\', ']', '_', '~', alphanumeric character, end of input, space, or tab\n"
+                `shouldErrorWithMessage` "4:20:\n  |\n4 |     age  (Maybe Int\n  |                    ^\nunexpected newline\nexpecting '!', '\"', ''', '(', ')', '-', '.', ':', '[', '\\', ']', '_', '~', alphanumeric character, end of input, space, or tab\n"
 
         it "errors on duplicate cascade update declarations" $ do
-            let definitions = [st|
+            let
+                definitions =
+                    [st|
 User
     age  Int OnUpdateCascade OnUpdateCascade
 |]
-            let [user] = defs definitions
+            let
+                [user] = defs definitions
             mapM (evaluate . unboundFieldCascade) (unboundEntityFields user)
-                `shouldErrorWithMessage`
-                    "found more than one OnUpdate action, tokens: [\"OnUpdateCascade\",\"OnUpdateCascade\"]"
+                `shouldErrorWithMessage` "found more than one OnUpdate action, tokens: [\"OnUpdateCascade\",\"OnUpdateCascade\"]"
 
         it "errors on duplicate cascade delete declarations" $ do
-            let definitions = [st|
+            let
+                definitions =
+                    [st|
 User
     age  Int OnDeleteCascade OnDeleteCascade
 |]
-            let [user] = defs definitions
+            let
+                [user] = defs definitions
             mapM (evaluate . unboundFieldCascade) (unboundEntityFields user)
-                `shouldErrorWithMessage`
-                    "found more than one OnDelete action, tokens: [\"OnDeleteCascade\",\"OnDeleteCascade\"]"
+                `shouldErrorWithMessage` "found more than one OnDelete action, tokens: [\"OnDeleteCascade\",\"OnDeleteCascade\"]"
 
         describe "custom Id column" $ do
             it "parses custom Id column" $ do
-                let definitions = [st|
+                let
+                    definitions =
+                        [st|
 User
     Id   Text
     name Text
     age  Int
 |]
-                let [user] = defs definitions
+                let
+                    [user] = defs definitions
                 getUnboundEntityNameHS user `shouldBe` EntityNameHS "User"
                 entityDB (unboundEntityDef user) `shouldBe` EntityNameDB "user"
-                let idFields = NEL.toList (entitiesPrimary (unboundEntityDef user))
+                let
+                    idFields = NEL.toList (entitiesPrimary (unboundEntityDef user))
                 (fieldHaskell <$> idFields) `shouldBe` [FieldNameHS "Id"]
                 (fieldDB <$> idFields) `shouldBe` [FieldNameDB "id"]
                 (fieldType <$> idFields) `shouldBe` [FTTypeCon Nothing "Text"]
-                (unboundFieldNameHS <$> unboundEntityFields user) `shouldBe`
-                    [ FieldNameHS "name"
-                    , FieldNameHS "age"
-                    ]
+                (unboundFieldNameHS <$> unboundEntityFields user)
+                    `shouldBe` [ FieldNameHS "name"
+                               , FieldNameHS "age"
+                               ]
 
             it "errors on duplicate custom Id column" $ do
-                let definitions = [st|
+                let
+                    definitions =
+                        [st|
 User
     Id   Text
     Id   Text
     name Text
     age  Int
 |]
-                let [user] = defs definitions
+                let
+                    [user] = defs definitions
                     errMsg = [st|expected only one Id declaration per entity|]
-                evaluate (unboundEntityDef user) `shouldErrorWithMessage`
-                    (T.unpack errMsg)
+                evaluate (unboundEntityDef user)
+                    `shouldErrorWithMessage` (T.unpack errMsg)
 
         describe "primary declaration" $ do
             it "parses Primary declaration" $ do
-                let definitions = [st|
+                let
+                    definitions =
+                        [st|
 User
     ref Text
     name Text
     age  Int
     Primary ref
 |]
-                let [user] = defs definitions
+                let
+                    [user] = defs definitions
                 getUnboundEntityNameHS user `shouldBe` EntityNameHS "User"
                 entityDB (unboundEntityDef user) `shouldBe` EntityNameDB "user"
-                let idFields = NEL.toList (entitiesPrimary (unboundEntityDef user))
+                let
+                    idFields = NEL.toList (entitiesPrimary (unboundEntityDef user))
                 (fieldHaskell <$> idFields) `shouldBe` [FieldNameHS "Id"]
                 (fieldDB <$> idFields) `shouldBe` [FieldNameDB "id"]
                 (fieldType <$> idFields) `shouldBe` [FTTypeCon Nothing "UserId"]
-                (unboundFieldNameHS <$> unboundEntityFields user) `shouldBe`
-                    [ FieldNameHS "ref"
-                    , FieldNameHS "name"
-                    , FieldNameHS "age"
-                    ]
-                entityUniques (unboundEntityDef user) `shouldBe`
-                    [ UniqueDef
-                        { uniqueHaskell =
-                            ConstraintNameHS "UserPrimaryKey"
-                        , uniqueDBName =
-                            ConstraintNameDB "primary_key"
-                        , uniqueFields =
-                            pure (FieldNameHS "ref", FieldNameDB "ref")
-                        , uniqueAttrs =
-                            []
-                        }
-                    ]
+                (unboundFieldNameHS <$> unboundEntityFields user)
+                    `shouldBe` [ FieldNameHS "ref"
+                               , FieldNameHS "name"
+                               , FieldNameHS "age"
+                               ]
+                entityUniques (unboundEntityDef user)
+                    `shouldBe` [ UniqueDef
+                                    { uniqueHaskell =
+                                        ConstraintNameHS "UserPrimaryKey"
+                                    , uniqueDBName =
+                                        ConstraintNameDB "primary_key"
+                                    , uniqueFields =
+                                        pure (FieldNameHS "ref", FieldNameDB "ref")
+                                    , uniqueAttrs =
+                                        []
+                                    }
+                               ]
 
             it "errors on duplicate custom Primary declaration" $ do
-                let definitions = [st|
+                let
+                    definitions =
+                        [st|
 User
     ref Text
     name Text
@@ -513,13 +519,16 @@ User
     Primary ref
     Primary name
 |]
-                let [user] = defs definitions
+                let
+                    [user] = defs definitions
                     errMsg = "expected only one Primary declaration per entity"
-                evaluate (unboundEntityDef user) `shouldErrorWithMessage`
-                    errMsg
+                evaluate (unboundEntityDef user)
+                    `shouldErrorWithMessage` errMsg
 
             it "errors on conflicting Primary/Id declarations" $ do
-                let definitions = [st|
+                let
+                    definitions =
+                        [st|
 User
     Id Text
     ref Text
@@ -527,56 +536,69 @@ User
     age  Int
     Primary ref
 |]
-                let [user] = defs definitions
+                let
+                    [user] = defs definitions
                     errMsg = [st|Specified both an ID field and a Primary field|]
-                evaluate (unboundEntityDef user) `shouldErrorWithMessage`
-                    (T.unpack errMsg)
+                evaluate (unboundEntityDef user)
+                    `shouldErrorWithMessage` (T.unpack errMsg)
 
             it "triggers error on invalid declaration" $ do
-                let definitions = [st|
+                let
+                    definitions =
+                        [st|
 User
     age Text
     Primary ref
 |]
-                let [user] = defs definitions
+                let
+                    [user] = defs definitions
                 case unboundPrimarySpec user of
                     NaturalKey ucd -> do
-                        evaluate (NEL.head $ unboundCompositeCols ucd) `shouldErrorWithMessage`
-                            "Unknown column in primary key constraint: \"ref\""
+                        evaluate (NEL.head $ unboundCompositeCols ucd)
+                            `shouldErrorWithMessage` "Unknown column in primary key constraint: \"ref\""
                     _ ->
                         error "Expected NaturalKey, failing"
 
         describe "entity unique constraints" $ do
             it "triggers error if declared field does not exist" $ do
-                let definitions = [st|
+                let
+                    definitions =
+                        [st|
 User
     name            Text
     emailFirst      Text
 
     UniqueEmail emailFirst emailSecond
 |]
-                let [user] = defs definitions
+                let
+                    [user] = defs definitions
                     uniques = entityUniques (unboundEntityDef user)
                     [dbNames] = fmap snd . uniqueFields <$> uniques
-                    errMsg = unwords
-                        [ "Unknown column in \"UniqueEmail\" constraint: \"emailSecond\""
-                        , "possible fields: [\"name\",\"emailFirst\"]"
-                        ]
-                evaluate (head (NEL.tail dbNames)) `shouldErrorWithMessage`
-                    errMsg
+                    errMsg =
+                        unwords
+                            [ "Unknown column in \"UniqueEmail\" constraint: \"emailSecond\""
+                            , "possible fields: [\"name\",\"emailFirst\"]"
+                            ]
+                evaluate (head (NEL.tail dbNames))
+                    `shouldErrorWithMessage` errMsg
 
             it "triggers error if no valid constraint name provided" $ do
-                let definitions = [st|
+                let
+                    definitions =
+                        [st|
 User
     age Text
     Unique some
 |]
-                let [user] = defs definitions
-                evaluate (unboundPrimarySpec user) `shouldErrorWithMessage`
-                    "invalid unique constraint on table[\"User\"] expecting an uppercase constraint name xs=[\"some\"]"
+                let
+                    [user] = defs definitions
+                evaluate (unboundPrimarySpec user)
+                    `shouldErrorWithMessage` "invalid unique constraint on table[\"User\"] expecting an uppercase constraint name xs=[\"some\"]"
 
         describe "foreign keys" $ do
-            let validDefinitions = [st|
+            let
+                validDefinitions =
+                    [st|
 User
     name            Text
     emailFirst      Text
@@ -601,11 +623,12 @@ Notification
                     [notificationForeignDef] =
                         unboundForeignDef <$> unboundForeignDefs notification
                 foreignConstraintNameDBName notificationForeignDef
-                    `shouldBe`
-                        ConstraintNameDB "fk_noti_user_notification"
+                    `shouldBe` ConstraintNameDB "fk_noti_user_notification"
 
             it "should error when insufficient params provided" $ do
-                let definitions = [st|
+                let
+                    definitions =
+                        [st|
 User
     name            Text
     emailFirst      Text
@@ -619,13 +642,15 @@ Notification
     sentToSecond    Text
     Foreign User
 |]
-                let [_user, notification] = defsSnake definitions
+                let
+                    [_user, notification] = defsSnake definitions
                 mapM (evaluate . unboundForeignFields) (unboundForeignDefs notification)
-                    `shouldErrorWithMessage`
-                        "invalid foreign key constraint on table[\"Notification\"] expecting a lower case constraint name or a cascading action xs=[]"
+                    `shouldErrorWithMessage` "invalid foreign key constraint on table[\"Notification\"] expecting a lower case constraint name or a cascading action xs=[]"
 
             it "should error when foreign fields not provided" $ do
-                let definitions = [st|
+                let
+                    definitions =
+                        [st|
 User
     name            Text
     emailFirst      Text
@@ -639,13 +664,15 @@ Notification
     sentToSecond    Text
     Foreign User fk_noti_user
 |]
-                let [_user, notification] = defsSnake definitions
+                let
+                    [_user, notification] = defsSnake definitions
                 mapM (evaluate . unboundForeignFields) (unboundForeignDefs notification)
-                    `shouldErrorWithMessage`
-                        "No fields on foreign reference."
+                    `shouldErrorWithMessage` "No fields on foreign reference."
 
             it "should error when number of parent and foreign fields differ" $ do
-                let definitions = [st|
+                let
+                    definitions =
+                        [st|
 User
     name            Text
     emailFirst      Text
@@ -659,13 +686,16 @@ Notification
     sentToSecond    Text
     Foreign User fk_noti_user sentToFirst sentToSecond References emailFirst
 |]
-                let [_user, notification] = defsSnake definitions
+                let
+                    [_user, notification] = defsSnake definitions
                 mapM (evaluate . unboundForeignFields) (unboundForeignDefs notification)
-                    `shouldErrorWithMessage`
-                        "invalid foreign key constraint on table[\"Notification\"] Found 2 foreign fields but 1 parent fields"
+                    `shouldErrorWithMessage` "invalid foreign key constraint on table[\"Notification\"] Found 2 foreign fields but 1 parent fields"
 
-            it "should throw error when there is more than one delete cascade on the declaration" $ do
-                let definitions = [st|
+            it
+                "should throw error when there is more than one delete cascade on the declaration" $ do
+                let
+                    definitions =
+                        [st|
 User
     name            Text
     emailFirst      Text
@@ -679,13 +709,16 @@ Notification
     sentToSecond    Text
     Foreign User OnDeleteCascade OnDeleteCascade
 |]
-                let [_user, notification] = defsSnake definitions
+                let
+                    [_user, notification] = defsSnake definitions
                 mapM (evaluate . unboundForeignFields) (unboundForeignDefs notification)
-                    `shouldErrorWithMessage`
-                        "invalid foreign key constraint on table[\"Notification\"] found more than one OnDelete actions"
+                    `shouldErrorWithMessage` "invalid foreign key constraint on table[\"Notification\"] found more than one OnDelete actions"
 
-            it "should throw error when there is more than one update cascade on the declaration" $ do
-                let definitions = [st|
+            it
+                "should throw error when there is more than one update cascade on the declaration" $ do
+                let
+                    definitions =
+                        [st|
 User
     name            Text
     emailFirst      Text
@@ -699,105 +732,137 @@ Notification
     sentToSecond    Text
     Foreign User OnUpdateCascade OnUpdateCascade
 |]
-                let [_user, notification] = defsSnake definitions
+                let
+                    [_user, notification] = defsSnake definitions
                 mapM (evaluate . unboundForeignFields) (unboundForeignDefs notification)
-                    `shouldErrorWithMessage`
-                        "invalid foreign key constraint on table[\"Notification\"] found more than one OnUpdate actions"
+                    `shouldErrorWithMessage` "invalid foreign key constraint on table[\"Notification\"] found more than one OnUpdate actions"
 
-            it "should allow you to enable snake cased foriegn keys via a preset configuration function" $ do
-                let [_user, notification] =
+            it
+                "should allow you to enable snake cased foriegn keys via a preset configuration function" $ do
+                let
+                    [_user, notification] =
                         defsSnake validDefinitions
                     [notificationForeignDef] =
                         unboundForeignDef <$> unboundForeignDefs notification
                 foreignConstraintNameDBName notificationForeignDef
-                    `shouldBe`
-                        ConstraintNameDB "notification_fk_noti_user"
+                    `shouldBe` ConstraintNameDB "notification_fk_noti_user"
 
         describe "ticked types" $ do
             it "should be able to parse ticked types" $ do
-                let simplifyField field =
+                let
+                    simplifyField field =
                         (unboundFieldNameHS field, unboundFieldType field)
-                let tickedDefinition = [st|
+                let
+                    tickedDefinition =
+                        [st|
 CustomerTransfer
     customerId CustomerId
     moneyAmount (MoneyAmount 'Customer 'Debit)
     currencyCode CurrencyCode
     uuid TransferUuid
 |]
-                let [customerTransfer] = defs tickedDefinition
-                let expectedType =
-                        FTTypeCon Nothing "MoneyAmount" `FTApp` FTTypePromoted "Customer" `FTApp` FTTypePromoted "Debit"
+                let
+                    [customerTransfer] = defs tickedDefinition
+                let
+                    expectedType =
+                        FTTypeCon Nothing "MoneyAmount"
+                            `FTApp` FTTypePromoted "Customer"
+                            `FTApp` FTTypePromoted "Debit"
 
-                (simplifyField <$> unboundEntityFields customerTransfer) `shouldBe`
-                    [ (FieldNameHS "customerId", FTTypeCon Nothing "CustomerId")
-                    , (FieldNameHS "moneyAmount", expectedType)
-                    , (FieldNameHS "currencyCode", FTTypeCon Nothing "CurrencyCode")
-                    , (FieldNameHS "uuid", FTTypeCon Nothing "TransferUuid")
-                    ]
+                (simplifyField <$> unboundEntityFields customerTransfer)
+                    `shouldBe` [ (FieldNameHS "customerId", FTTypeCon Nothing "CustomerId")
+                               , (FieldNameHS "moneyAmount", expectedType)
+                               , (FieldNameHS "currencyCode", FTTypeCon Nothing "CurrencyCode")
+                               , (FieldNameHS "uuid", FTTypeCon Nothing "TransferUuid")
+                               ]
 
         describe "type literals" $ do
             it "should be able to parse type literals" $ do
-                let simplifyField field =
+                let
+                    simplifyField field =
                         (unboundFieldNameHS field, unboundFieldType field)
-                let tickedDefinition = [st|
+                let
+                    tickedDefinition =
+                        [st|
 WithFinite
     one    (Finite 1)
     twenty (Labelled "twenty")
 |]
-                let [withFinite] = defs tickedDefinition
+                let
+                    [withFinite] = defs tickedDefinition
 
-                (simplifyField <$> unboundEntityFields withFinite) `shouldBe`
-                    [ (FieldNameHS "one", FTApp (FTTypeCon Nothing "Finite") (FTLit (IntTypeLit 1)))
-                    , (FieldNameHS "twenty", FTApp (FTTypeCon Nothing "Labelled") (FTLit (TextTypeLit "twenty")))
-                    ]
+                (simplifyField <$> unboundEntityFields withFinite)
+                    `shouldBe` [ (FieldNameHS "one", FTApp (FTTypeCon Nothing "Finite") (FTLit (IntTypeLit 1)))
+                               ,
+                                   ( FieldNameHS "twenty"
+                                   , FTApp (FTTypeCon Nothing "Labelled") (FTLit (TextTypeLit "twenty"))
+                                   )
+                               ]
 
     describe "parseFieldType" $ do
         it "simple types" $
             parseFieldType "FooBar" `shouldBe` Right (FTTypeCon Nothing "FooBar")
         it "module types" $
-            parseFieldType "Data.Map.FooBar" `shouldBe` Right (FTTypeCon (Just "Data.Map") "FooBar")
+            parseFieldType "Data.Map.FooBar"
+                `shouldBe` Right (FTTypeCon (Just "Data.Map") "FooBar")
         it "application" $
-            parseFieldType "Foo Bar" `shouldBe` Right (
-                FTTypeCon Nothing "Foo" `FTApp` FTTypeCon Nothing "Bar")
+            parseFieldType "Foo Bar"
+                `shouldBe` Right
+                    ( FTTypeCon Nothing "Foo" `FTApp` FTTypeCon Nothing "Bar"
+                    )
         it "application multiple" $
-            parseFieldType "Foo Bar Baz" `shouldBe` Right (
-                (FTTypeCon Nothing "Foo" `FTApp` FTTypeCon Nothing "Bar")
-                `FTApp` FTTypeCon Nothing "Baz"
-                )
+            parseFieldType "Foo Bar Baz"
+                `shouldBe` Right
+                    ( (FTTypeCon Nothing "Foo" `FTApp` FTTypeCon Nothing "Bar")
+                        `FTApp` FTTypeCon Nothing "Baz"
+                    )
         it "parens" $ do
-            let foo = FTTypeCon Nothing "Foo"
+            let
+                foo = FTTypeCon Nothing "Foo"
                 bar = FTTypeCon Nothing "Bar"
                 baz = FTTypeCon Nothing "Baz"
-            parseFieldType "Foo (Bar Baz)" `shouldBe` Right (
-                foo `FTApp` (bar `FTApp` baz))
+            parseFieldType "Foo (Bar Baz)"
+                `shouldBe` Right
+                    ( foo `FTApp` (bar `FTApp` baz)
+                    )
         it "lists" $ do
-            let foo = FTTypeCon Nothing "Foo"
+            let
+                foo = FTTypeCon Nothing "Foo"
                 bar = FTTypeCon Nothing "Bar"
                 bars = FTList bar
                 baz = FTTypeCon Nothing "Baz"
-            parseFieldType "Foo [Bar] Baz" `shouldBe` Right (
-                foo `FTApp` bars `FTApp` baz)
+            parseFieldType "Foo [Bar] Baz"
+                `shouldBe` Right
+                    ( foo `FTApp` bars `FTApp` baz
+                    )
         it "numeric type literals" $ do
-            let expected = FTApp (FTTypeCon Nothing "Finite") (FTLit (IntTypeLit 1))
+            let
+                expected = FTApp (FTTypeCon Nothing "Finite") (FTLit (IntTypeLit 1))
             parseFieldType "Finite 1" `shouldBe` Right expected
         it "string type literals" $ do
-            let expected = FTApp (FTTypeCon Nothing "Labelled") (FTLit (TextTypeLit "twenty"))
+            let
+                expected = FTApp (FTTypeCon Nothing "Labelled") (FTLit (TextTypeLit "twenty"))
             parseFieldType "Labelled \"twenty\"" `shouldBe` Right expected
         it "nested list / parens (list inside parens)" $ do
-            let maybeCon = FTTypeCon Nothing "Maybe"
+            let
+                maybeCon = FTTypeCon Nothing "Maybe"
                 int = FTTypeCon Nothing "Int"
-            parseFieldType "Maybe (Maybe [Int])" `shouldBe` Right
-                (maybeCon `FTApp` (maybeCon `FTApp` FTList int))
+            parseFieldType "Maybe (Maybe [Int])"
+                `shouldBe` Right
+                    (maybeCon `FTApp` (maybeCon `FTApp` FTList int))
         it "nested list / parens (parens inside list)" $ do
-            let maybeCon = FTTypeCon Nothing "Maybe"
+            let
+                maybeCon = FTTypeCon Nothing "Maybe"
                 int = FTTypeCon Nothing "Int"
-            parseFieldType "[Maybe (Maybe Int)]" `shouldBe` Right
-                (FTList (maybeCon `FTApp` (maybeCon `FTApp` int)))
+            parseFieldType "[Maybe (Maybe Int)]"
+                `shouldBe` Right
+                    (FTList (maybeCon `FTApp` (maybeCon `FTApp` int)))
         it "fails on lowercase starts" $ do
             parseFieldType "nothanks" `shouldBe` Left "PSFail \"nothanks\""
 
     describe "#1175 empty entity" $ do
-        let subject =
+        let
+            subject =
                 [st|
 Foo
     name String
@@ -815,26 +880,27 @@ Baz
                     |]
 
         it "parse works" $ do
-            let test name'fieldCount parsedList = do
+            let
+                test name'fieldCount parsedList = do
                     case (name'fieldCount, parsedList) of
                         ([], []) ->
                             pure ()
                         ((name, fieldCount) : _, []) ->
-                            expectationFailure
-                                $ "Expected an entity with name "
-                                <> name
-                                <> " and " <> show fieldCount <> " fields"
-                                <> ", but the list was empty..."
-
+                            expectationFailure $
+                                "Expected an entity with name "
+                                    <> name
+                                    <> " and "
+                                    <> show fieldCount
+                                    <> " fields"
+                                    <> ", but the list was empty..."
                         ((name, fieldCount) : ys, (x : xs)) -> do
                             let
-                                UnboundEntityDef {..} =
+                                UnboundEntityDef{..} =
                                     x
                             (unEntityNameHS (getUnboundEntityNameHS x), length unboundEntityFields)
-                                `shouldBe`
-                                    (T.pack name, fieldCount)
+                                `shouldBe` (T.pack name, fieldCount)
                             test ys xs
-                        ([], _:_) ->
+                        ([], _ : _) ->
                             expectationFailure
                                 "more entities parsed than expected"
 
@@ -852,7 +918,7 @@ Baz
 
 arbitraryWhiteSpaceChar :: Gen Char
 arbitraryWhiteSpaceChar =
-  oneof $ pure <$> [' ', '\t', '\n', '\r']
+    oneof $ pure <$> [' ', '\t', '\n', '\r']
 
 shouldErrorWithMessage :: IO a -> String -> Expectation
 shouldErrorWithMessage action expectedMsg = do

--- a/persistent/test/Database/Persist/QuasiSpec.hs
+++ b/persistent/test/Database/Persist/QuasiSpec.hs
@@ -415,7 +415,7 @@ User
             let [user] = defs definitions
             evaluate (unboundEntityDef user)
                 `shouldErrorWithMessage`
-                    "4:20:\n  |\n4 |     age  (Maybe Int\n  |                    ^\nunexpected newline\nexpecting '!', '\"', ''', '(', ')', '-', '.', ':', '[', '\\', ']', '_', '~', alphanumeric character, space, or tab\n"
+                    "4:20:\n  |\n4 |     age  (Maybe Int\n  |                    ^\nunexpected newline\nexpecting '!', '\"', ''', '(', ')', '-', '.', ':', '[', '\\', ']', '_', '~', alphanumeric character, end of input, space, or tab\n"
 
         it "errors on duplicate cascade update declarations" $ do
             let definitions = [st|

--- a/persistent/test/Database/Persist/QuasiSpec.hs
+++ b/persistent/test/Database/Persist/QuasiSpec.hs
@@ -409,6 +409,12 @@ Notification
             entityComments (unboundEntityDef car) `shouldBe` Just "This is a Car\n"
             entityComments (unboundEntityDef vehicle) `shouldBe` Nothing
 
+        it "treats tabs as spaces" $ do
+          let
+            str = T.pack "User\n\tId Text\n\tname Text\n\tage Int"
+            [user] = defs str
+          getUnboundEntityNameHS user `shouldBe` EntityNameHS "User"
+
         it "should error on malformed input, unterminated parens" $ do
             let
                 definitions =

--- a/persistent/test/Database/Persist/THSpec.hs
+++ b/persistent/test/Database/Persist/THSpec.hs
@@ -45,6 +45,7 @@ import Test.QuickCheck.Gen (Gen)
 import Database.Persist
 import Database.Persist.EntityDef.Internal
 import Database.Persist.Quasi.Internal (SourceLoc(..), sourceLocFromTHLoc)
+import Database.Persist.Types.Span
 import Database.Persist.Sql
 import Database.Persist.Sql.Util
 import Database.Persist.TH

--- a/persistent/test/Database/Persist/THSpec.hs
+++ b/persistent/test/Database/Persist/THSpec.hs
@@ -336,7 +336,7 @@ spec = describe "THSpec" $ do
                     }
         describe "entityDef" $ do
             it "correct position" $ do
-                let Just theSpan = entitySourceSpan simpleCascadeDef
+                let Just theSpan = entitySpan simpleCascadeDef
                 theSpan `shouldSatisfy` ((> locStartLine personDefBeforeLoc) . spanStartLine)
                 theSpan `shouldSatisfy` (\s -> spanStartLine s < spanEndLine s)
                 theSpan `shouldSatisfy` ((< locStartLine personDefAfterLoc) . spanEndLine)
@@ -389,7 +389,7 @@ spec = describe "THSpec" $ do
                             -- We cannot test this is a precise value without
                             -- being really fragile, but we have another test to
                             -- verify the line is in range.
-                            , entitySourceSpan = entitySourceSpan simpleCascadeDef
+                            , entitySpan = entitySpan simpleCascadeDef
                             }
         it "has the cascade on the field def" $ do
             fieldCascade subject `shouldBe` expected

--- a/persistent/test/Database/Persist/THSpec.hs
+++ b/persistent/test/Database/Persist/THSpec.hs
@@ -45,7 +45,7 @@ import Test.QuickCheck.Gen (Gen)
 import Database.Persist
 import Database.Persist.EntityDef.Internal
 import Database.Persist.Quasi.Internal (SourceLoc(..), sourceLocFromTHLoc)
-import Database.Persist.Types.Span
+import Database.Persist.Types.SourceSpan
 import Database.Persist.Sql
 import Database.Persist.Sql.Util
 import Database.Persist.TH
@@ -336,7 +336,7 @@ spec = describe "THSpec" $ do
                     }
         describe "entityDef" $ do
             it "correct position" $ do
-                let Just theSpan = entitySpan simpleCascadeDef
+                let Just theSpan = entitySourceSpan simpleCascadeDef
                 theSpan `shouldSatisfy` ((> locStartLine personDefBeforeLoc) . spanStartLine)
                 theSpan `shouldSatisfy` (\s -> spanStartLine s < spanEndLine s)
                 theSpan `shouldSatisfy` ((< locStartLine personDefAfterLoc) . spanEndLine)
@@ -389,7 +389,7 @@ spec = describe "THSpec" $ do
                             -- We cannot test this is a precise value without
                             -- being really fragile, but we have another test to
                             -- verify the line is in range.
-                            , entitySpan = entitySpan simpleCascadeDef
+                            , entitySourceSpan = entitySourceSpan simpleCascadeDef
                             }
         it "has the cascade on the field def" $ do
             fieldCascade subject `shouldBe` expected


### PR DESCRIPTION
This PR uses Megaparsec to reimplement the tokenization and initial parsing of entity definitions.

**It also slightly changes the semantics of documentation comments**; it is now possible to write Haddock-style pre-comment blocks:

```
-- | This is a multi-line documentation block 
-- in the style of Haddock pre-comments.

-- | This is a multi-line documentation block
-- | in the old Persistent style, which is still
-- | supported.
```

Other than this, there are no intentional changes in behavior. Before merging this, I think it would be a very good idea to test that some other packages depending on persistent (e.g. Esqueleto) build and run correctly with these changes. **I have not done this yet**, but I think I should open the PR anyway so I can get feedback.

---

Before submitting your PR, check that you've:

- [x] Ran `fourmolu` on any changed files (`restyled` will do this for you, so
  accept the suggested changes if it makes them)
- [ ] Adhered to the code style (see the `.editorconfig` and `fourmolu.yaml` files for details)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)
