### PR TITLE
Fix missing UTC timezone "Z" in Sqlite UTCTime strings

### DIFF
--- a/persistent-sqlite/ChangeLog.md
+++ b/persistent-sqlite/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog for persistent-sqlite
 
+## 2.13.3.1
+
+* [1585](https://github.com/yesodweb/persistent/pull/1585)
+    * Fix missing timezone "Z" in Sqlite UTCTime strings, e.g.
+      "2025-04-12T06:53:42Z"
+
 ## 2.13.3.0
 
 * [#1524](https://github.com/yesodweb/persistent/pull/1524)

--- a/persistent-sqlite/Database/Sqlite.hs
+++ b/persistent-sqlite/Database/Sqlite.hs
@@ -486,8 +486,13 @@ bind statement sqlData = do
        $ zip [1..] sqlData
   return ()
 
+-- | Format UTCTime value as a ISO86091 string.
+-- It contains timezone "Z" which corresponds to UTC, e.g. "2025-04-12T06:53:42Z".
+-- Note: We manually format here to support "time" package >=1.6,
+-- but consider using `Data.Time.Format.ISO8601` iso8601Show and iso8601ParseM when bumping
+-- lower "time" package bound to >=1.9.
 format8601 :: UTCTime -> String
-format8601 = formatTime defaultTimeLocale "%FT%T%Q"
+format8601 = formatTime defaultTimeLocale "%FT%T%QZ"
 
 foreign import ccall "sqlite3_column_type"
   columnTypeC :: Ptr () -> Int -> IO Int

--- a/persistent-sqlite/persistent-sqlite.cabal
+++ b/persistent-sqlite/persistent-sqlite.cabal
@@ -1,5 +1,5 @@
 name:               persistent-sqlite
-version:            2.13.3.0
+version:            2.13.3.1
 license:            MIT
 license-file:       LICENSE
 author:             Michael Snoyman <michael@snoyman.com>
@@ -77,7 +77,7 @@ library
     , microlens-th          >=0.4.1.1
     , monad-logger          >=0.3.25
     , mtl
-    , persistent            >=2.13.3  && <3
+    , persistent            >=2.15.2.0  && <3
     , resource-pool
     , resourcet             >=1.1.9
     , text                  >=1.2

--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog for persistent
 
+# 2.15.2.0
+
+* [#1585](https://github.com/yesodweb/persistent/pull/1585)
+    * Support parsing PersistField UTCTime from text with timezone, e.g. "2025-04-12T06:53:42Z".
+      This is needed for Sqlite, which has no native datetime support but uses e.g. TEXT.
+
 # 2.15.1.0
 
 * [#1519](https://github.com/yesodweb/persistent/pull/1519/files/9865a295f4545d30e55aacb6efc25f27f758e8ad#diff-5af2883367baae8f7f266df6a89fc2d1defb7572d94ed069e05c8135a883bc45)

--- a/persistent/Database/Persist/Class/PersistField.hs
+++ b/persistent/Database/Persist/Class/PersistField.hs
@@ -11,7 +11,7 @@ module Database.Persist.Class.PersistField
 
 import Control.Arrow (second)
 import Control.Monad ((<=<))
-import Control.Applicative ((<|>))
+import Control.Applicative (asum)
 import qualified Data.Aeson as A
 import Data.ByteString.Char8 (ByteString, unpack, readInt)
 import qualified Data.ByteString.Lazy as L
@@ -311,7 +311,7 @@ instance PersistField UTCTime where
         in
           case NonEmpty.nonEmpty (reads s) of
             Nothing ->
-                case parse8601 s <|> parsePretty s of
+                case asum [parse8601 s, parse8601NoTimezone s, parsePretty s, parsePrettyNoTimezone s] of
                     Nothing -> Left $ fromPersistValueParseError "UTCTime" x
                     Just x' -> Right x'
             Just matches ->
@@ -323,12 +323,20 @@ instance PersistField UTCTime where
                 Right $ fst $ NonEmpty.last matches
       where
 #if MIN_VERSION_time(1,5,0)
+        -- Note: consider using `Data.Time.Format.ISO8601` iso8601ParseM when bumping
+        -- lower "time" package bound to >=1.9; this function require the timezone "Z",
+        -- so best suitable when e.g. dropping support non-canonial "notimezone" and "pretty" parse variants
+        -- in persistent 3.0.
         parseTime' = parseTimeM True defaultTimeLocale
 #else
         parseTime' = parseTime defaultTimeLocale
 #endif
-        parse8601 = parseTime' "%FT%T%Q"
-        parsePretty = parseTime' "%F %T%Q"
+        parse8601 = parseTime' "%FT%T%QZ"
+        parsePretty = parseTime' "%F %T%QZ"
+        -- Before 2.13.3.1 persistent-sqlite was missing the timezone "Z" for UTC,
+        -- which was only implicit, so these functions ensure backwards-compatibility.
+        parse8601NoTimezone = parseTime' "%FT%T%Q"
+        parsePrettyNoTimezone = parseTime' "%F %T%Q"
     fromPersistValue x@(PersistByteString s) =
         case reads $ unpack s of
             (d, _):_ -> Right d

--- a/persistent/Database/Persist/Class/PersistField.hs
+++ b/persistent/Database/Persist/Class/PersistField.hs
@@ -11,11 +11,11 @@ module Database.Persist.Class.PersistField
 
 import Control.Arrow (second)
 import Control.Monad ((<=<))
-import Control.Applicative (asum)
 import qualified Data.Aeson as A
 import Data.ByteString.Char8 (ByteString, unpack, readInt)
 import qualified Data.ByteString.Lazy as L
 import Data.Fixed
+import Data.Foldable (asum)
 import Data.Int (Int8, Int16, Int32, Int64)
 import qualified Data.IntMap as IM
 import qualified Data.List.NonEmpty as NonEmpty

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:               persistent
-version:            2.15.1.0
+version:            2.15.2.0
 license:            MIT
 license-file:       LICENSE
 author:             Michael Snoyman <michael@snoyman.com>

--- a/persistent/test/Database/Persist/ClassSpec.hs
+++ b/persistent/test/Database/Persist/ClassSpec.hs
@@ -1,7 +1,7 @@
 module Database.Persist.ClassSpec where
 
-import Database.Persist.Class
 import Data.Time
+import Database.Persist.Class
 import Database.Persist.Types
 import Test.Hspec
 
@@ -9,7 +9,15 @@ spec :: Spec
 spec = describe "Class" $ do
     describe "PersistField" $ do
         describe "UTCTime" $ do
-            it "fromPersistValue with format" $
+            it "fromPersistValue with ISO8601 format including UTC timezone Z (canonical)" $
+                fromPersistValue (PersistText "2018-02-27T10:49:42.123Z")
+                    `shouldBe` Right
+                        (UTCTime (fromGregorian 2018 02 27) (timeOfDayToTime (TimeOfDay 10 49 42.123)))
+            it "fromPersistValue with ISO8601 format no timezone (backwards-compatibility)" $
+                fromPersistValue (PersistText "2018-02-27T10:49:42.123")
+                    `shouldBe` Right
+                        (UTCTime (fromGregorian 2018 02 27) (timeOfDayToTime (TimeOfDay 10 49 42.123)))
+            it "fromPersistValue with pretty format (backwards-compatibility)" $
                 fromPersistValue (PersistText "2018-02-27 10:49:42.123")
-                    `shouldBe`
-                        Right (UTCTime (fromGregorian 2018 02 27) (timeOfDayToTime (TimeOfDay 10 49 42.123)))
+                    `shouldBe` Right
+                        (UTCTime (fromGregorian 2018 02 27) (timeOfDayToTime (TimeOfDay 10 49 42.123)))


### PR DESCRIPTION
I noticed that the Sqlite formatting from UTCTime values to string (sqlite doesn't support datetime natively) is missing the UTC timezone marker "Z". So it should be e.g. "2025-04-12T06:53:42Z" instead of "2025-04-12T06:53:42".

I made this change is non-breaking (UTC timezone was implicitly assumed before) by keeping the old parsing logic so new and old format can be read from existing databases.

Loosely related to #1542 #1117 and #339 

Before submitting your PR, check that you've:

- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [x] Ran `fourmolu` on any changed files (`restyled` will do this for you, so
  accept the suggested changes if it makes them)
- [ ] Adhered to the code style (see the `.editorconfig` and `fourmolu.yaml` files for details)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
