### PR TITLE
Document mpsFieldLabelModifier with example

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for persistent
 
+# 2.15.1.1 (unreleased)
+
+* [#1587](https://github.com/yesodweb/persistent/pull/1587)
+    * Improve documentation of `mpsFieldLabelModifier`.
+
 # 2.15.1.0
 
 * [#1519](https://github.com/yesodweb/persistent/pull/1519/files/9865a295f4545d30e55aacb6efc25f27f758e8ad#diff-5af2883367baae8f7f266df6a89fc2d1defb7572d94ed069e05c8135a883bc45)

--- a/persistent/Database/Persist/TH/Internal.hs
+++ b/persistent/Database/Persist/TH/Internal.hs
@@ -1136,7 +1136,7 @@ data MkPersistSettings = MkPersistSettings
     -- }
     -- @
     --
-    -- When you have multiple entites with the same field name, you will need to
+    -- When you have multiple entites with the same field name, you might need to
     -- add @{-# LANGUAGE DuplicateRecordFields #-}@ for your code to compile.
     --
     -- @since 2.11.0.0

--- a/persistent/Database/Persist/TH/Internal.hs
+++ b/persistent/Database/Persist/TH/Internal.hs
@@ -1115,8 +1115,6 @@ data MkPersistSettings = MkPersistSettings
     --
     -- Note: this setting is ignored if the deprecated 'mpsPrefixFields' is set to False.
     --
-    -- @since 2.11.0.0
-    --
     -- === __Example without entity name__
     --
     -- You may not want the entity name prefix for all fields, so use
@@ -1141,6 +1139,7 @@ data MkPersistSettings = MkPersistSettings
     -- When you have multiple entites with the same field name, you will need to
     -- add @{-# LANGUAGE DuplicateRecordFields #-}@ for your code to compile.
     --
+    -- @since 2.11.0.0
     , mpsAvoidHsKeyword :: Text -> Text
     -- ^ Customise function for field accessors applied only when the field name matches any of Haskell keywords.
     --

--- a/persistent/Database/Persist/TH/Internal.hs
+++ b/persistent/Database/Persist/TH/Internal.hs
@@ -1053,7 +1053,9 @@ fixEntityDef ued =
             filter isHaskellUnboundField (unboundEntityFields ued)
         }
 
--- | Settings to be passed to the 'mkPersist' function.
+-- | Settings that can be passed to the 'mkPersist' (mps) function to control what code is generated.
+-- This is (just) the data type definition, so you will most likely want to use and adapt concrete values
+-- like 'sqlSettings'.
 data MkPersistSettings = MkPersistSettings
     { mpsBackend :: Type
     -- ^ Which database backend we\'re using. This type is used for the
@@ -1079,17 +1081,66 @@ data MkPersistSettings = MkPersistSettings
     , mpsPrefixFields :: Bool
     -- ^ Prefix field names with the model name. Default: True.
     --
-    -- Note: this field is deprecated. Use the mpsFieldLabelModifier  and
+    -- Note: this field is deprecated. Use the 'mpsFieldLabelModifier'  and
     -- 'mpsConstraintLabelModifier' instead.
     , mpsFieldLabelModifier :: Text -> Text -> Text
-    -- ^ Customise the field accessors and lens names using the entity and field
-    -- name.  Both arguments are upper cased.
+    -- ^ Customise the field names (and lens names) for generated entity data types.
     --
-    -- Default: appends entity and field.
+    -- Default: simply appends entity name and field name, equivalent to
     --
-    -- Note: this setting is ignored if mpsPrefixFields is set to False.
+    -- @
+    -- mpsFieldLabelModifier = \\entityName fieldName -> entityName <> fieldName
+    -- @
+    --
+    -- to avoid duplicate record field collisions.
+    --
+    -- For example, with default 'sqlSettings' and
+    --
+    -- @
+    -- 'mkPersistWith' 'sqlSettings' [] ['persistLowerCase'|
+    --     Person
+    --         name   Text
+    --         age    Int
+    -- |]
+    -- @
+    --
+    -- it will generate the entity data type
+    --
+    -- @
+    -- Person {
+    --     personName :: Text,  -- generated field name
+    --     personAge  :: Int    -- generated field name
+    -- }
+    -- @
+    --
+    -- Note: this setting is ignored if the deprecated 'mpsPrefixFields' is set to False.
     --
     -- @since 2.11.0.0
+    --
+    -- === __Example without entity name__
+    --
+    -- You may not want the entity name prefix for all fields, so use
+    --
+    -- @
+    -- 'mkPersistWith' ('sqlSettings' { mpsFieldLabelModifier = \\\_entityName fieldName -> fieldName }) [] ['persistLowerCase'|
+    --     Person
+    --         name   Text
+    --         age    Int
+    -- |]
+    -- @
+    --
+    -- instead. This will generate the entity data type
+    --
+    -- @
+    -- Person {
+    --     name :: Text,
+    --     age  :: Int
+    -- }
+    -- @
+    --
+    -- When you have multiple entites with the same field name, you will need to
+    -- add '{-# LANGUAGE DuplicateRecordFields #-}' for your code to compile.
+    --
     , mpsAvoidHsKeyword :: Text -> Text
     -- ^ Customise function for field accessors applied only when the field name matches any of Haskell keywords.
     --
@@ -1102,7 +1153,7 @@ data MkPersistSettings = MkPersistSettings
     --
     -- Default: appends entity and field
     --
-    -- Note: this setting is ignored if mpsPrefixFields is set to False.
+    -- Note: this setting is ignored if the deprecated 'mpsPrefixFields' is set to False.
     --
     -- @since 2.11.0.0
     , mpsEntityHaddocks :: Bool

--- a/persistent/Database/Persist/TH/Internal.hs
+++ b/persistent/Database/Persist/TH/Internal.hs
@@ -1139,7 +1139,7 @@ data MkPersistSettings = MkPersistSettings
     -- @
     --
     -- When you have multiple entites with the same field name, you will need to
-    -- add '{-# LANGUAGE DuplicateRecordFields #-}' for your code to compile.
+    -- add @{-# LANGUAGE DuplicateRecordFields #-}@ for your code to compile.
     --
     , mpsAvoidHsKeyword :: Text -> Text
     -- ^ Customise function for field accessors applied only when the field name matches any of Haskell keywords.

--- a/persistent/Database/Persist/TH/Internal.hs
+++ b/persistent/Database/Persist/TH/Internal.hs
@@ -1086,7 +1086,7 @@ data MkPersistSettings = MkPersistSettings
     , mpsFieldLabelModifier :: Text -> Text -> Text
     -- ^ Customise the field names (and lens names) for generated entity data types.
     --
-    -- Default: simply appends entity name and field name, equivalent to
+    -- Default: appends entity name and field name, equivalent to
     --
     -- @
     -- mpsFieldLabelModifier = \\entityName fieldName -> entityName <> fieldName


### PR DESCRIPTION
I found the documentation for `mpsFieldLabelModifier` harder to understand than necessary. So let's fix it. A PR for `mpsConstraintLabelModifier` might follow.

Before submitting your PR, check that you've:

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [ ] Ran `fourmolu` on any changed files (`restyled` will do this for you, so
  accept the suggested changes if it makes them)
- [ ] Adhered to the code style (see the `.editorconfig` and `fourmolu.yaml` files for details)

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
