### PR TITLE
don't export Span from Types

### DIFF
--- a/persistent/Database/Persist/Types.hs
+++ b/persistent/Database/Persist/Types.hs
@@ -69,7 +69,6 @@ import Database.Persist.Types.Base
        , PersistValue(..)
        , ReferenceDef(..)
        , SqlType(..)
-       , Span(..)
        , UniqueDef(..)
        , UpdateException(..)
        , WhyNullable(..)

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -96,6 +96,7 @@ library
     Database.Persist.TH
     Database.Persist.TH.Internal
     Database.Persist.Types
+    Database.Persist.Types.Span
 
   other-modules:
     Database.Persist.Sql.Class
@@ -107,7 +108,6 @@ library
     Database.Persist.Sql.Run
     Database.Persist.Sql.Types
     Database.Persist.Types.Base
-    Database.Persist.Types.Span
 
   -- These modules only make sense for compilers with access to DerivingVia
   if impl(ghc >=8.6.1)

--- a/persistent/test/Database/Persist/THSpec.hs
+++ b/persistent/test/Database/Persist/THSpec.hs
@@ -45,6 +45,7 @@ import Test.QuickCheck.Gen (Gen)
 import Database.Persist
 import Database.Persist.EntityDef.Internal
 import Database.Persist.Quasi.Internal (SourceLoc(..), sourceLocFromTHLoc)
+import Database.Persist.Types.Span
 import Database.Persist.Sql
 import Database.Persist.Sql.Util
 import Database.Persist.TH


### PR DESCRIPTION
Per a conversation with @parsonsmatt, exposing `Span` externally was an unintentional change. It is used in spec, however, so this PR moves it into its own module.
 
---

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)