### PR TITLE
mongoDB: Use Specific Database for Authentication

### DIFF
--- a/persistent-mongoDB/ChangeLog.md
+++ b/persistent-mongoDB/ChangeLog.md
@@ -1,5 +1,8 @@
 # Changelog for persistent-mongoDB
 
+## 2.14.0.0
+* MongoDB authentication now allows specifying which database to authenticate against, which may be different from the database that one normally needs to access.
+
 ## 2.13.1.0
 
 * Restore update write concern behavior with MongoDB Driver for MongoDB >= 6.0 [#1550](https://github.com/yesodweb/persistent/pull/1550)

--- a/persistent-mongoDB/persistent-mongoDB.cabal
+++ b/persistent-mongoDB/persistent-mongoDB.cabal
@@ -1,5 +1,5 @@
 name:               persistent-mongoDB
-version:            2.13.1.0
+version:            2.14.0.0
 license:            MIT
 license-file:       LICENSE
 author:             Greg Weber <greg@gregweber.info>


### PR DESCRIPTION
Prior to this pull request, the database that is in primary use was required to also be the same database used for authentication. This pull request allows for the database for authentication to be used differently.

The above is necessary due to a user being tied to a specific database for authentication but may have access to multiple databases. [Documentation Here](https://www.mongodb.com/docs/manual/core/authorization/)

Since this is an API breaking change, the version has been bumped from 2.13.1.0 to 2.14.0.0.
