### PR TITLE
Demonstrate foreign reference bug

### DIFF
--- a/persistent/test/Database/Persist/TH/ForeignRefSpec.hs
+++ b/persistent/test/Database/Persist/TH/ForeignRefSpec.hs
@@ -86,10 +86,27 @@ ParentExplicit
 ChildExplicit
     name Text
     Foreign ParentExplicit OnDeleteCascade OnUpdateCascade fkparent name
+
+CustomIdReference
+    Id ForeignTargetId
+
 |]
 
 spec :: Spec
 spec = describe "ForeignRefSpec" $ do
+    describe "CustomIdReference" $ do
+        let
+            edef =
+                entityDef $ Proxy @CustomIdReference
+        it "should have a foreign reference" $ do
+            case getEntityId edef of
+                EntityIdField fieldDef ->
+                    fieldReference fieldDef
+                        `shouldBe`
+                            ForeignRef (EntityNameHS "ForeignTarget")
+                other ->
+                    fail $ "Expected EntityIdField, got: " <> show other
+
     describe "HasCustomName" $ do
         let
             edef =
@@ -98,9 +115,6 @@ spec = describe "ForeignRefSpec" $ do
             entityDB edef
                 `shouldBe`
                     EntityNameDB "custom_name"
-
-    it "should compile" $ do
-        True `shouldBe` True
 
     describe "ForeignPrimarySource" $ do
         let


### PR DESCRIPTION
It was discovered that the form:

```haskell
Table
    name Text

OtherTable
    Id TableId
```

does not properly generate foreign key references. This PR has a minimal test case reproducing and demonstrating this behavior.

---

Before submitting your PR, check that you've:

- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html)
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock
- [ ] Ran `fourmolu` on any changed files (`restyled` will do this for you, so
  accept the suggested changes if it makes them)
- [ ] Adhered to the code style (see the `.editorconfig` and `fourmolu.yaml` files for details)

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR
- [ ] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_-->
