### PR TITLE
Warn on quoted attributes

### DIFF
--- a/persistent-qq/test/PersistentTestModels.hs
+++ b/persistent-qq/test/PersistentTestModels.hs
@@ -38,7 +38,7 @@ share
     -- Indented comment
   Person json
     name Text
-    age Int "some ignored -- \" attribute"
+    age Int some="ignored -- \" attribute"
     color Text Maybe -- this is a comment sql=foobarbaz
     PersonNameKey name -- this is a comment sql=foobarbaz
     deriving Show Eq

--- a/persistent-sqlite/test1.hs
+++ b/persistent-sqlite/test1.hs
@@ -8,7 +8,7 @@ import Control.Monad.IO.Class
 mkPersist [$persist|
 Person sql=PersonTable
     name String update Eq Ne Desc In
-    age Int update "Asc" Lt "some ignored attribute"
+    age Int update Asc Lt someIgnoredAttribute
     color String null Eq Ne sql=mycolorfield NotIn Ge
     PersonNameKey name
 Pet

--- a/persistent-test/src/PersistentTestModels.hs
+++ b/persistent-test/src/PersistentTestModels.hs
@@ -30,7 +30,7 @@ share [mkPersist persistSettings { mpsGeneric = True },  mkMigrate "testMigrate"
     -- Indented comment
   Person json
     name Text
-    age Int "some ignored -- \" attribute"
+    age Int some="ignored -- \" attribute"
     color Text Maybe -- this is a comment sql=foobarbaz
     PersonNameKey name -- this is a comment sql=foobarbaz
     deriving Show Eq

--- a/persistent/Database/Persist/Quasi.hs
+++ b/persistent/Database/Persist/Quasi.hs
@@ -931,8 +931,8 @@ module Database.Persist.Quasi
     , setPsIdName
     , getPsTabErrorLevel
     , setPsTabErrorLevel
-    , getPsQuotedFieldAttributeErrorLevel
-    , setPsQuotedFieldAttributeErrorLevel
+    , getPsQuotedArgumentErrorLevel
+    , setPsQuotedArgumentErrorLevel
     ) where
 
 import Database.Persist.Quasi.PersistSettings

--- a/persistent/Database/Persist/Quasi.hs
+++ b/persistent/Database/Persist/Quasi.hs
@@ -186,7 +186,7 @@ User sql=big_user_table
 This will alter the generated SQL to be:
 
 @
-CREATE TABEL big_user_table (
+CREATE TABLE big_user_table (
     id      SERIAL PRIMARY KEY,
     name    VARCHAR,
     age     INT
@@ -784,9 +784,9 @@ check = do
 convert
     :: (Entity Vehicle, Maybe (Entity Bicycle), Maybe (Entity Car))
     -> Vehicle'
-convert (Entity _ (VehicycleBicycleSum _), Just (Entity _ (Bicycle brand)), _) =
+convert (Entity _ (VehicleBicycleSum _), Just (Entity _ (Bicycle brand)), _) =
     Bike brand
-convert (Entity _ (VehicycleCarSum _), _, Just (Entity _ (Car make model))) =
+convert (Entity _ (VehicleCarSum _), _, Just (Entity _ (Car make model))) =
     Car make model
 convert _ =
     error "The database preconditions have been violated!"
@@ -931,6 +931,8 @@ module Database.Persist.Quasi
     , setPsIdName
     , getPsTabErrorLevel
     , setPsTabErrorLevel
+    , getPsQuotedFieldAttributeErrorLevel
+    , setPsQuotedFieldAttributeErrorLevel
     ) where
 
 import Database.Persist.Quasi.PersistSettings

--- a/persistent/Database/Persist/Quasi/Internal.hs
+++ b/persistent/Database/Persist/Quasi/Internal.hs
@@ -16,7 +16,7 @@ module Database.Persist.Quasi.Internal
     , PersistSettings (..)
     , upperCaseSettings
     , lowerCaseSettings
-    , Token (..)
+    , Attribute (..)
     , SourceLoc (..)
     , sourceLocFromTHLoc
     , parseFieldType
@@ -206,7 +206,7 @@ entityNamesFromParsedDef ps parsedEntDef = (entNameHS, entNameDB)
             getDbName
                 ps
                 (unEntityNameHS entNameHS)
-                (parsedEntityDefEntityAttributes parsedEntDef)
+                (attributeContent <$> parsedEntityDefEntityAttributes parsedEntDef)
 
 -- | This type represents an @Id@ declaration in the QuasiQuoted syntax.
 --
@@ -527,12 +527,11 @@ mkUnboundEntityDef ps parsedEntDef =
                     EntityIdField $
                         maybe autoIdField (unboundIdDefToFieldDef (defaultIdName ps) entNameHS) idField
                 , entityAttrs =
-                    parsedEntityDefEntityAttributes parsedEntDef
-                , entityFields =
-                    []
+                    attributeContent <$> parsedEntityDefEntityAttributes parsedEntDef
+                , entityFields = []
                 , entityUniques = entityConstraintDefsUniquesList entityConstraintDefs
                 , entityForeigns = []
-                , entityDerives = concat $ mapMaybe takeDerives textAttribs
+                , entityDerives = concat $ mapMaybe takeDerives (textAttribs ++ textDirectives)
                 , entityExtra = parsedEntityDefExtras parsedEntDef
                 , entitySum = parsedEntityDefIsSum parsedEntDef
                 , entityComments =
@@ -546,19 +545,22 @@ mkUnboundEntityDef ps parsedEntDef =
     (entNameHS, entNameDB) =
         entityNamesFromParsedDef ps parsedEntDef
 
-    attribs =
-        parsedEntityDefFieldAttributes parsedEntDef
+    fields = parsedEntityDefFields parsedEntDef
+    directives = parsedEntityDefDirectives parsedEntDef
 
     cols :: [UnboundFieldDef]
-    cols = foldMap (toList . commentedField ps) attribs
+    cols = foldMap (toList . commentedField ps) fields
 
     textAttribs :: [[Text]]
-    textAttribs = fmap tokenContent . fst <$> attribs
+    textAttribs = entityFieldContent . fst <$> fields
+
+    textDirectives :: [[Text]]
+    textDirectives = directiveContent . fst <$> directives
 
     entityConstraintDefs =
         foldMap
             (maybe mempty (takeConstraint ps entNameHS cols) . NEL.nonEmpty)
-            textAttribs
+            (textAttribs ++ textDirectives)
 
     idField =
         case entityConstraintDefsIdField entityConstraintDefs of
@@ -574,10 +576,10 @@ mkUnboundEntityDef ps parsedEntDef =
 
     commentedField
         :: PersistSettings
-        -> ([Token], Maybe Text)
+        -> (EntityField, Maybe Text)
         -> Maybe UnboundFieldDef
-    commentedField s (tokens, mCommentText) = do
-        unb <- takeColsEx s (tokenContent <$> tokens)
+    commentedField s (field, mCommentText) = do
+        unb <- takeColsEx s (entityFieldContent field)
         pure $ unb{unboundFieldComments = mCommentText}
 
     autoIdField :: FieldDef

--- a/persistent/Database/Persist/Quasi/Internal/ModelParser.hs
+++ b/persistent/Database/Persist/Quasi/Internal/ModelParser.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -5,23 +6,20 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TupleSections #-}
-{-# LANGUAGE CPP #-}
 
 module Database.Persist.Quasi.Internal.ModelParser
     ( SourceLoc (..)
-    , Token (..)
-    , tokenContent
-    , anyToken
-    , ParsedEntityDef
-    , parsedEntityDefComments
-    , parsedEntityDefEntityName
-    , parsedEntityDefIsSum
-    , parsedEntityDefEntityAttributes
-    , parsedEntityDefFieldAttributes
-    , parsedEntityDefExtras
-    , parsedEntityDefSpan
+    , Attribute (..)
+    , attribute
+    , attributeContent
+    , Directive (..)
+    , directiveContent
+    , EntityField (..)
+    , entityField
+    , entityFieldContent
+    , ParsedEntityDef (..)
     , parseSource
-    , memberBlockAttrs
+    , memberEntityFields
     , ParserWarning
     , parserWarningMessage
     , ParseResult
@@ -34,7 +32,7 @@ module Database.Persist.Quasi.Internal.ModelParser
     ) where
 
 import Control.Applicative (Alternative)
-import Control.Monad (MonadPlus, mzero, void)
+import Control.Monad (MonadPlus, void, when)
 import Control.Monad.Reader (MonadReader, ReaderT, asks, runReaderT)
 import Control.Monad.State
 import Control.Monad.Writer
@@ -42,7 +40,7 @@ import Data.Char (isSpace)
 import Data.Either (partitionEithers)
 import Data.Foldable (fold)
 import Data.Functor.Identity
-import Data.List (find, intercalate)
+import Data.List (intercalate)
 import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NEL
 import qualified Data.Map as M
@@ -52,11 +50,12 @@ import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as Text
 import Data.Void
+import Database.Persist.Quasi.Internal.TypeParser
 import Database.Persist.Quasi.PersistSettings.Internal
 import Database.Persist.Types
 import Database.Persist.Types.SourceSpan
 import Language.Haskell.TH.Syntax (Lift)
-import Text.Megaparsec hiding (Token)
+import Text.Megaparsec
 import Text.Megaparsec.Char
 import qualified Text.Megaparsec.Char.Lexer as L
 import qualified Text.Megaparsec.Stream as TMS
@@ -101,6 +100,7 @@ newtype Parser a = Parser
         , MonadState ExtraState
         , MonadReader PersistSettings
         , MonadParsec Void String
+        , MonadFail
         )
 
 type EntityParseError = ParseErrorBundle String Void
@@ -211,19 +211,18 @@ tryOrWarn msg p l r = do
             else parseError err
 
 -- | Attempts to parse with a provided parser. If it fails with an error matching
--- the provided predicate, it registers a delayed error with the provided message and falls
+-- the provided predicate, it registers a delayed error and falls
 -- back to the second provided parser.
 --
 -- This is useful when registering errors in space consumers and other parsers that are called
 -- with `try`, since a non-delayed error in this context will cause backtracking and not
 -- get reported to the user.
 tryOrRegisterError
-    :: String
-    -> (ParseError String Void -> Bool)
+    :: (ParseError String Void -> Bool)
     -> Parser a
     -> Parser a
     -> Parser a
-tryOrRegisterError msg p l r = do
+tryOrRegisterError p l r = do
     parserState <- getParserState
     withRecovery (delayedError $ statePosState parserState) l
   where
@@ -244,7 +243,7 @@ tryOrReport
     -> Parser a
     -> Parser a
 tryOrReport level msg p l r = case level of
-    Just LevelError -> tryOrRegisterError msg p l r
+    Just LevelError -> tryOrRegisterError p l r
     Just LevelWarning -> tryOrWarn msg p l r
     Nothing -> r
 
@@ -258,36 +257,105 @@ data SourceLoc = SourceLoc
     }
     deriving (Show, Lift)
 
--- @since 2.16.0.0
-data Token
-    = Quotation Text
-    | Equality Text Text
+-- | An attribute of an entity field definition.
+--
+-- @since 2.17.1.0
+data Attribute
+    = Assignment Text Text
     | Parenthetical Text
-    | BlockKey Text
     | PText Text
+    | -- | Quoted field attributes are deprecated since 2.17.1.0.
+      Quotation Text
     deriving (Eq, Ord, Show)
 
+-- | The name of an entity block or extra block.
+--
+-- @since 2.17.1.0
+newtype BlockKey = BlockKey Text
+    deriving (Show)
+
+-- | A parsed comment or doc comment.
+--
 -- @since 2.16.0.0
 data CommentToken
     = DocComment Text
     | Comment Text
     deriving (Eq, Ord, Show)
 
--- | Converts a token into a Text representation for second-stage parsing or presentation to the user
+-- | Converts an attribute into a Text representation for second-stage parsing or
+-- presentation to the user
 --
 -- @since 2.16.0.0
-tokenContent :: Token -> Text
-tokenContent = \case
-    Quotation s -> s
-    Equality l r -> mconcat [l, "=", r]
+attributeContent :: Attribute -> Text
+attributeContent = \case
+    Assignment l r -> mconcat [l, "=", r]
     Parenthetical s -> s
     PText s -> s
-    BlockKey s -> s
+    Quotation s -> s
+
+-- | Converts a directive into a Text representation for second-stage parsing or
+-- presentation to the user
+--
+-- @since 2.17.1.0
+directiveContent :: Directive -> [Text]
+directiveContent = fmap Text.pack . directiveTokens
+
+entityFieldContent :: EntityField -> [Text]
+entityFieldContent f =
+    [ fieldNameAndStrictnessAsText f
+    , (typeExprContent . entityFieldType) f
+    ]
+        ++ fmap attributeContent (entityFieldAttributes f)
+
+blockKeyContent :: BlockKey -> Text
+blockKeyContent (BlockKey t) = t
+
+-- | Generates the field name of an EntityField, accompanied by
+-- its strictness sigil, if one is present.
+-- This is only needed temporarily, and can eventually be refactored away.
+fieldNameAndStrictnessAsText :: EntityField -> Text
+fieldNameAndStrictnessAsText f =
+    let
+        s = case entityFieldStrictness f of
+            Just Strict -> "!"
+            Just Lazy -> "~"
+            Nothing -> ""
+        (FieldName fn) = entityFieldName f
+     in
+        s <> fn
 
 commentContent :: CommentToken -> Text
 commentContent = \case
     Comment s -> s
     DocComment s -> s
+
+quotedAttributeErrorMessage :: String
+quotedAttributeErrorMessage = "Unexpected quotation mark in entity field attribute"
+
+attribute :: Parser Attribute
+attribute = do
+    quotedFieldAttributeErrorLevel <- asks psQuotedFieldAttributeErrorLevel
+    tryOrReport
+        quotedFieldAttributeErrorLevel
+        "Quoted attributes are deprecated."
+        isQuotedAttributeError
+        attribute'
+        (Quotation . Text.pack <$> quotation)
+  where
+    isQuotedAttributeError (FancyError _ s) = s == Set.singleton (ErrorFail quotedAttributeErrorMessage)
+    isQuotedAttributeError _ = False
+
+attribute' :: Parser Attribute
+attribute' = do
+    q <- lookAhead (optional $ char '"')
+    case q of
+        Just _ -> fail quotedAttributeErrorMessage
+        Nothing ->
+            choice
+                [ try assignment
+                , parenthetical
+                , ptext
+                ]
 
 docComment :: Parser (SourcePos, CommentToken)
 docComment = do
@@ -365,6 +433,9 @@ spaceConsumerN =
         skipComment
         empty
 
+-- This catch-all character class is used in a variety of places, and includes characters
+-- which have syntactic function. As we continue to iterate on the parser, we may want to consider
+-- shrinking or eliminating `contentChar`.
 contentChar :: Parser Char
 contentChar =
     choice
@@ -408,19 +479,19 @@ charLiteral = label "literal character" $ do
                 _ -> unexpected (Tokens $ char2 :| [])
         _ -> pure char1
 
-equality :: Parser Token
-equality = label "equality expression" $ do
+assignment :: Parser Attribute
+assignment = label "assignment expression" $ do
     L.lexeme spaceConsumer $ do
         lhs <- some contentChar
         _ <- char '='
         rhs <-
             choice
-                [ quotation'
+                [ quotation
                 , sqlLiteral
                 , parentheticalInner
                 , some $ contentChar <|> char '(' <|> char ')'
                 ]
-        pure $ Equality (Text.pack lhs) (Text.pack rhs)
+        pure $ Assignment (Text.pack lhs) (Text.pack rhs)
   where
     parentheticalInner = do
         str <- parenthetical'
@@ -449,15 +520,10 @@ sqlLiteral = label "SQL literal" $ do
             , fromMaybe "" st
             ]
 
-quotation :: Parser Token
-quotation = label "quotation" $ do
-    str <- L.lexeme spaceConsumer quotation'
-    pure . Quotation $ Text.pack str
+quotation :: Parser String
+quotation = char '"' *> manyTill charLiteral (char '"')
 
-quotation' :: Parser String
-quotation' = char '"' *> manyTill charLiteral (char '"')
-
-parenthetical :: Parser Token
+parenthetical :: Parser Attribute
 parenthetical = label "parenthetical" $ do
     str <- L.lexeme spaceConsumer parenthetical'
     pure . Parenthetical . Text.pack . init . drop 1 $ str
@@ -470,33 +536,41 @@ parenthetical' = do
     q = mconcat <$> some (c <|> parenthetical')
     c = (: []) <$> choice [contentChar, nonLineSpaceChar, char '"']
 
-blockKey :: Parser Token
+blockKey :: Parser BlockKey
 blockKey = label "block key" $ do
     fl <- upperChar
     rl <- many alphaNumChar
     pure . BlockKey . Text.pack $ fl : rl
 
-ptext :: Parser Token
-ptext = label "plain token" $ do
-    str <- L.lexeme spaceConsumer $ some contentChar
-    pure . PText . Text.pack $ str
+fieldStrictness :: Parser FieldStrictness
+fieldStrictness = label "strictness sigil" $ do
+    c <- char '!' <|> char '~'
+    case c of
+        '!' -> pure Strict
+        '~' -> pure Lazy
+        _ -> error "unreachable"
 
--- @since 2.16.0.0
-anyToken :: Parser Token
-anyToken =
-    choice
-        [ try equality
-        , quotation
-        , parenthetical
-        , ptext
-        ]
+fieldName :: Parser FieldName
+fieldName = label "field name" $ do
+    fl <- lowerChar
+    rl <- many alphaNumChar
+    pure . FieldName . Text.pack $ fl : rl
+
+ptext :: Parser Attribute
+ptext = label "plain attribute" $ do
+    str <- L.lexeme spaceConsumer $ do
+        first <- alphaNumChar
+        rest <- many contentChar
+        pure (first : rest)
+    pure . PText . Text.pack $ str
 
 data ParsedEntityDef = ParsedEntityDef
     { parsedEntityDefComments :: [Text]
     , parsedEntityDefEntityName :: EntityNameHS
     , parsedEntityDefIsSum :: Bool
-    , parsedEntityDefEntityAttributes :: [Attr]
-    , parsedEntityDefFieldAttributes :: [([Token], Maybe Text)]
+    , parsedEntityDefEntityAttributes :: [Attribute]
+    , parsedEntityDefFields :: [(EntityField, Maybe Text)]
+    , parsedEntityDefDirectives :: [(Directive, Maybe Text)]
     , parsedEntityDefExtras :: M.Map Text [ExtraLine]
     , parsedEntityDefSpan :: Maybe SourceSpan
     }
@@ -511,7 +585,7 @@ data DocCommentBlock = DocCommentBlock
 data EntityHeader = EntityHeader
     { entityHeaderSum :: Bool
     , entityHeaderTableName :: Text
-    , entityHeaderRemainingTokens :: [Token]
+    , entityHeaderRemainingAttributes :: [Attribute]
     , entityHeaderPos :: SourcePos
     }
     deriving (Show)
@@ -531,23 +605,33 @@ entityBlockLastPos eb = case entityBlockMembers eb of
     [] -> entityBlockFirstPos eb
     members -> maximum $ fmap memberEndPos members
 
-entityBlockBlockAttrs :: EntityBlock -> [BlockAttr]
-entityBlockBlockAttrs = foldMap f <$> entityBlockMembers
+entityBlockEntityFields :: EntityBlock -> [EntityField]
+entityBlockEntityFields = foldMap f <$> entityBlockMembers
   where
     f m = case m of
         MemberExtraBlock _ -> []
-        MemberBlockAttr ba -> [ba]
+        MemberEntityField ba -> [ba]
+        MemberDirective _ -> []
 
 entityBlockExtraBlocks :: EntityBlock -> [ExtraBlock]
 entityBlockExtraBlocks = foldMap f <$> entityBlockMembers
   where
     f m = case m of
         MemberExtraBlock eb -> [eb]
-        MemberBlockAttr _ -> []
+        MemberEntityField _ -> []
+        MemberDirective _ -> []
+
+entityBlockDirectives :: EntityBlock -> [Directive]
+entityBlockDirectives = foldMap f <$> entityBlockMembers
+  where
+    f m = case m of
+        MemberExtraBlock _ -> []
+        MemberEntityField _ -> []
+        MemberDirective bd -> [bd]
 
 data ExtraBlockHeader = ExtraBlockHeader
     { extraBlockHeaderKey :: Text
-    , extraBlockHeaderRemainingTokens :: [Token]
+    , extraBlockHeaderRemainingAttributes :: [Attribute]
     , extraBlockHeaderPos :: SourcePos
     }
     deriving (Show)
@@ -555,53 +639,82 @@ data ExtraBlockHeader = ExtraBlockHeader
 data ExtraBlock = ExtraBlock
     { extraBlockDocCommentBlock :: Maybe DocCommentBlock
     , extraBlockExtraBlockHeader :: ExtraBlockHeader
-    , extraBlockMembers :: NonEmpty Member
+    , extraBlockLines :: NonEmpty ExtraBlockLine
     }
     deriving (Show)
 
-data BlockAttr = BlockAttr
-    { blockAttrDocCommentBlock :: Maybe DocCommentBlock
-    , blockAttrTokens :: [Token]
-    , blockAttrPos :: SourcePos
+data FieldStrictness = Strict | Lazy
+    deriving (Show)
+
+newtype FieldName = FieldName Text
+    deriving (Show)
+
+data EntityField = EntityField
+    { entityFieldDocCommentBlock :: Maybe DocCommentBlock
+    , entityFieldStrictness :: Maybe FieldStrictness
+    , entityFieldName :: FieldName
+    , entityFieldType :: TypeExpr
+    , entityFieldAttributes :: [Attribute]
+    , entityFieldPos :: SourcePos
     }
     deriving (Show)
 
-data Member = MemberExtraBlock ExtraBlock | MemberBlockAttr BlockAttr
+data Directive = Directive
+    { directiveDocCommentBlock :: Maybe DocCommentBlock
+    , directiveTokens :: [String]
+    , directivePos :: SourcePos
+    }
+    deriving (Show)
+
+data Member
+    = MemberExtraBlock ExtraBlock
+    | MemberEntityField EntityField
+    | MemberDirective Directive
+    deriving (Show)
+
+data ExtraBlockLine = ExtraBlockLine
+    { extraBlockLineDocCommentBlock :: Maybe DocCommentBlock
+    , extraBlockLineTokens :: [String]
+    , extraBlockLinePos :: SourcePos
+    }
     deriving (Show)
 
 -- | The source position at the beginning of the member's final line.
 memberEndPos :: Member -> SourcePos
-memberEndPos (MemberBlockAttr fs) = blockAttrPos fs
-memberEndPos (MemberExtraBlock ex) = memberEndPos . NEL.last . extraBlockMembers $ ex
+memberEndPos (MemberEntityField fs) = entityFieldPos fs
+memberEndPos (MemberDirective d) = directivePos d
+memberEndPos (MemberExtraBlock ex) = extraBlockLinePos . NEL.last . extraBlockLines $ ex
 
--- | Represents an entity member as a list of BlockAttrs
+-- | Represents an entity member as a list of EntityFields
 --
 -- @since 2.16.0.0
-memberBlockAttrs :: Member -> [BlockAttr]
-memberBlockAttrs (MemberBlockAttr fs) = [fs]
-memberBlockAttrs (MemberExtraBlock ex) = foldMap memberBlockAttrs . extraBlockMembers $ ex
+memberEntityFields :: Member -> [EntityField]
+memberEntityFields (MemberEntityField fs) = [fs]
+memberEntityFields (MemberDirective _) = []
+memberEntityFields (MemberExtraBlock _) = []
 
 extraBlocksAsMap :: [ExtraBlock] -> M.Map Text [ExtraLine]
 extraBlocksAsMap exs = M.fromList $ fmap asPair exs
   where
     asPair ex =
-        (extraBlockHeaderKey . extraBlockExtraBlockHeader $ ex, extraLines ex)
-    extraLines ex = foldMap asExtraLine (extraBlockMembers ex)
-    asExtraLine (MemberBlockAttr fs) = [tokenContent <$> blockAttrTokens fs]
-    asExtraLine _ = []
+        ( extraBlockHeaderKey . extraBlockExtraBlockHeader $ ex
+        , NEL.toList (extraLines ex)
+        )
+    extraLines :: ExtraBlock -> NonEmpty [Text]
+    extraLines ex = fmap Text.pack . extraBlockLineTokens <$> extraBlockLines ex
 
 entityHeader :: Parser EntityHeader
 entityHeader = do
     pos <- getSourcePos
     plus <- optional (char '+')
     en <- validHSpace *> L.lexeme spaceConsumer blockKey
-    rest <- L.lexeme spaceConsumer (many anyToken)
+    rest <- L.lexeme spaceConsumer (many attribute)
     _ <- setLastDocumentablePosition
     pure
         EntityHeader
             { entityHeaderSum = isJust plus
-            , entityHeaderTableName = tokenContent en
-            , entityHeaderRemainingTokens = rest
+            , entityHeaderTableName = blockKeyContent en
+            , entityHeaderRemainingAttributes = rest
             , entityHeaderPos = pos
             }
 
@@ -627,7 +740,7 @@ getDcb = do
     let
         candidates = dropWhile (\(_sp, ct) -> not (isDocComment ct)) comments
         filteredCandidates = dropWhile (commentIsIncorrectlyPositioned es) candidates
-    pure $ docCommentBlockFromPositionedTokens filteredCandidates
+    pure $ docCommentBlockFromPositionedAttributes filteredCandidates
   where
     commentIsIncorrectlyPositioned
         :: ExtraState -> (SourcePos, CommentToken) -> Bool
@@ -638,51 +751,117 @@ getDcb = do
 extraBlock :: Parser Member
 extraBlock = L.indentBlock spaceConsumerN innerParser
   where
-    mkExtraBlockMember dcb (header, blockAttrs) =
+    mkExtraBlockMember dcb (header, extraBlockLines) =
         MemberExtraBlock
             ExtraBlock
                 { extraBlockExtraBlockHeader = header
-                , extraBlockMembers = ensureNonEmpty blockAttrs
+                , extraBlockLines = ensureNonEmpty extraBlockLines
                 , extraBlockDocCommentBlock = dcb
                 }
-    ensureNonEmpty members = case NEL.nonEmpty members of
+    ensureNonEmpty lines = case NEL.nonEmpty lines of
         Just nel -> nel
-        Nothing -> error "unreachable" -- members is known to be non-empty
+        Nothing -> error "unreachable" -- lines is known to be non-empty
     innerParser = do
         dcb <- getDcb
         header <- extraBlockHeader
         pure $
-            L.IndentSome Nothing (return . mkExtraBlockMember dcb . (header,)) blockAttr
+            L.IndentSome
+                Nothing
+                (return . mkExtraBlockMember dcb . (header,))
+                extraBlockLine
 
 extraBlockHeader :: Parser ExtraBlockHeader
 extraBlockHeader = do
     pos <- getSourcePos
     tn <- L.lexeme spaceConsumer blockKey
-    rest <- L.lexeme spaceConsumer (many anyToken)
+    rest <- L.lexeme spaceConsumer (many attribute)
     _ <- setLastDocumentablePosition
     pure $
         ExtraBlockHeader
-            { extraBlockHeaderKey = tokenContent tn
-            , extraBlockHeaderRemainingTokens = rest
+            { extraBlockHeaderKey = blockKeyContent tn
+            , extraBlockHeaderRemainingAttributes = rest
             , extraBlockHeaderPos = pos
             }
 
-blockAttr :: Parser Member
-blockAttr = do
+extraBlockLine :: Parser ExtraBlockLine
+extraBlockLine = do
     dcb <- getDcb
     pos <- getSourcePos
-    line <- some anyToken
+    tokens <- some $ L.lexeme spaceConsumer (some contentChar)
     _ <- setLastDocumentablePosition
     pure $
-        MemberBlockAttr
-            BlockAttr
-                { blockAttrDocCommentBlock = dcb
-                , blockAttrTokens = line
-                , blockAttrPos = pos
+        ExtraBlockLine
+            { extraBlockLineDocCommentBlock = dcb
+            , extraBlockLineTokens = tokens
+            , extraBlockLinePos = pos
+            }
+
+entityField :: Parser Member
+entityField = do
+    dcb <- getDcb
+    pos <- getSourcePos
+    ss <- optional fieldStrictness
+    fn <- L.lexeme spaceConsumer fieldName
+    ft <- L.lexeme spaceConsumer typeExpr -- Note that `typeExpr` consumes outer parentheses.
+    fa <- optional $ L.lexeme spaceConsumer (many attribute)
+    _ <- setLastDocumentablePosition
+    lookAhead (void newline <|> eof)
+    pure $
+        MemberEntityField
+            EntityField
+                { entityFieldDocCommentBlock = dcb
+                , entityFieldStrictness = ss
+                , entityFieldName = fn
+                , entityFieldType = ft
+                , entityFieldAttributes = fromMaybe [] fa
+                , entityFieldPos = pos
+                }
+
+directiveName :: Parser String
+directiveName =
+    label "directive name" $
+        choice
+            [ string "deriving"
+            , directiveName'
+            ]
+  where
+    directiveName' = do
+        fl <- upperChar
+        rl <- many alphaNumChar
+        pure (fl : rl)
+
+-- Parses an argument to an entity definition directive. It's somewhat naive about it,
+-- and we should refine this in the future.
+directiveArgument :: Parser String
+directiveArgument =
+    choice
+        [ parenthetical'
+        , some $ contentChar <|> char '='
+        ]
+
+directive :: Parser Member
+directive = do
+    dcb <- getDcb
+    pos <- getSourcePos
+    dn <- L.lexeme spaceConsumer directiveName
+    args <- some $ L.lexeme spaceConsumer directiveArgument
+    _ <- setLastDocumentablePosition
+    lookAhead (void newline <|> eof)
+    pure $
+        MemberDirective
+            Directive
+                { directiveDocCommentBlock = dcb
+                , directiveTokens = dn : args
+                , directivePos = pos
                 }
 
 member :: Parser Member
-member = try extraBlock <|> blockAttr
+member =
+    choice
+        [ try extraBlock
+        , directive
+        , entityField
+        ]
 
 entityBlock :: Parser EntityBlock
 entityBlock = do
@@ -710,9 +889,9 @@ isDocComment tok = case tok of
     DocComment _ -> True
     _ -> False
 
-docCommentBlockFromPositionedTokens
+docCommentBlockFromPositionedAttributes
     :: [(SourcePos, CommentToken)] -> Maybe DocCommentBlock
-docCommentBlockFromPositionedTokens ptoks =
+docCommentBlockFromPositionedAttributes ptoks =
     case NEL.nonEmpty ptoks of
         Nothing -> Nothing
         Just nel ->
@@ -744,7 +923,8 @@ toParsedEntityDef mSourceLoc eb =
         , parsedEntityDefEntityName = entityNameHS
         , parsedEntityDefIsSum = isSum
         , parsedEntityDefEntityAttributes = entityAttributes
-        , parsedEntityDefFieldAttributes = parsedFieldAttributes
+        , parsedEntityDefFields = parsedFields
+        , parsedEntityDefDirectives = parsedDirectives
         , parsedEntityDefExtras = extras
         , parsedEntityDefSpan = mSpan
         }
@@ -754,13 +934,15 @@ toParsedEntityDef mSourceLoc eb =
             []
             docCommentBlockLines
             (entityBlockDocCommentBlock eb)
-    entityAttributes =
-        tokenContent <$> (entityHeaderRemainingTokens . entityBlockEntityHeader) eb
+    entityAttributes = entityHeaderRemainingAttributes . entityBlockEntityHeader $ eb
     isSum = entityHeaderSum . entityBlockEntityHeader $ eb
     entityNameHS = EntityNameHS . entityHeaderTableName . entityBlockEntityHeader $ eb
 
-    attributePair a = (blockAttrTokens a, docCommentBlockText <$> blockAttrDocCommentBlock a)
-    parsedFieldAttributes = fmap attributePair (entityBlockBlockAttrs eb)
+    fieldPair a = (a, docCommentBlockText <$> entityFieldDocCommentBlock a)
+    parsedFields = fmap fieldPair (entityBlockEntityFields eb)
+
+    directivePair d = (d, docCommentBlockText <$> directiveDocCommentBlock d)
+    parsedDirectives = fmap directivePair (entityBlockDirectives eb)
 
     extras = extraBlocksAsMap (entityBlockExtraBlocks eb)
     filepath = maybe "" locFile mSourceLoc

--- a/persistent/Database/Persist/Quasi/Internal/ModelParser.hs
+++ b/persistent/Database/Persist/Quasi/Internal/ModelParser.hs
@@ -268,6 +268,16 @@ data Attribute
       Quotation Text
     deriving (Eq, Ord, Show)
 
+-- | An argument to an entity field directive.
+--
+-- @since 2.17.1.0
+data DirectiveArgument
+    = -- This is too unstructured. We should rework directive parsing and make this smarter.
+      DText Text
+    | -- | Quoted directive arguments are deprecated since 2.17.1.0.
+      DQuotation Text
+    deriving (Eq, Ord, Show)
+
 -- | The name of an entity block or extra block.
 --
 -- @since 2.17.1.0
@@ -298,7 +308,7 @@ attributeContent = \case
 --
 -- @since 2.17.1.0
 directiveContent :: Directive -> [Text]
-directiveContent = fmap Text.pack . directiveTokens
+directiveContent d = directiveArgumentContent <$> directiveArguments d
 
 entityFieldContent :: EntityField -> [Text]
 entityFieldContent f =
@@ -313,6 +323,8 @@ blockKeyContent (BlockKey t) = t
 -- | Generates the field name of an EntityField, accompanied by
 -- its strictness sigil, if one is present.
 -- This is only needed temporarily, and can eventually be refactored away.
+--
+-- @since 2.17.1.0
 fieldNameAndStrictnessAsText :: EntityField -> Text
 fieldNameAndStrictnessAsText f =
     let
@@ -334,10 +346,10 @@ quotedAttributeErrorMessage = "Unexpected quotation mark in entity field attribu
 
 attribute :: Parser Attribute
 attribute = do
-    quotedFieldAttributeErrorLevel <- asks psQuotedFieldAttributeErrorLevel
+    quotedFieldAttributeErrorLevel <- asks psQuotedArgumentErrorLevel
     tryOrReport
         quotedFieldAttributeErrorLevel
-        "Quoted attributes are deprecated."
+        "Quoted field attributes are deprecated since 2.17.1.0, and will be removed in or after 2.18.0.0"
         isQuotedAttributeError
         attribute'
         (Quotation . Text.pack <$> quotation)
@@ -661,7 +673,7 @@ data EntityField = EntityField
 
 data Directive = Directive
     { directiveDocCommentBlock :: Maybe DocCommentBlock
-    , directiveTokens :: [String]
+    , directiveArguments :: [DirectiveArgument]
     , directivePos :: SourcePos
     }
     deriving (Show)
@@ -830,14 +842,65 @@ directiveName =
         rl <- many alphaNumChar
         pure (fl : rl)
 
+quotedArgumentErrorMessage :: String
+quotedArgumentErrorMessage = "Unexpected quotation mark in directive argument"
+
 -- Parses an argument to an entity definition directive. It's somewhat naive about it,
 -- and we should refine this in the future.
-directiveArgument :: Parser String
-directiveArgument =
-    choice
-        [ parenthetical'
-        , some $ contentChar <|> char '='
-        ]
+directiveArgument :: Parser DirectiveArgument
+directiveArgument = do
+    quotedArgumentErrorLevel <- asks psQuotedArgumentErrorLevel
+    tryOrReport
+        quotedArgumentErrorLevel
+        "Quoted directive arguments are deprecated since 2.17.1.0, and will be removed in or after 2.18.0.0"
+        isQuotedArgumentError
+        directiveArgument'
+        (DQuotation . Text.pack <$> quotation)
+  where
+    isQuotedArgumentError (FancyError _ s) = s == Set.singleton (ErrorFail quotedArgumentErrorMessage)
+    isQuotedArgumentError _ = False
+    directiveArgument' = do
+        q <- lookAhead (optional $ char '"')
+        case q of
+            Just _ -> fail quotedArgumentErrorMessage
+            Nothing ->
+                choice
+                    [ DText . Text.pack <$> parenthetical'
+                    , DText . Text.pack <$> some directiveArgumentChar
+                    ]
+    -- This big random-looking character class is a sign that the parser is too lax.
+    -- When we improve directive parsing, we'll eliminate this.
+    -- Note that this character class is not identical to the class parsed by the top-level function `contentChar`.
+    directiveArgumentChar =
+        choice
+            [ alphaNumChar
+            , char '.'
+            , char '['
+            , char ']'
+            , char '_'
+            , char '\''
+            , char '!'
+            , char '~'
+            , char '-'
+            , char ':'
+            , char ','
+            , char '='
+            , do
+                backslash <- char '\\'
+                nextChar <- lookAhead anySingle
+                if nextChar == '(' || nextChar == ')'
+                    then single nextChar
+                    else pure backslash
+            ]
+
+-- | Converts a directive argument into a Text representation for second-stage
+-- parsing or presentation to the user
+--
+-- @since 2.17.1.0
+directiveArgumentContent :: DirectiveArgument -> Text
+directiveArgumentContent = \case
+    DText t -> t
+    DQuotation t -> t
 
 directive :: Parser Member
 directive = do
@@ -851,7 +914,7 @@ directive = do
         MemberDirective
             Directive
                 { directiveDocCommentBlock = dcb
-                , directiveTokens = dn : args
+                , directiveArguments = DText (Text.pack dn) : args
                 , directivePos = pos
                 }
 

--- a/persistent/Database/Persist/Quasi/Internal/TypeParser.hs
+++ b/persistent/Database/Persist/Quasi/Internal/TypeParser.hs
@@ -1,0 +1,179 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Database.Persist.Quasi.Internal.TypeParser
+    ( TypeExpr (..)
+    , TypeConstructor (..)
+    , typeExpr
+    , innerTypeExpr
+    , typeExprContent
+    ) where
+
+import Data.Text (Text)
+import qualified Data.Text as T
+import Text.Megaparsec
+import Text.Megaparsec.Char
+import qualified Text.Megaparsec.Char.Lexer as L
+
+-- | A parsed type expression.
+--
+-- @since 2.17.1.0
+data TypeExpr
+    = TypeApplication TypeExpr [TypeExpr]
+    | TypeConstructorExpr TypeConstructor
+    | TypeLitString String
+    | TypeLitInt String
+    | TypeLitPromotedConstructor TypeConstructor
+    deriving (Show, Eq)
+
+-- | A parsed type constructor.
+--
+-- @since 2.17.1.0
+data TypeConstructor
+    = ListConstructor
+    | TypeConstructor String
+    deriving (Show, Eq)
+
+-- | Parses a Persistent-style type expression.
+-- Persistent's type expressions are largely similar to Haskell's, but with a few differences:
+--
+-- 1. Syntactic sugar is not currently supported for constructing types other than List.
+-- 2. Only certain typelevel literals are supported: Strings, Ints, and promoted type constructors.
+-- 3. Because they must be parsed as part of an entity field definition, top-level applications
+--    of non-nullary type constructors (except for the sugary List constructor) must
+--    be parenthesized.
+--
+--    VALID:    Int
+--    VALID:    [Maybe Int]
+--    VALID:    (Maybe Int)
+--    INVALID:  Maybe Int
+--
+-- @since 2.17.1.0
+typeExpr :: ((MonadParsec e String) m) => m TypeExpr
+typeExpr = typeExpr' False
+
+-- | Parses a type expression in non-top-level contexts, where an unparenthesized type constructor
+-- application is acceptable.
+--
+-- @since 2.17.1.0
+innerTypeExpr :: ((MonadParsec e String) m) => m TypeExpr
+innerTypeExpr = typeExpr' True
+
+typeExpr' :: ((MonadParsec e String) m) => Bool -> m TypeExpr
+typeExpr' isInner = label "type expression" $ do
+    let
+        validEmbeddedApplications =
+            if isInner
+                then
+                    [ simpleTypeApplication
+                    , complexTypeApplication
+                    ]
+                else [nullaryTypeApplication]
+    choice $
+        validEmbeddedApplications
+            ++ [ whitespaceBetween '(' ')' innerTypeExpr
+               , listType
+               , typeLitPromotedConstructor
+               , typeLitString
+               , typeLitInt
+               ]
+  where
+    -- This is a proper subset of `simpleTypeApplication`.
+    nullaryTypeApplication :: ((MonadParsec e String) m) => m TypeExpr
+    nullaryTypeApplication = do
+        tc <- typeConstructor <* optional hspace
+        pure $ TypeApplication (TypeConstructorExpr tc) []
+
+-- This does not parse sugary constructors such as the List constructor `[]`.
+typeConstructor :: ((MonadParsec e String) m) => m TypeConstructor
+typeConstructor = do
+    first <- upperChar
+    rest <- many $ choice [alphaNumChar, char '.', char '\'']
+    pure $ TypeConstructor (first : rest)
+
+whitespaceBetween :: ((MonadParsec e String) m) => Char -> Char -> m a -> m a
+whitespaceBetween ldelim rdelim =
+    between (char ldelim *> optional hspace) (optional hspace *> char rdelim)
+
+complexTypeApplication :: ((MonadParsec e String) m) => m TypeExpr
+complexTypeApplication = do
+    t <- whitespaceBetween '(' ')' innerTypeExpr <* hspace
+    args <- some (typeExpr <* optional hspace)
+    pure $ TypeApplication t args
+
+simpleTypeApplication :: ((MonadParsec e String) m) => m TypeExpr
+simpleTypeApplication = do
+    tc <- typeConstructor <* optional hspace
+    args <- many (typeExpr <* optional hspace)
+    pure $ TypeApplication (TypeConstructorExpr tc) args
+
+typeLitString :: ((MonadParsec e String) m) => m TypeExpr
+typeLitString = do
+    s <- char '"' *> manyTill L.charLiteral (char '"')
+    pure $ TypeLitString s
+
+typeLitInt :: ((MonadParsec e String) m) => m TypeExpr
+typeLitInt = TypeLitInt <$> some digitChar
+
+typeLitPromotedConstructor :: ((MonadParsec e String) m) => m TypeExpr
+typeLitPromotedConstructor = do
+    _ <- char '\'' <* optional hspace
+    TypeLitPromotedConstructor <$> typeConstructor
+
+listType :: ((MonadParsec e String) m) => m TypeExpr
+listType = do
+    t <- whitespaceBetween '[' ']' innerTypeExpr
+    pure $ TypeApplication (TypeConstructorExpr ListConstructor) [t]
+
+-- | Given a TypeExpr, renders it back to a String in a canonical form that looks
+-- normal to humans and is re-parseable when making an UnboundEntityDef that uses it.
+--
+-- @since 2.17.1.0
+typeExprContent :: TypeExpr -> Text
+typeExprContent = typeExprContent' False
+
+-- This is a little gnarly-looking. That's mostly due to attempting to avoid inserting
+-- superfluous parentheses.
+typeExprContent' :: Bool -> TypeExpr -> Text
+typeExprContent' wrapped = \case
+    TypeLitString s ->
+        mconcat
+            [ "\""
+            , T.pack s
+            , "\""
+            ]
+    TypeLitInt s -> T.pack s
+    TypeLitPromotedConstructor tc -> "'" <> typeExprContent' wrapped (TypeConstructorExpr tc)
+    TypeConstructorExpr (TypeConstructor s) -> T.pack s
+    TypeConstructorExpr ListConstructor -> "List"
+    TypeApplication (TypeConstructorExpr tc) args -> simpleTypeApplicationContent tc args wrapped
+    TypeApplication t exps ->
+        mconcat
+            [ typeExprContent' True t
+            , " "
+            , T.intercalate " " $ fmap typeExprContent exps
+            ]
+  where
+    typeArgsListContent :: Bool -> [TypeExpr] -> Text
+    typeArgsListContent wrapped exps = T.intercalate " " $ fmap (typeExprContent' wrapped) exps
+
+    simpleTypeApplicationContent :: TypeConstructor -> [TypeExpr] -> Bool -> Text
+    simpleTypeApplicationContent ListConstructor args _ =
+        mconcat
+            [ "["
+            , typeArgsListContent False args
+            , "]"
+            ]
+    simpleTypeApplicationContent (TypeConstructor s) [] _ = T.pack s
+    simpleTypeApplicationContent (TypeConstructor s) exps True =
+        mconcat
+            [ "("
+            , simpleTypeApplicationContent (TypeConstructor s) exps False
+            , ")"
+            ]
+    simpleTypeApplicationContent (TypeConstructor s) exps False =
+        mconcat
+            [ T.pack s
+            , " "
+            , typeArgsListContent True exps
+            ]

--- a/persistent/Database/Persist/Quasi/PersistSettings.hs
+++ b/persistent/Database/Persist/Quasi/PersistSettings.hs
@@ -20,8 +20,8 @@ module Database.Persist.Quasi.PersistSettings
     , setPsIdName
     , getPsTabErrorLevel
     , setPsTabErrorLevel
-    , getPsQuotedFieldAttributeErrorLevel
-    , setPsQuotedFieldAttributeErrorLevel
+    , getPsQuotedArgumentErrorLevel
+    , setPsQuotedArgumentErrorLevel
     ) where
 
 import Database.Persist.Quasi.PersistSettings.Internal

--- a/persistent/Database/Persist/Quasi/PersistSettings.hs
+++ b/persistent/Database/Persist/Quasi/PersistSettings.hs
@@ -20,6 +20,8 @@ module Database.Persist.Quasi.PersistSettings
     , setPsIdName
     , getPsTabErrorLevel
     , setPsTabErrorLevel
+    , getPsQuotedFieldAttributeErrorLevel
+    , setPsQuotedFieldAttributeErrorLevel
     ) where
 
 import Database.Persist.Quasi.PersistSettings.Internal

--- a/persistent/Database/Persist/Quasi/PersistSettings/Internal.hs
+++ b/persistent/Database/Persist/Quasi/PersistSettings/Internal.hs
@@ -38,8 +38,9 @@ data PersistSettings = PersistSettings
     -- ^ Whether and with what severity to disallow tabs in entity source text.
     --
     -- @since 2.16.0.0
-    , psQuotedFieldAttributeErrorLevel :: Maybe ParserErrorLevel
-    -- ^ Whether and with what severity to disallow quoted entity field attributes.
+    , psQuotedArgumentErrorLevel :: Maybe ParserErrorLevel
+    -- ^ Whether and with what severity to disallow quoted entity field attributes
+    -- and quoted directive arguments.
     --
     -- @since 2.17.1.0
     }
@@ -52,7 +53,7 @@ defaultPersistSettings =
         , psStrictFields = True
         , psIdName = "id"
         , psTabErrorLevel = Just LevelWarning
-        , psQuotedFieldAttributeErrorLevel = Just LevelWarning
+        , psQuotedArgumentErrorLevel = Just LevelWarning
         }
 upperCaseSettings = defaultPersistSettings
 lowerCaseSettings =
@@ -188,18 +189,20 @@ setPsTabErrorLevel
 setPsTabErrorLevel l ps = ps{psTabErrorLevel = l}
 
 -- | Retrieve the severity of the error generated when the parser encounters a
--- quoted entity field attribute.
--- If it is @Nothing@, quoted attributes are permitted in entity field definitions.
+-- quoted entity field attribute or quoted directive argument.
+-- If it is @Nothing@, quoted arguments are permitted in both entity field
+-- definitions and directives.
 --
 -- @since 2.17.1.0
-getPsQuotedFieldAttributeErrorLevel :: PersistSettings -> Maybe ParserErrorLevel
-getPsQuotedFieldAttributeErrorLevel = psQuotedFieldAttributeErrorLevel
+getPsQuotedArgumentErrorLevel :: PersistSettings -> Maybe ParserErrorLevel
+getPsQuotedArgumentErrorLevel = psQuotedArgumentErrorLevel
 
 -- | Set the severity of the error generated when the parser encounters a
 -- quoted entity field attribute.
--- If set to @Nothing@, quoted attributes are permitted in entity field definitions.
+-- If set to @Nothing@, quoted arguments are permitted in both entity field
+-- definitions and directives.
 --
 -- @since 2.17.1.0
-setPsQuotedFieldAttributeErrorLevel
+setPsQuotedArgumentErrorLevel
   :: Maybe ParserErrorLevel -> PersistSettings -> PersistSettings
-setPsQuotedFieldAttributeErrorLevel l ps = ps{psQuotedFieldAttributeErrorLevel = l}
+setPsQuotedArgumentErrorLevel l ps = ps{psQuotedArgumentErrorLevel = l}

--- a/persistent/Database/Persist/Quasi/PersistSettings/Internal.hs
+++ b/persistent/Database/Persist/Quasi/PersistSettings/Internal.hs
@@ -38,6 +38,10 @@ data PersistSettings = PersistSettings
     -- ^ Whether and with what severity to disallow tabs in entity source text.
     --
     -- @since 2.16.0.0
+    , psQuotedFieldAttributeErrorLevel :: Maybe ParserErrorLevel
+    -- ^ Whether and with what severity to disallow quoted entity field attributes.
+    --
+    -- @since 2.17.1.0
     }
 
 defaultPersistSettings, upperCaseSettings, lowerCaseSettings :: PersistSettings
@@ -48,6 +52,7 @@ defaultPersistSettings =
         , psStrictFields = True
         , psIdName = "id"
         , psTabErrorLevel = Just LevelWarning
+        , psQuotedFieldAttributeErrorLevel = Just LevelWarning
         }
 upperCaseSettings = defaultPersistSettings
 lowerCaseSettings =
@@ -181,3 +186,20 @@ getPsTabErrorLevel = psTabErrorLevel
 setPsTabErrorLevel
     :: Maybe ParserErrorLevel -> PersistSettings -> PersistSettings
 setPsTabErrorLevel l ps = ps{psTabErrorLevel = l}
+
+-- | Retrieve the severity of the error generated when the parser encounters a
+-- quoted entity field attribute.
+-- If it is @Nothing@, quoted attributes are permitted in entity field definitions.
+--
+-- @since 2.17.1.0
+getPsQuotedFieldAttributeErrorLevel :: PersistSettings -> Maybe ParserErrorLevel
+getPsQuotedFieldAttributeErrorLevel = psQuotedFieldAttributeErrorLevel
+
+-- | Set the severity of the error generated when the parser encounters a
+-- quoted entity field attribute.
+-- If set to @Nothing@, quoted attributes are permitted in entity field definitions.
+--
+-- @since 2.17.1.0
+setPsQuotedFieldAttributeErrorLevel
+  :: Maybe ParserErrorLevel -> PersistSettings -> PersistSettings
+setPsQuotedFieldAttributeErrorLevel l ps = ps{psQuotedFieldAttributeErrorLevel = l}

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -85,6 +85,7 @@ library
     Database.Persist.Quasi.PersistSettings.Internal
     Database.Persist.Quasi.Internal
     Database.Persist.Quasi.Internal.ModelParser
+    Database.Persist.Quasi.Internal.TypeParser
     Database.Persist.Sql
     Database.Persist.Sql.Migration
     Database.Persist.Sql.Types.Internal

--- a/persistent/test/Database/Persist/QuasiSpec.hs
+++ b/persistent/test/Database/Persist/QuasiSpec.hs
@@ -20,6 +20,7 @@ import Database.Persist.Quasi.PersistSettings
 import Database.Persist.Quasi.PersistSettings.Internal (psTabErrorLevel)
 import Database.Persist.Quasi.Internal
 import Database.Persist.Quasi.Internal.ModelParser
+import Database.Persist.Quasi.Internal.TypeParser
 import Database.Persist.Types
 import Test.Hspec
 import Test.QuickCheck
@@ -111,18 +112,79 @@ spec = describe "Quasi" $ do
                         , unboundFieldGenerated = Nothing
                         }
 
-    describe "tokenization" $ do
+    describe "type parsing" $ do
+      let
+          parseType :: String -> ParseResult TypeExpr
+          parseType s = do
+                let
+                  (warnings, res) = runConfiguredParser defaultPersistSettings initialExtraState innerTypeExpr "" s
+                case res of
+                  Left peb -> (warnings, Left peb)
+                  Right (te, _acc) -> (warnings, Right te)
+
+          isType typeStr expectedTypeExpr = do
+            let (_warnings, Right te) = parseType typeStr
+            te `shouldBe` expectedTypeExpr
+            typeExprContent te `shouldBe` T.pack typeStr
+
+          -- these are some helper functions to make expectations less verbose
+          simpleType s = (TypeApplication (TypeConstructorExpr (TypeConstructor s)) [])
+          typeApp s ts = (TypeApplication (TypeConstructorExpr (TypeConstructor s)) ts)
+          listOf t = (TypeApplication (TypeConstructorExpr ListConstructor) [t])
+
+      it "parses types of kind '*'" $ do
+          "String" `isType` simpleType "String"
+
+      it "parses type constructors with dots" $ do
+          "ThisIs.AType" `isType` simpleType "ThisIs.AType"
+
+      it "parses higher-kinded types" $ do
+          "Maybe String" `isType` typeApp "Maybe" [simpleType "String"]
+
+      it "is greedy when parsing arguments to a type constructor" $ do
+          "Map String Int" `isType` typeApp "Map" [simpleType "String", simpleType "Int"]
+
+      it "parses higher-kinded types when parameterized by complex types (1)" $ do
+        "Map String (Maybe [Int])" `isType`
+          typeApp "Map" [simpleType "String", typeApp "Maybe" [listOf (simpleType "Int")]]
+
+      it "parses higher-kinded types when parameterized by complex types (2)" $ do
+        "Map (Maybe Int) [Int]" `isType`
+          typeApp "Map" [(typeApp "Maybe" [simpleType "Int"]), listOf (simpleType "Int")]
+
+      it "parses type expressions constructed by a partially parameterized type" $ do
+        "(Map String) [Int]" `isType`
+          TypeApplication (typeApp "Map" [(simpleType "String")]) [listOf (simpleType "Int")]
+
+      it "parses lists of lists" $ do
+        "[[Maybe String]]" `isType` listOf (listOf (typeApp "Maybe" [simpleType "String"]))
+
+      it "parses list types of complex types" $ do
+        "[(Map String) [Int]]" `isType`
+          listOf (TypeApplication (typeApp "Map" [(simpleType "String")]) [listOf (simpleType "Int")])
+
+      it "parses type-level String literals" $ do
+        "Labelled \"abcd\"" `isType` typeApp "Labelled" [TypeLitString "abcd"]
+
+      it "parses type-level Int literals" $ do
+        "Val 3" `isType` typeApp "Val" [TypeLitInt "3"]
+
+      it "parses promoted type constructors" $ do
+        "'Maybe" `isType` TypeLitPromotedConstructor (TypeConstructor "Maybe")
+
+    describe "attribute parsing" $ do
         let
-            tokenize :: String -> ParseResult [Token]
-            tokenize s = do
-              let (warnings, res) = runConfiguredParser defaultPersistSettings initialExtraState (some anyToken) "" s
+            parseAttributes :: String -> ParseResult [Attribute]
+            parseAttributes s = do
+              let
+                (warnings, res) = runConfiguredParser defaultPersistSettings initialExtraState (some attribute) "" s
               case res of
                 Left peb ->
                   (warnings, Left peb)
                 Right (tokens, _acc) -> (warnings, Right tokens)
 
         it "handles normal words" $
-            tokenize "foo   bar  baz"
+            parseAttributes "foo   bar  baz"
                 `shouldBe` ([], Right
                              ( [ PText "foo"
                                , PText "bar"
@@ -132,7 +194,7 @@ spec = describe "Quasi" $ do
                            )
 
         it "handles numbers" $
-            tokenize "one (Finite 1)"
+            parseAttributes "one (Finite 1)"
                 `shouldBe` ([], Right
                              ( [ PText "one"
                                , Parenthetical "Finite 1"
@@ -141,65 +203,58 @@ spec = describe "Quasi" $ do
                            )
 
         it "handles quotes" $
-            tokenize "\"foo bar\" \"baz\""
+            parseAttributes "abc=\"foo bar\" def=\"baz\""
                 `shouldBe` ([], Right
-                             ( [ Quotation "foo bar"
-                               , Quotation "baz"
+                             ( [ Assignment "abc" "foo bar"
+                               , Assignment "def" "baz"
                                ]
                              )
                            )
 
         it "handles SQL literals with no specified type" $
-            tokenize "attr='[\"ab\\'cd\", 1, 2]'"
+            parseAttributes "attr='[\"ab\\'cd\", 1, 2]'"
                 `shouldBe` ([], Right
-                             ( [Equality "attr" "'[\"ab'cd\", 1, 2]'"]
+                             ( [Assignment "attr" "'[\"ab'cd\", 1, 2]'"]
                              )
                            )
 
         it "handles SQL literals with a specified type" $
-            tokenize "attr='{\"\\'a\\'\": [1, 2.2, \"\\'3\\'\"]}'::type_name"
+            parseAttributes "attr='{\"\\'a\\'\": [1, 2.2, \"\\'3\\'\"]}'::type_name"
                 `shouldBe` ([], Right
-                             ( [Equality "attr" "'{\"'a'\": [1, 2.2, \"'3'\"]}'::type_name"]
-                             )
-                           )
-
-        it "should error if quotes are unterminated" $ do
-          (fmap . first) errorBundlePretty (tokenize "\"foo bar")
-                `shouldBe` ([], Left
-                             ( "1:9:\n  |\n1 | \"foo bar\n  |         ^\nunexpected end of input\nexpecting '\"' or literal character\n"
+                             ( [Assignment "attr" "'{\"'a'\": [1, 2.2, \"'3'\"]}'::type_name"]
                              )
                            )
 
         it "handles commas in tokens" $
-            tokenize "x=COALESCE(left,right)  \"baz\""
+            parseAttributes "x=COALESCE(left,right)  baz"
                 `shouldBe` ([], Right
-                             ( [ Equality "x" "COALESCE(left,right)"
-                               , Quotation "baz"
+                             ( [ Assignment "x" "COALESCE(left,right)"
+                               , PText "baz"
                                ]
                              )
                            )
 
         it "handles quotes mid-token" $
-            tokenize "x=\"foo bar\"  \"baz\""
+            parseAttributes "x=\"foo bar\"  baz"
                 `shouldBe` ([], Right
-                             ( [ Equality "x" "foo bar"
-                               , Quotation "baz"
+                             ( [ Assignment "x" "foo bar"
+                               , PText "baz"
                                ]
                              )
                            )
 
         it "handles escaped quotes mid-token" $
-            tokenize "x=\\\"foo bar\"  \"baz\""
+            parseAttributes "x=\\\"foo bar\"  baz"
                 `shouldBe` ([], Right
-                             ( [ Equality "x" "\\\"foo"
+                             ( [ Assignment "x" "\\\"foo"
                                , PText "bar\""
-                               , Quotation "baz"
+                               , PText "baz"
                                ]
                              )
                            )
 
         it "handles unnested parentheses" $
-            tokenize "(foo bar)  (baz)"
+            parseAttributes "(foo bar)  (baz)"
                 `shouldBe` ([], Right
                              ( [ Parenthetical "foo bar"
                                , Parenthetical "baz"
@@ -208,16 +263,16 @@ spec = describe "Quasi" $ do
                            )
 
         it "handles unnested parentheses mid-token" $
-            tokenize "x=(foo bar)  (baz)"
+            parseAttributes "x=(foo bar)  (baz)"
                 `shouldBe` ([], Right
-                             ( [ Equality "x" "foo bar"
+                             ( [ Assignment "x" "foo bar"
                                , Parenthetical "baz"
                                ]
                              )
                            )
 
         it "handles nested parentheses" $
-            tokenize "(foo (bar))  (baz)"
+            parseAttributes "(foo (bar))  (baz)"
                 `shouldBe` ([], Right
                              ( [ Parenthetical "foo (bar)"
                                , Parenthetical "baz"
@@ -226,7 +281,7 @@ spec = describe "Quasi" $ do
                            )
 
         it "handles escaped quotation marks in plain tokens" $
-            tokenize "foo bar\\\"baz"
+            parseAttributes "foo bar\\\"baz"
                 `shouldBe` ([], Right
                              ( [ PText "foo"
                                , PText "bar\\\"baz"
@@ -235,24 +290,24 @@ spec = describe "Quasi" $ do
                            )
 
         it "handles escaped quotation marks in quotations" $
-            tokenize "foo \"bar\\\"baz\""
+            parseAttributes "foo bar=\"baz\\\"quux\""
                 `shouldBe` ([], Right
                              ( [ PText "foo"
-                               , Quotation "bar\"baz"
+                               , Assignment "bar" "baz\"quux"
                                ]
                              )
                            )
 
         it "handles escaped quotation marks in equalities" $
-            tokenize "y=\"baz\\\"\""
+            parseAttributes "y=\"baz\\\"\""
                 `shouldBe` ([], Right
-                             ( [ Equality "y" "baz\""
+                             ( [ Assignment "y" "baz\""
                                ]
                              )
                            )
 
         it "handles escaped quotation marks in parentheticals" $
-            tokenize "(foo \\\"bar)"
+            parseAttributes "(foo \\\"bar)"
                 `shouldBe` ([], Right
                              ( [ Parenthetical "foo \\\"bar"
                                ]
@@ -260,16 +315,16 @@ spec = describe "Quasi" $ do
                            )
 
         it "handles escaped parentheses in quotations" $
-            tokenize "foo \"bar\\(baz\""
+            parseAttributes "foo bar=\"baz\\(quux\""
                 `shouldBe` ([], Right
                              ( [ PText "foo"
-                               , Quotation "bar(baz"
+                               , Assignment "bar" "baz(quux"
                                ]
                              )
                            )
 
         it "handles escaped parentheses in plain tokens" $
-            tokenize "foo bar\\(baz"
+            parseAttributes "foo bar\\(baz"
                 `shouldBe` ([], Right
                              ( [ PText "foo"
                                , PText "bar(baz"
@@ -278,7 +333,7 @@ spec = describe "Quasi" $ do
                            )
 
         it "handles escaped parentheses in parentheticals" $
-            tokenize "(foo \\(bar)"
+            parseAttributes "(foo \\(bar)"
                 `shouldBe` ([], Right
                              ( [ Parenthetical "foo (bar"
                                ]
@@ -286,43 +341,97 @@ spec = describe "Quasi" $ do
                            )
 
         it "handles escaped parentheses in equalities" $
-            tokenize "y=baz\\("
+            parseAttributes "y=baz\\("
                 `shouldBe` ([], Right
-                             ( [ Equality "y" "baz("
+                             ( [ Assignment "y" "baz("
                                ]
                              )
                            )
 
         it "handles mid-token quote in later token" $
-            tokenize "foo bar baz=(bin\")"
+            parseAttributes "foo bar baz=(bin\")"
                 `shouldBe` ([], Right
                              ( [ PText "foo"
                                , PText "bar"
-                               , Equality "baz" "bin\""
+                               , Assignment "baz" "bin\""
                                ]
                              )
                            )
 
-    describe "parser settings" $ do
+    describe "entity field parsing" $ do
+        let
+            parseField :: String -> ParseResult ()
+            parseField s = do
+              let
+                (warnings, res) = runConfiguredParser defaultPersistSettings initialExtraState entityField "" s
+              case res of
+                Left peb ->
+                  (warnings, Left peb)
+                Right (_, _) -> (warnings, Right ())
+
+        it "should error if quotes are unterminated in an attribute" $ do
+            (fmap . first) errorBundlePretty (parseField "field String sql=\"foo bar")
+                  `shouldBe` ([], Left
+                               ("1:17:\n  |\n1 | field String sql=\"foo bar\n  |                 ^\nunexpected '='\nexpecting '!', '\"', ''', ',', '-', '.', ':', '[', '\\', ']', '_', '~', alphanumeric character, assignment expression, end of input, newline, parenthetical, or plain attribute\n"
+                               )
+                             )
+
+        it "should error if quotes are unterminated in a type" $ do
+            (fmap . first) errorBundlePretty (parseField "field (Label \"unterminated)")
+                  `shouldBe` ([], Left
+                               ("1:28:\n  |\n1 | field (Label \"unterminated)\n  |                            ^\nunexpected end of input\nexpecting '\"' or literal character\n"
+                               )
+                             )
+
+    describe "tab error level setting" $ do
       let definitions = T.pack "User\n\tId Text\n\tname String"
 
       describe "when configured to permit tabs" $ do
         let
-            [user] = defsWithSettings lowerCaseSettings{ psTabErrorLevel = Nothing } definitions
+          (warnings, [user]) = defsWithWarnings lowerCaseSettings{ psTabErrorLevel = Nothing } definitions
+
         it "permits tab indentation" $
           getUnboundEntityNameHS user `shouldBe` EntityNameHS "User"
+
+        it "doesn't generate a warning" $
+          warnings `shouldBe` []
 
       describe "when configured to warn on tabs" $ do
         let
             (warnings, [user]) = defsWithWarnings lowerCaseSettings{ psTabErrorLevel = Just LevelWarning } definitions
+
         it "permits tab indentation" $
           getUnboundEntityNameHS user `shouldBe` EntityNameHS "User"
+
+        it "generates one warning per line with tabs" $
+          length warnings `shouldBe` 2
 
       describe "when configured to disallow tabs" $ do
         let
           [user] = defsWithSettings lowerCaseSettings{ psTabErrorLevel = Just LevelError } definitions
+
         it "rejects tab indentation" $
           evaluate (unboundEntityDef user) `shouldErrorWithMessage` "2:1:\n  |\n2 |  Id Text\n  | ^\nunexpected tab\nexpecting valid whitespace\n\n3:1:\n  |\n3 |  name String\n  | ^\nunexpected tab\nexpecting valid whitespace\n"
+
+    describe "quoted attribute error level setting" $ do
+      let definitions = T.pack "User\n name String \"Maybe\""
+
+      describe "when configured to warn on quoted attriutes" $ do
+        let
+            (warnings, [user]) = defsWithWarnings lowerCaseSettings{ psTabErrorLevel = Just LevelWarning } definitions
+
+        it "permits quoted attributes" $
+            (unboundFieldAttrs <$> unboundEntityFields user) `shouldBe` [[FieldAttrMaybe]]
+
+        it "generates a warning" $
+          length warnings `shouldBe` 1
+
+      describe "when configured to disallow quoted attriutes" $ do
+        let
+            (warnings, [user]) = defsWithWarnings lowerCaseSettings{ psTabErrorLevel = Just LevelWarning } definitions
+
+        it "rejects quoted attributes" $
+            (unboundFieldAttrs <$> unboundEntityFields user) `shouldBe` [[FieldAttrMaybe]]
 
     describe "parse" $ do
         let
@@ -390,6 +499,23 @@ Car
               `shouldBe` [ (ConstraintNameHS "UniqueModel", [(FieldNameHS "model", FieldNameDB "model")])
                          ]
             (simplifyUnique <$> entityUniques (unboundEntityDef vehicle)) `shouldBe` []
+
+        it "should parse quoted attributes" $ do
+            let [precompiledCacheParent] = defs [st|
+                                                   PrecompiledCacheParent sql="precompiled_cache"
+                                                     platformGhcDir FilePath "default=(hex(randomblob(16)))"
+                                                     deriving Show
+                                                |]
+            (unboundFieldAttrs <$> unboundEntityFields precompiledCacheParent)
+                `shouldBe` [[FieldAttrDefault "(hex(randomblob(16)))"]]
+
+        it "should parse entity block attributes with nested parens on equality rhs" $ do
+            let [precompiledCacheParent] = defs [st|
+                                                   PrecompiledCacheParent sql="precompiled_cache"
+                                                     platformGhcDir FilePath default=(hex(randomblob(16)))
+                                                |]
+            (unboundFieldAttrs <$> unboundEntityFields precompiledCacheParent)
+                `shouldBe` [[FieldAttrDefault "hex(randomblob(16))"]]
 
         it "should parse the `entityForeigns` field" $ do
             let
@@ -462,7 +588,7 @@ User
             let
                 [user] = defs definitions
             evaluate (unboundEntityDef user)
-                `shouldErrorWithMessage` "4:20:\n  |\n4 |     age  (Maybe Int\n  |                    ^\nunexpected newline\nexpecting '!', '\"', ''', '(', ')', ',', '-', '.', ':', '[', '\\', ']', '_', '~', alphanumeric character, space, or tab\n"
+                `shouldErrorWithMessage` "4:20:\n  |\n4 |     age  (Maybe Int\n  |                    ^\nunexpected newline\nexpecting ''', ')', '.', alphanumeric character, type expression, or white space\n"
 
         it "errors on duplicate cascade update declarations" $ do
             let

--- a/persistent/test/Database/Persist/QuasiSpec.hs
+++ b/persistent/test/Database/Persist/QuasiSpec.hs
@@ -17,7 +17,7 @@ import qualified Data.Text as T
 import Database.Persist.EntityDef.Internal
 import Database.Persist.Quasi
 import Database.Persist.Quasi.PersistSettings
-import Database.Persist.Quasi.PersistSettings.Internal (psTabErrorLevel)
+import Database.Persist.Quasi.PersistSettings.Internal (psTabErrorLevel, psQuotedArgumentErrorLevel)
 import Database.Persist.Quasi.Internal
 import Database.Persist.Quasi.Internal.ModelParser
 import Database.Persist.Quasi.Internal.TypeParser
@@ -411,14 +411,17 @@ spec = describe "Quasi" $ do
           [user] = defsWithSettings lowerCaseSettings{ psTabErrorLevel = Just LevelError } definitions
 
         it "rejects tab indentation" $
-          evaluate (unboundEntityDef user) `shouldErrorWithMessage` "2:1:\n  |\n2 |  Id Text\n  | ^\nunexpected tab\nexpecting valid whitespace\n\n3:1:\n  |\n3 |  name String\n  | ^\nunexpected tab\nexpecting valid whitespace\n"
+          evaluate (unboundEntityDef user)
+            `shouldErrorWithMessage`
+            "2:1:\n  |\n2 |  Id Text\n  | ^\nunexpected tab\nexpecting valid whitespace\n\n3:1:\n  |\n3 |  name String\n  | ^\nunexpected tab\nexpecting valid whitespace\n"
+
 
     describe "quoted attribute error level setting" $ do
       let definitions = T.pack "User\n name String \"Maybe\""
 
-      describe "when configured to warn on quoted attriutes" $ do
+      describe "when configured to warn on quoted attributes" $ do
         let
-            (warnings, [user]) = defsWithWarnings lowerCaseSettings{ psTabErrorLevel = Just LevelWarning } definitions
+            (warnings, [user]) = defsWithWarnings lowerCaseSettings{ psQuotedArgumentErrorLevel = Just LevelWarning } definitions
 
         it "permits quoted attributes" $
             (unboundFieldAttrs <$> unboundEntityFields user) `shouldBe` [[FieldAttrMaybe]]
@@ -426,12 +429,36 @@ spec = describe "Quasi" $ do
         it "generates a warning" $
           length warnings `shouldBe` 1
 
-      describe "when configured to disallow quoted attriutes" $ do
+      describe "when configured to disallow quoted attributes" $ do
         let
-            (warnings, [user]) = defsWithWarnings lowerCaseSettings{ psTabErrorLevel = Just LevelWarning } definitions
+            (warnings, [user]) = defsWithWarnings lowerCaseSettings{ psQuotedArgumentErrorLevel = Just LevelError } definitions
 
         it "rejects quoted attributes" $
-            (unboundFieldAttrs <$> unboundEntityFields user) `shouldBe` [[FieldAttrMaybe]]
+          evaluate (unboundEntityDef user)
+            `shouldErrorWithMessage`
+             "2:14:\n  |\n2 |  name String \"Maybe\"\n  |              ^\nUnexpected quotation mark in entity field attribute\n"
+
+    describe "quoted directive argument error level setting" $ do
+      let definitions = T.pack "User\n name String\n deriving \"Show\""
+
+      describe "when configured to warn on quoted arguments" $ do
+        let
+            (warnings, [user]) = defsWithWarnings lowerCaseSettings{ psQuotedArgumentErrorLevel = Just LevelWarning } definitions
+
+        it "permits quoted attributes" $
+            getUnboundEntityNameHS user `shouldBe` EntityNameHS "User"
+
+        it "generates a warning" $
+          length warnings `shouldBe` 1
+
+      describe "when configured to disallow quoted arguments" $ do
+        let
+            (warnings, [user]) = defsWithWarnings lowerCaseSettings{ psQuotedArgumentErrorLevel = Just LevelError } definitions
+
+        it "rejects quoted arguments" $
+          evaluate (unboundEntityDef user)
+            `shouldErrorWithMessage`
+            "3:11:\n  |\n3 |  deriving \"Show\"\n  |           ^\nUnexpected quotation mark in directive argument\n"
 
     describe "parse" $ do
         let

--- a/persistent/test/Database/Persist/TH/ForeignRefSpec.hs
+++ b/persistent/test/Database/Persist/TH/ForeignRefSpec.hs
@@ -128,7 +128,7 @@ spec = describe "ForeignRefSpec" $ do
                             pure ()
                         as ->
                             expectationFailure . mconcat $
-                                [ "Expected one foreign reference on childDef, "
+                                [ "(Explicit) Expected one foreign reference on childDef, "
                                 , "got: "
                                 , show as
                                 ]
@@ -172,7 +172,7 @@ spec = describe "ForeignRefSpec" $ do
                                 ForeignRef (EntityNameHS "ParentImplicit")
                     as ->
                         error . mconcat $
-                            [ "Expected one foreign reference on childDef, "
+                            [ "(Implicit) Expected one foreign reference on childDef, "
                             , "got: "
                             , show as
                             ]


### PR DESCRIPTION
**This is a draft because I'm still testing it with downstream packages.**

For [#1599].

The old version of the parser allowed entity field attributes to be wrapped in quotation marks; the enclosing `"`s would get parsed away and the enclosed text passed through in the attribute text on the `ParsedEntityDefinition`.

I discussed this with @parsonsmatt , and we'd like to deprecate this behavior. In [#1599] it seems to have been in use as a workaround for a parser bug that no longer exists. (If it's necessary to escape whitespace in a field attribute, this can still be done by wrapping the attribute in `(` `)` instead of quotes.)

This PR restores the old behavior and adds a configurable deprecation message as a warning. It's not easy to do this without some further refactoring of the parser. Banning quotes in entity field arguments will also ban them in entity field _types_, which would be incorrect — field types can include typelevel string literals.

This is a good opportunity to make the parser smarter. It's currently pretty naive — essentially, it breaks each line of an entity definition block into tokens and then stops. In doing this, it ignores a lot of genuine syntactic data. It doesn't know that the line starts with the field name, is followed by a type, and is then followed by a series of attributes. It's very easy to write an field definition that parses successfully but fails semantically.

Improving this situation is an incremental directional step towards a formal specification for the language.

This PR:
- Implements a more exact parser for entity field definitions, including structural representation of the field name, type, strictness, and attributes.
- Separates parsing of entity fields from non-field things like `deriving` statements. I'm calling these "directives" here. In the interest of keeping the PR from growing even more huge, directives are parsed naively for now.
  - I'd like to add support for Haskell-style `deriving` syntax in the future; this will be easier when it's parsed separately.
- Temporarily restores the old parser's behavior for entity field definitions and directive arguments that are wrapped in quotes.
- Adds a configurable warning message when entity field definitions and directive arguments are wrapped in quotes.

Currently, all of this new structure is thrown away in `mkUnboundEntityDef`. There's something of an impedance mismatch:
- `mkUnboundEntityDef` doesn't care about the difference between field definitions and directives; it wants the parsed structure to be reduced back to a string of tokens.
- `mkUnboundEntityDef` wants to re-parse types itself.
- `mkUnboundEntityDef` wants to re-parse key/value attributes itself.
- etc, etc, etc

I think this situation could be improved with some effort, but that's outside the scope of this PR.