### PR TITLE
RFC: Direct row codecs for persistent

### DIFF
--- a/RFC-direct-decode.md
+++ b/RFC-direct-decode.md
@@ -1,0 +1,1055 @@
+# RFC: Direct Row Codecs for persistent
+
+## Status
+
+Draft. I have a proof-of-concept implementation PostgreSQL that I'm getting into a publishable state.
+
+## Summary
+
+Add a backend-agnostic direct codec layer to persistent that bypasses `PersistValue` entirely. On the **decode** side, typed query results go from the database's wire format to Haskell records without intermediate representations. On the **encode** side, Haskell values go from record fields to the wire format without detouring through `PersistValue`.
+
+The decode path uses continuation-passing style (CPS) throughout, so the success path allocates zero `Either` constructors and zero `PersistValue` wrappers. The encode path operates similarly, but in the opposite direction.
+
+The existing `PersistValue`-based path is unchanged. All current code continues to compile and run without modification.
+
+## Motivation
+
+### Allocation overhead
+
+Every row decoded from any persistent backend follows this path today:
+
+```mermaid
+flowchart LR
+    A["wire format"] -->|"decode to PersistValue"| B["PersistValue per column"]
+    B -->|"cons cell"| C["[PersistValue]"]
+    C -->|"fromPersistValue per field"| D["Haskell record"]
+```
+
+For a 10-column row, this allocates:
+- 10 `PersistValue` heap objects (tagged union, 2+ words each)
+- 10 list cons cells (3 words each)
+- ~9 intermediate `Either Text (a -> b -> ...)` values from the applicative `fromPersistValues` chain
+- Then `fromPersistValue` pattern-matches each `PersistValue` again to extract the payload
+
+That works out to roughly 70 words (~560 bytes) of pure overhead per row, all short-lived. For a 100k row result set, this produces ~56MB of intermediate garbage that exists only to be collected.
+
+Encoding has a symmetric problem: `toPersistFields` converts each record field into a `PersistValue`, then the backend immediately inspects it to produce the wire format. Every insert and update pays this cost.
+
+### Limited type vocabulary
+
+`PersistValue` has a fixed set of constructors that cannot represent backend-specific types natively. This implementation was chosen back in the 2010s when the most common backends were MySQL and PostgreSQL, and the most common use cases were simple CRUD operations. Nowadays, production-grade applications often need to support more types, often with database-specific support. In order to support these types, we currently have to shoehorn them into the existing constructors, losing type safety and precision. Examples from the PostgreSQL backend include:
+
+- **JSON/JSONB**: stored as `PersistByteString`, losing the distinction between JSON and raw bytes
+- **UUID**: stored as `PersistLiteralEscaped` with hex-encoded bytes, requiring a text-to-UUID conversion on each read
+- **Intervals**: stored as `PersistRational`, losing semantic meaning (PostgreSQL's `interval` has year/month/day/time components that `Rational` cannot faithfully represent)
+- **Composite types**: PostgreSQL composite values have no `PersistValue` representation at all
+- **Inet/cidr**: IP address types round-trip through `PersistLiteralEscaped`
+- **Arrays of custom types**: `PersistList`/`PersistArray` elements must themselves be `PersistValue`, so arrays of domain types require double conversion
+- **Enums**: backend enums are sent as text with no type safety at the Haskell boundary
+
+Furthermore, heavily using the custom type support makes it harder to improve the underlying library- for example, we could switch to the binary protocol that PostgreSQL supports, but custom values all need to be converted to use the binary protocol, or at least audited to ensure they are compatible.
+
+This means that nearly any changes to the underlying library constitutes a breaking change for all users of the library, which is long-term unsustainable.
+
+With the proposed `FieldDecode`/`FieldEncode` classes, backend packages can provide instances for any Haskell type directly, and the type mapping is no longer constrained by `PersistValue`'s fixed vocabulary. This gives us significant flexibility to improve the underlying library without introducing breaking changes for users.
+
+### Runtime type checks
+
+`fromPersistValue` performs runtime pattern matching on the `PersistValue` constructor at every field–  effectively a type check that the schema already guarantees at compile time. The direct path eliminates this redundancy: TH generates code that calls the correct decoder for each field's statically-known type.
+
+### Extensibility without breaking changes
+
+When a database adds a new type (or a backend author wants to support an existing type more faithfully), persistent's current architecture requires either adding a constructor to `PersistValue` (a breaking change to every backend and every `PersistField` instance) or cramming the value into an existing constructor like `PersistLiteralEscaped` (lossy, with no type safety).
+
+With `FieldDecode`/`FieldEncode`, a backend package can add support for any new type by publishing a new instance- without touching persistent core, without coordinating with other backends, and without breaking any downstream users. A PostgreSQL backend could add `FieldDecode PgRowEnv HStore` or `FieldDecode PgRowEnv TSVector` the day PostgreSQL ships them. Users who don't reference these types are completely unaffected.
+
+### Stable SQL for prepared statements and pipelining
+
+Today, persistent generates bulk inserts by expanding `INSERT INTO t VALUES (?,?,?), (?,?,?), ...` with one bind parameter per value. For 10k rows of 10 columns, that's 100k bind parameters and a SQL string whose length changes with every batch–  defeating prepared statement caching and forcing the database to re-plan the query each time.
+
+Similarly, `WHERE id IN (?,?,?,...)` expands to a variable number of bind parameters.
+
+The direct encode path opens the door to column-oriented encoding: a single fixed SQL template like `INSERT ... SELECT * FROM UNNEST($1, $2, ...)` where each parameter is an array of all values for one column, or `WHERE id = ANY($1)` with a single array parameter. The SQL string stays the same regardless of how many rows or values are involved, which is a prerequisite for proper prepared statement reuse.[^pipeline]
+
+[^pipeline]: Fixed SQL templates are also a prerequisite for prepared statements, which parse and plan the SQL once and execute it many times. Variable-length SQL strings change with every batch size, so they can never be prepared: every call is a cold parse and plan. Prepared statements in turn enable *protocol-level pipelining*: sending multiple execute messages to the database without waiting for each response before sending the next (see PostgreSQL's [pipeline mode](https://www.postgresql.org/docs/current/libpq-pipeline-mode.html)). Pipeline mode doesn't require prepared statements, but unless prepared statements can be run with a consistent set of parameters, you can't use them effectively in pipeline mode since you have to create a huge number of them.
+
+## Design: Decoding
+
+### Core abstraction: `RowReader` + `FieldDecode` + `FromRow`
+
+I propose introducing three new types/classes in persistent core, all backend-agnostic:
+
+```haskell
+-- CPS column-cursor monad
+newtype RowReader env a = RowReader
+    { unRowReader
+        :: forall r. env -> Counter
+        -> (Text -> IO r)   -- on error
+        -> (a -> IO r)      -- on success
+        -> IO r
+    }
+
+-- Per-field direct decoding, split into prepare + run.
+class FieldDecode env a where
+    -- | Inspect column metadata once per result set, returning a
+    --   specialized runner that can decode every row without
+    --   re-checking types.
+    prepareField
+        :: env -> FieldNameDB -> Int
+        -> (Text -> IO r) -> (FieldRunner env a -> IO r) -> IO r
+
+-- | The product of 'prepareField'. Runs on each row with only the
+--   row-varying data (row index, raw bytes, etc.)- column type
+--   dispatch has already happened.
+newtype FieldRunner env a = FieldRunner
+    { runField :: forall r. env -> (Text -> IO r) -> (a -> IO r) -> IO r }
+
+-- Per-entity direct decoding. TH generates instances.
+class FromRow env a where
+    rowReader :: RowReader env a
+```
+
+`env` is an opaque, backend-specific type that carries whatever the backend needs to read a column: a result pointer and row index for SQL databases, a BSON document for MongoDB, a key-value list for Redis, etc.
+
+The key insight behind the prepare/run split is that within a single result set, the column types are fixed: every row has the same OIDs (PostgreSQL), the same field types (MySQL), or the same BSON structure (MongoDB). `FromRow` exposes a `prepareRow` method that runs `prepareField` for each column once per result set, producing a `RowDecoder` that captures the resolved `FieldRunner`s in a closure. The per-row loop then calls only `runField`–  no OID dispatch, no vector index, no branching on column types.
+
+```haskell
+-- Produced by prepareRow: no Counter needed, column positions
+-- are baked into the captured FieldRunners.
+newtype RowDecoder env a = RowDecoder
+    { runRowDecoder :: forall r. env -> (Text -> IO r) -> (a -> IO r) -> IO r }
+```
+
+The conduit loop prepares once against the first row's metadata, then reuses the decoder:
+
+```haskell
+ctr <- newCounter
+decoder <- prepareRow metaEnv ctr onErr pure   -- runs prepareField × N columns
+-- per-row loop: only runField, zero dispatch
+go decoder row rowCount = ...
+    val <- runRowDecoderCPS decoder (PgRowEnv ret row colTypes cache) onErr pure
+    yield val
+```
+
+`FromRow` instances built from `nextField` (via `rowReader`) still work–  the default `prepareRow` falls back to calling `rowReader` per row. TH-generated instances and the stock tuple instances provide real `prepareRow` implementations that capture the runners.
+
+`FieldDecode` takes both a `FieldNameDB` (for document stores that look up fields by name) and an `Int` column index (for SQL backends that read by position). Each backend uses whichever access pattern is natural and ignores the other.
+
+### Why CPS?
+
+A naive `IO (Either Text a)` return type allocates a `Right` constructor at every step in the applicative chain, even on the success path where the error case is never used. With CPS, the success continuation is passed directly and the `Either` is never constructed:
+
+```haskell
+RowReader ff <*> RowReader fa = RowReader $ \env ctr onErr onOk ->
+    ff env ctr onErr $ \f ->
+        fa env ctr onErr $ \a ->
+            onOk (f a)
+```
+
+Both `prepareField` and `FieldRunner` are CPS too, so the backend's decoder feeds its result directly into the continuation. Callers use `runRowReaderCPS` to supply their success and failure actions without materializing unnecessary values:
+
+```haskell
+val <- runRowReaderCPS rowReader env ctr
+    (throwIO . PersistMarshalError)  -- on error: throw directly
+    pure                              -- on success: return value directly
+yield val
+```
+
+The entire path from wire format to `yield` produces zero `Either` constructors and zero `PersistValue` wrappers.
+
+### TH generates `FromRow` alongside `PersistEntity`
+
+For an entity `User { userName :: Text, userAge :: Maybe Int }`, `mkPersist` generates both the existing `PersistEntity` instance (unchanged) and a new `FromRow` instance:
+
+```haskell
+instance (FieldDecode env Text, FieldDecode env (Maybe Int))
+      => FromRow env User where
+    rowReader = User
+        <$> nextField (FieldNameDB "name")
+        <*> nextField (FieldNameDB "age")
+```
+
+Under the hood, `nextField` calls `prepareField` on the first row and caches the resulting `FieldRunner`, then applies `runField` for each subsequent row. The instance is polymorphic over `env`–  the `FieldDecode` constraints resolve when a concrete backend is chosen, and the entity definition itself remains backend-agnostic.
+
+### Backend implementations
+
+Each backend provides its own `env` type and `FieldDecode` instances. The same TH-generated `FromRow` code works across all of them without modification.
+
+#### PostgreSQL
+
+I've got a prototype implementation that fully passes all tests for persistent and esqueleto. The `env` environment value wraps a `PGresult` handle, a row index, a vector of column OIDs classified into a `PgType` ADT, and an `OidCache` for resolving dynamically-assigned OIDs (composites, enums, domains). `FieldDecode` instances inspect the `PgType` once during `prepareField` and return a `FieldRunner` that calls the appropriate `postgresql-binary` decoder directly, without re-checking the OID on each row. Instances cover `Bool`, `Int16`-`Int64`, `Int`, `Double`, `Scientific`, `Rational`, `Text`, `ByteString`, `Day`, `TimeOfDay`, `UTCTime`, and `Maybe a`. Backend-specific types like `UUID`, `IPRange`, `DiffTime`, `Value` (JSON), and composite types can be added as further instances without any changes to persistent core. Compound types (arrays, composites) are handled by a value-level `PgDecode`/`PgEncode` layer that composes through the binary wire format (see "Compound types" below).
+
+```haskell
+-- Sketch (simplified from the prototype):
+instance FieldDecode PgRowEnv Text where
+    prepareField env _ col onErr onOk = do
+        pgType <- columnType env col
+        case pgType of
+            Scalar PgText    -> onOk (FieldRunner $ \env' onErr' onOk' -> readBytes env' col >>= decodeWith textDecoder onErr' onOk')
+            Scalar PgVarchar -> onOk (FieldRunner $ \env' onErr' onOk' -> readBytes env' col >>= decodeWith textDecoder onErr' onOk')
+            _                -> onErr ("type mismatch: expected text, got " <> show pgType)
+```
+
+The `case pgType of` branch runs once per result set via `prepareRow`. On subsequent rows, only the captured `FieldRunner` executes–  no OID lookup, no branching on column types.
+
+#### SQLite
+
+The environment wraps a `Sqlite.Statement`. SQLite's dynamic typing means the column type can technically vary per row, so `prepareField` here is lightweight, but it still validates that the column index is in range and captures the statement reference, keeping the per-row `FieldRunner` simple.
+
+```haskell
+instance FieldDecode SqliteRowEnv Text where
+    prepareField (SqliteRowEnv stmt) _ col onErr onOk =
+        onOk $ FieldRunner $ \(SqliteRowEnv stmt') onErr' onOk' -> do
+            ty <- Sqlite.columnType stmt' (colIdx col)
+            case ty of
+                Sqlite.NullColumn -> onErr' "unexpected NULL for Text"
+                _                 -> Sqlite.columnText stmt' (colIdx col) >>= onOk'
+```
+
+#### MySQL
+
+The environment wraps a vector of `MySQLBase.Field` metadata and a vector of `Maybe ByteString` row data. `prepareField` captures the field metadata once, and the returned `FieldRunner` uses it to call `MySQL.convert` on each row's data without re-reading the metadata.
+
+```haskell
+instance FieldDecode MySQLRowEnv Text where
+    prepareField env _ col onErr onOk =
+        let field = mysqlFields env V.! col
+        in onOk $ FieldRunner $ \env' onErr' onOk' ->
+            case mysqlRow env' V.! col of
+                Nothing -> onErr' "unexpected NULL for Text"
+                Just bs -> case MySQL.convert field bs of
+                    Just t  -> onOk' t
+                    Nothing -> onErr' "MySQL: cannot convert to Text"
+```
+
+#### MongoDB
+
+The environment wraps a BSON `Document`. `FieldDecode` looks up fields by name (ignoring the column index), which is why the class takes both parameters. For MongoDB, the prepare step is essentially a no-op since each document is self-describing, but the split still keeps the interface uniform.
+
+```haskell
+instance FieldDecode MongoRowEnv Text where
+    prepareField _ name _ onErr onOk =
+        onOk $ FieldRunner $ \(MongoRowEnv doc) onErr' onOk' ->
+            case DB.look (unFieldNameDB name) doc of
+                Just (DB.String t) -> onOk' t
+                Just DB.Null       -> onErr' "unexpected NULL for Text"
+                Nothing            -> onErr' ("missing field: " <> unFieldNameDB name)
+                _                  -> onErr' "expected String"
+
+-- Distinguishes absent fields from null fields:
+instance FieldDecode MongoRowEnv a => FieldDecode MongoRowEnv (Maybe a) where
+    prepareField env name col onErr onOk =
+        prepareField env name col onErr $ \inner ->
+            onOk $ FieldRunner $ \(MongoRowEnv doc) onErr' onOk' ->
+                case DB.look (unFieldNameDB name) doc of
+                    Nothing      -> onOk' Nothing
+                    Just DB.Null -> onOk' Nothing
+                    _            -> runField inner (MongoRowEnv doc) onErr' (onOk' . Just)
+```
+
+#### Redis
+
+The environment wraps binary-encoded key-value pairs. Like MongoDB, `FieldDecode` looks up by field name. The prepare step captures the encoded field name to avoid re-encoding it on every lookup.
+
+```haskell
+instance FieldDecode RedisRowEnv Text where
+    prepareField _ name _ onErr onOk =
+        let key = encodeUtf8 (unFieldNameDB name)
+        in onOk $ FieldRunner $ \(RedisRowEnv pairs) onErr' onOk' ->
+            case V.find (\(k, _) -> k == key) pairs of
+                Just (_, bs) -> case Binary.decode (L.fromStrict bs) of
+                    BinPersistText t -> onOk' t
+                    _                -> onErr' "expected Text"
+                Nothing -> onErr' ("missing field: " <> unFieldNameDB name)
+```
+
+#### How `FromRow` unifies all backends
+
+The same TH-generated instance resolves to different concrete code depending on the `env` type. The prepare/run split means that backends with uniform column types (PostgreSQL, MySQL) get the type dispatch out of the hot loop, while document stores (MongoDB, Redis) still benefit from the uniform interface even though their "prepare" step is lighter.
+
+| `env` | What `prepareField` inspects | What `FieldRunner` reads from |
+|-------|------------------------------|-------------------------------|
+| PostgreSQL | column OID + `OidCache` for composites/enums | binary row data via `postgresql-binary` decoders |
+| SQLite | (lightweight–  validates column index) | `sqlite3_column_*` C API per row |
+| MySQL | `MySQLBase.Field` metadata | `Maybe ByteString` row data + `MySQL.convert` |
+| MongoDB | (no-op–  documents are self-describing) | `DB.look` on BSON `Document` (by field name) |
+| Redis | encodes field name to `ByteString` | `Binary.decode` from key-value pair |
+
+The entity definition contains no backend-specific code, and `PersistValue` appears nowhere in the decode path.
+
+### Specialization: eliminating dictionary overhead
+
+The `FromRow` and `FieldDecode` instances are polymorphic over `env`, which means that in the general case GHC passes typeclass dictionaries at runtime: an indirect function call per field, per row. For a 10-column entity over 100k rows, that's a million indirect calls that could be direct invocations insteadj.
+
+The standard fix is `SPECIALIZE` pragmas. Backend packages can emit specializations for their concrete `env` type, and we will extend TH to generate them automatically from the `MkPersistSettings`.
+
+In order to achieve this, `mkPersist` will gain a new configuration field `mpsDirectEnvTypes :: [Name]` for environments that consumers want to be specialized. When this list contains `'PgRowEnv`, the generated `FromRow` instance for an entity `User` looks like:
+
+```haskell
+instance (FieldDecode env Text, FieldDecode env (Maybe Int))
+      => FromRow env User where
+    rowReader = User <$> nextField "name" <*> nextField "age"
+    {-# SPECIALIZE instance FromRow PgRowEnv User #-}
+```
+
+The pragma is placed inside the body of the instance declaration. When GHC sees it, it creates a monomorphic copy of `rowReader @PgRowEnv @User`, and is then able to inline all the `FieldRunner` calls and eliminate dictionary indirection entirely. The per-row loop collapses to a straight sequence of concrete decoder calls with no polymorphism left at runtime.
+
+Because the list lives in `MkPersistSettings`, code that uses `persistent` against several different backends from a single module (e.g. one module that needs both `PgRowEnv` and `SqliteRowEnv`) can set `mpsDirectEnvTypes = [''PgRowEnv, ''SqliteRowEnv]` and `TH` will emit specializations for both. Backends that don't appear in the list do not get specialized code generated; yet the instance remains polymorphic and continues to compile normally.
+
+This matters most for the `FieldRunner` closures produced by `prepareField`. After specialization, GHC can see through the closure and inline the decoder body directly into the row-reading loop, which in turn enables further optimizations like unboxing intermediate results and eliminating redundant null checks across adjacent fields. Without specialization, the closure is opaque to the optimizer because its concrete type isn't known at the call site.
+
+The encode path benefits similarly: `ToRow`'s `toRowBuilder` and each `FieldEncode` instance can be specialized per `Param` type as soon as `TH` generates `SPECIALIZE` pragmas for the encoding side.
+
+### Query execution
+
+```haskell
+class HasDirectQuery backend where
+    type Env backend
+    directQuerySource
+        :: MonadIO m
+        => backend -> Text -> [PersistValue]
+        -> Acquire (ConduitM () (Env backend) m ())
+
+class HasDirectInsert backend where
+    type Param backend
+    directInsert
+        :: MonadIO m
+        => backend -> Text -> SmallArray (Param backend)
+        -> m ()
+```
+
+Each backend implements `HasDirectQuery` (naming subject to change, just calling it `Direct` to indicate that we're bypassing `PersistValue`,) to send a query and yield one `Env backend` per result row. The conduit consumer runs `prepareField` on the first row (or the result metadata) to obtain `FieldRunner`s, then applies them to every subsequent row via `runField`. The type dispatch happens once and the per-row loop is a straight-line decode.
+
+`HasDirectInsert` is the encoding counterpart, accepting pre-encoded parameters and sending them to the database. A backend instance for PostgreSQL, for example, would define `type Param PgBackend = PgParam` where `PgParam` carries the OID, binary payload, and format code for each parameter.
+
+### User-facing API
+
+In order to make migration as straightforward as possible, the `.Experimental` modules export the same function names as the originals, with additional constraints that indicate that the direct path should be used:
+
+```haskell
+-- Database.Persist.Sql.Experimental:
+rawQuery :: (FromRow (Env backend) a, HasDirectQuery backend, ...)
+    => Text -> [PersistValue] -> ReaderT backend m (Acquire (ConduitM () a m ()))
+
+rawSql :: (FromRow (Env backend) a, HasDirectQuery backend, ...)
+    => Text -> [PersistValue] -> ReaderT backend m [a]
+```
+
+### Esqueleto integration
+
+A `SqlSelectDirect` class parallels esqueleto's `SqlSelect` with a CPS `RowReader`-based decoder:
+
+```haskell
+class SqlSelect a r => SqlSelectDirect a r env where
+    sqlSelectDirectRow :: RowReader env r
+```
+
+This class is parameterized by `env` rather than `backend`–  the mapping from backend to env happens at the call site via the `Env` type family. This means `SqlSelectDirect` instances are written per environment type, which is the right granularity: the row format depends on the env, not on which backend wrapper is in use.
+
+Instances for `Entity`, `Value`, `Maybe (Entity)`, and tuples. The `.Experimental.Direct` module exports `select` with the extra constraint–  same name, same query DSL:
+
+```haskell
+-- Database.Esqueleto.Experimental.Direct:
+import Database.Esqueleto.Experimental.Direct
+
+users <- select $ do
+    p <- from $ table @Person
+    where_ (p ^. PersonAge >=. val 18)
+    return p
+-- Identical syntax. The direct path is chosen by the import, not the function name.
+```
+
+The `backend` type variable already carried by esqueleto resolves `Env backend` via the associated type family in `HasDirectQuery`, which then satisfies the `SqlSelectDirect a r (Env backend)` constraint.
+
+## Design: Encoding
+
+The decode side has a working prototype. The encode side follows the same principles.
+
+### The problem
+
+```mermaid
+flowchart LR
+    A["Haskell record"] -->|"toPersistFields"| B["[PersistValue]"]
+    B -->|"encode per field"| C["wire format"]
+```
+
+Every field is boxed into `PersistValue` and then immediately unboxed. For bulk inserts of 10k rows × 10 columns, that's 100k unnecessary `PersistValue` allocations.
+
+### `FieldEncode`: one class, one method
+
+```haskell
+class FieldEncode param a where
+    encodeField :: a -> param
+```
+
+`param` is a backend-specific encoded parameter type. Each backend decides what `param` looks like: a PostgreSQL backend might use a type carrying an OID, encoded bytes, and a format tag; an SQLite backend might use a sum type mirroring SQLite's type affinity (`SqliteInt !Int64 | SqliteText !Text | ...`).
+
+The class is deliberately minimal: it has one class with one method, but enables a wide range of backends to be supported without breaking changes.
+
+### Alternative: contravariant encoders (hasql-style)
+
+It's worth considering the approach that hasql takes here, which uses contravariant functors to compose encoders:
+
+```haskell
+-- hasql's style:
+userParams :: Params User
+userParams =
+       (userName >$< param (nonNullable text))
+    <> (userAge  >$< param (nullable int4))
+```
+
+The `>$<` operator (contramap from `Contravariant`) lets you project a field out of a record and feed it into an encoder, and `<>` sequences them. The result is a single `Params User` value that knows how to encode an entire record in one pass.
+
+This approach is advantageous in several ways:
+
+1. The encoder is a first-class value that can be composed, stored, and reused; you can build an encoder for a composite type by combining encoders for its parts, and the types enforce that every field is accounted for. 
+2. It separates the *description* of the encoding from the *execution*, which pairs well with the prepare/run split on the decode side: you could prepare a `Params` once and run it per row.
+
+My main concern around this is the learning curve: `Contravariant` and `Divisible` are less familiar than `Applicative` to most Haskell developers, and the corpus of good intuition around them is a bit lacking. For a library like `persistent`, whose user base spans from beginners to experts, that friction matters. `hasql`'s encoding API is one of the things that I've found to be something of a barrier to adoption with `hasql`, even though I'm relatively fluent with Haskell and appreciate the type safety it provides.
+
+That said, if we're already asking users to change imports and adopt new constraints, the marginal cost of learning contravariant composition might be acceptable? Especially since TH can generate the encoders automatically for `Entity` types, meaning most users would only encounter the raw API when writing custom queries. The generated code would look something like:
+
+```haskell
+instance HasEncoder param User where
+    encoder =
+           (userName >$< fieldEncoder @Text)
+        <> (userAge  >$< fieldEncoder @(Maybe Int))
+```
+
+This is an area where we should probably prototype both approaches and see which one leads to clearer error messages and more natural composition in practice. The simple `FieldEncode` class is easier to explain and implement first, but if we're going to make breaking changes at some point anyway, the contravariant approach might be the better long-term bet. It may also be the case that we can build a small DSL on top of `Contravariant` that doesn't feel as foreign to users, which may give us the best of both worlds.
+
+### `ToRow`: TH-generated, produces a builder
+
+```haskell
+-- Writes encoded params into a SmallMutableArray, avoiding intermediate lists.
+newtype ParamBuilder param = ParamBuilder (SmallMutableArray RealWorld param -> Int -> IO Int)
+
+instance Monoid (ParamBuilder param)
+
+writeParam :: FieldEncode param a => a -> ParamBuilder param
+buildParams :: Int -> ParamBuilder param -> IO (SmallArray param)
+```
+
+TH generates:
+
+```haskell
+instance (FieldEncode param Text, FieldEncode param (Maybe Int))
+      => ToRow param User where
+    toRowBuilder (User name age) = writeParam name <> writeParam age
+```
+
+Usage:
+
+```haskell
+params <- buildParams 2 (toRowBuilder user)
+-- params :: SmallArray param, ready for the backend
+```
+
+### Typed query parameters
+
+`FieldEncode` also gives us typed query parameters without routing through `[PersistValue]`:
+
+```haskell
+rawQueryDirectTyped @(Entity User)
+    "SELECT ?? FROM user WHERE age > $1 AND name LIKE $2"
+    (writeParam (18 :: Int) <> writeParam ("A%" :: Text))
+```
+
+Each Haskell value goes directly to the backend's encoded format, skipping `toPersistValue` entirely.
+
+### Column-oriented encoding: UNNEST and = ANY
+
+The direct encode path is designed to support column-oriented parameter encoding, which enables two important patterns:
+
+**Bulk inserts via UNNEST**: instead of `INSERT INTO t VALUES (?,?,?), (?,?,?), ...` with a dynamic SQL string, use `INSERT INTO t (c1, c2, ...) SELECT * FROM UNNEST($1, $2, ...)` where each `$N` is an array containing all values for that column across all rows. The SQL template is fixed regardless of batch size, enabling prepared statement reuse.
+
+**IN-clause via = ANY**: instead of `WHERE id IN (?,?,?,...)` with a variable number of parameters, use `WHERE id = ANY($1)` with one array parameter. Again, the SQL is fixed.
+
+Both patterns require encoding a collection of Haskell values directly into the database's binary array format:
+
+```haskell
+class FieldEncodeArray param a where
+    encodeColumnArray :: Vector a -> param
+```
+
+TH can generate a columnar encoder that transposes a `Vector record` into per-column arrays and encodes each one directly:
+
+```haskell
+class ToRowColumnar param a where
+    toColumnarBuilder :: Vector a -> ParamBuilder param
+
+instance (FieldEncodeArray param Text, FieldEncodeArray param (Maybe Int))
+      => ToRowColumnar param User where
+    toColumnarBuilder users =
+           writeParam (encodeColumnArray (V.map userName users))
+        <> writeParam (encodeColumnArray (V.map userAge users))
+```
+
+For 10k rows × 10 columns, this means that instead of 100k `PersistValue` objects transposed into `PersistArray` lists, the direct path builds 10 binary column arrays from the record fields with no intermediate representation.
+
+## Allocation comparison (decode path)
+
+For a 10-column entity, per row:
+
+|| | `PersistValue` path | Direct CPS path |
+|---|---|---|---|
+| `PersistValue` objects | 10 | 0 |
+| List cons cells | 10 | 0 |
+| `Either` from applicative chain | ~9 | 0 |
+| `Either` from field decode | 10 | 0 (CPS) |
+| `Either` at boundary | 0 | 0 (`runRowReaderCPS`) |
+| Boxed `Int` (column counter) | 10 | 0 (unboxed counter) |
+| Column type dispatch | 10 per row | 10 once (via `prepareRow`) |
+| **Total intermediate objects** | **~49** | **0** |
+
+For 100k rows, that's roughly 4.9 million intermediate objects eliminated.
+
+## Migration strategy: `.Experimental` modules
+
+Following the precedent set by esqueleto (which introduced `Database.Esqueleto.Experimental` for its new `FROM` syntax), the direct codec API lives in `.Experimental` modules alongside the existing API. Users opt in by changing their imports. The existing modules are unchanged.
+
+### persistent core
+
+| Module | Contents |
+|--------|----------|
+| `Database.Persist.Sql` | Unchanged. `selectList`, `get`, `rawSql`, etc. continue to use `[PersistValue]`. |
+| `Database.Persist.Sql.Experimental` | **New.** Re-exports everything from `Database.Persist.Sql`, plus direct-path variants with additional `FromRow`/`ToRow` constraints. Same names, same signatures–  just extra constraints. |
+
+The experimental module provides versions of the standard operations that take the direct path when the constraints are satisfied:
+
+**Note on Standard Operations:**
+
+As of this RFC, only raw query functions are implemented (`rawQueryDirect` and `rawSqlDirect`). The higher-level operations listed above (`selectList`, `get`, `insertMany_`) are planned but not yet implemented. These would be implemented in experimental modules to give users typed, zero-allocation versions of core persistent operations.
+
+Users switch by changing one import:
+
+```haskell
+-- Before:
+import Database.Persist.Sql
+
+-- After (direct path, zero PersistValue):
+import Database.Persist.Sql.Experimental
+```
+
+All existing code continues to work because the experimental signatures are strictly more constrained: they accept a subset of the original callers (those whose backend supports direct codecs). If a backend doesn't have `HasDirectQuery`/`FromRow` instances, etc., the experimental variants simply won't type-check, and the user stays on the original import.
+
+### esqueleto
+
+| Module | Contents |
+|--------|----------|
+| `Database.Esqueleto.Experimental` | Unchanged. |
+| `Database.Esqueleto.Experimental.Direct` | **New.** Re-exports everything from `Database.Esqueleto.Experimental`, plus `selectDirect`, `selectOneDirect`, etc. with `SqlSelectDirect` constraints. |
+
+```haskell
+-- Database.Esqueleto.Experimental (unchanged):
+select :: (SqlSelect a r, MonadIO m, SqlBackendCanRead backend)
+    => SqlQuery a -> ReaderT backend m [r]
+
+-- Database.Esqueleto.Experimental.Direct (new):
+select :: ( SqlSelect a r, SqlSelectDirect a r (Env backend)
+          , MonadIO m, SqlBackendCanRead backend, HasDirectQuery backend )
+    => SqlQuery a -> ReaderT backend m [r]
+```
+
+As long as we provide the same function name, same return type, same query DSL- the only difference is the extra constraints ensuring the direct path is used. The one area where users will run into labor on their end is converting their custom type instances to use the new direct encoding/decoding APIs.
+
+### Backend packages
+
+Each backend package that supports direct codecs exports its `env` type from the primary existing module, as well as its `FieldDecode`/`FieldEncode` instances. These don't need their own `.Experimental` modules: the instances are always available, and they are picked up via normal instance resolution when the user uses the experimental persistent/esqueleto modules.
+
+### Graduation path
+
+Once the direct path is proven stable:
+
+1. The `.Experimental` signatures move into the main modules. The extra constraints are additive: they narrow the accepted backends but don't change behavior for backends that satisfy them.
+2. Backends that don't support direct codecs continue to work via the `[PersistValue]` path.
+3. Eventually, `PersistValue`-based operations could be deprecated in favor of the direct path.
+
+This mirrors esqueleto's migration of its `FROM` syntax from `.Experimental` to the recommended default.
+
+## Relationship to `SqlBackend`
+
+A key design tension that I think requires some discussion: much of the persistent ecosystem (esqueleto's `rawSelectSource`, persistent's default `PersistQueryRead` implementation, user code using `SqlPersistT`) projects down to bare `SqlBackend`, erasing the concrete backend type. The `HasDirectQuery backend` constraint needs to reduce `Env backend` to a concrete type, but `SqlBackend` doesn't correspond to any particular backend, so `Env SqlBackend` has no meaningful definition in terms of the way we want to use it in this proposal.
+
+There are two approaches I think we could take, and they complement each other to some extent.
+
+### Approach 1: Backend-specific types (recommended for new code)
+
+Users and libraries work with the concrete backend type (`WriteBackend PostgreSQLBackend`, `SqliteBackend`, etc.) instead of `SqlBackend`. The `HasDirectQuery` constraint resolves naturally.
+
+For most _application_ code, the concrete type appears only in the runner (`withPostgresqlPool`, `withSqliteConn`, etc.) and the `ReaderT backend m` type. Switching from `SqlPersistT` to a backend-specific `ReaderT` is a relatively straightforward find-and-replace change.
+
+### Approach 2: A direct-codec field on `SqlBackend`
+
+For code that flows through `SqlBackend`, and there's a lot of it, we'd ideally bridge the gap by adding a dedicated field that carries the direct codec machinery from whatever backend created the connection. `SqlBackend` already works this way for other operations: `connInsertSql`, `connPrepare`, `connInsertManySql`, etc. are all function-valued fields that the backend populates at connection setup time, closing over its own concrete types. The direct path would fit naturally into the same pattern:
+
+```haskell
+data SqlBackend = SqlBackend
+    { ...existing fields...
+    , connDirectCodecs :: Maybe DirectCodecs
+    }
+```
+
+The naive idea is to use a rank-2 type so the caller passes a *polymorphic* `RowReader` and the backend instantiates it at its own concrete `env`:
+
+```haskell
+-- ⚠ THIS DOES NOT TYPECHECK: see below
+data DirectCodecs = DirectCodecs
+    { dcQueryAndDecode
+        :: forall a m. MonadIO m
+        => (forall env. FromRow env a => RowReader env a)
+        -> Text -> [PersistValue]
+        -> Acquire (ConduitM () a m ())
+    }
+```
+
+#### Why the rank-2 approach fails
+
+The argument `(forall env. FromRow env a => RowReader env a)` is fine from the *caller's* perspective. the TH-generated `rowReader` class method has exactly this type (polymorphic in `env`, constrained by `FromRow env a`). The caller can provide it.
+
+The problem is on the *consumption* side. The backend's implementation needs to instantiate `env` at its concrete type:
+
+```haskell
+mkPgDirectCodecs :: PgConnection -> DirectCodecs
+mkPgDirectCodecs conn = DirectCodecs
+    { dcQueryAndDecode = \polyReader sql params -> do
+        let reader = polyReader @PgRowEnv  -- needs FromRow PgRowEnv a
+        src <- pgQuerySource conn sql params
+        src .| decodeRowsConduit reader
+    }
+```
+
+When the backend writes `polyReader @PgRowEnv`, GHC needs to discharge the constraint `FromRow PgRowEnv a`. But `a` is a rigid type variable from the outer `forall a`. The backend's lambda must work for *all* `a`, and GHC has no instance `FromRow PgRowEnv a` that covers every possible type. The fact that `FieldDecode PgRowEnv Text` etc. are "in scope" doesn't help; GHC can't perform instance resolution for `FromRow PgRowEnv a` without knowing what `a` is. This produces:
+
+```
+Could not deduce (FromRow PgRowEnv a) arising from a use of 'polyReader'
+```
+
+This is a fundamental tension: you can't erase both `env` (via the closure in `SqlBackend`) and `a` (via `forall a`) while still relying on typeclass instance resolution to connect them. The dictionary for something like `FromRow PgRowEnv User` exists at each specific call site, but nobody at the backend's definition site can work with it.
+
+#### Possible directions
+
+Several alternative encodings were considered, but each has significant drawbacks:
+
+**Parameterize `DirectCodecs` by `env`:** If `DirectCodecs env` carries the env type, the backend can accept `RowReader env a` directly. But `SqlBackend` would need to hold `DirectCodecs env` for some `env`, meaning either `SqlBackend` becomes parameterized (a massive breaking change to the entire ecosystem) or the `env` is hidden behind an existential... at which point the caller can't construct a `RowReader` for an env it doesn't know.
+
+**Compile the decoder at the call site:** The call site knows both `a` and the backend, so it *could* resolve all constraints and produce a fully monomorphic decoding function to pass into `DirectCodecs`. But this requires the call site to know the concrete env type, which means it already has the concrete backend type–  and if it has the concrete backend type, it doesn't need the `SqlBackend` bridge.
+
+**Add a `FromRow` constraint to `dcQueryAndDecode`:** This just pushes the problem: `DirectCodecs` is stored in `SqlBackend` where `a` isn't in scope, so there's nowhere to put the constraint.
+
+#### Solution: `DirectEntity` with `Typeable`-based dispatch
+
+The key insight is that the *entity itself* can carry the knowledge of which `env` types it supports– doing at the term level what `PersistEntityBackend` does at the type level. The mechanism is `Typeable` + `eqTypeRep`.
+
+**A new class: the entity advertises its decoders**
+
+```haskell
+class DirectEntity a where
+    lookupDirectDecoder
+        :: forall env. Typeable env
+        => Proxy env -> Maybe (RowDecoder env a)
+```
+
+TH generates instances using `eqTypeRep` to test the existentially-hidden `env` at runtime. When `mpsDirectEnvTypes = [''PgRowEnv]`:
+
+```haskell
+instance DirectEntity User where
+    lookupDirectDecoder :: forall env. Typeable env
+        => Proxy env -> Maybe (RowDecoder env User)
+    lookupDirectDecoder _ =
+        case eqTypeRep (typeRep @env) (typeRep @PgRowEnv) of
+            Just HRefl -> Just $ RowDecoder $ \env' onErr onOk -> do
+                ctr <- newCounter
+                prepareRow env' ctr onErr $ \decoder ->
+                    runRowDecoder decoder env' onErr onOk
+            Nothing    -> Nothing
+```
+
+When `HRefl` matches, GHC learns `env ~ PgRowEnv` in that branch and can discharge `FromRow PgRowEnv User` via the polymorphic instance (since the `FieldDecode PgRowEnv` instances are in scope from the backend import).
+
+For applications that target multiple backends, `mpsDirectEnvTypes` lists all of them and TH chains the `eqTypeRep` cases:
+
+```haskell
+-- mpsDirectEnvTypes = [''PgRowEnv, ''SqliteRowEnv]
+instance DirectEntity User where
+    lookupDirectDecoder :: forall env. Typeable env
+        => Proxy env -> Maybe (RowDecoder env User)
+    lookupDirectDecoder _ =
+        case eqTypeRep (typeRep @env) (typeRep @PgRowEnv) of
+            Just HRefl -> Just $ RowDecoder $ \env' onErr onOk -> do
+                ctr <- newCounter
+                prepareRow env' ctr onErr $ \d -> runRowDecoder d env' onErr onOk
+            Nothing -> case eqTypeRep (typeRep @env) (typeRep @SqliteRowEnv) of
+                Just HRefl -> Just $ RowDecoder $ \env' onErr onOk -> do
+                    ctr <- newCounter
+                    prepareRow env' ctr onErr $ \d -> runRowDecoder d env' onErr onOk
+                Nothing -> Nothing
+```
+
+Each branch independently resolves its `FromRow` constraint–  the PostgreSQL branch needs `FieldDecode PgRowEnv Text` etc. in scope, the SQLite branch needs `FieldDecode SqliteRowEnv Text` etc. Both are available from their respective backend imports. The fallback `Nothing` is returned for any `env` type not in the list.
+
+At runtime, the `SqlBackend` carries a `DirectQueryCap` from whichever backend created the connection. A PostgreSQL connection stores `MkDirectQueryCap (Proxy @PgRowEnv) ...`, a SQLite connection stores `MkDirectQueryCap (Proxy @SqliteRowEnv) ...`. When `lookupDirectDecoder` runs, exactly one branch matches and produces the decoder; the others are never entered.
+
+**`SqlBackend` stores an existential capability**
+
+```haskell
+data DirectQueryCap where
+    MkDirectQueryCap
+        :: forall env. Typeable env
+        => !(Proxy env)
+        -> (forall a. RowDecoder env a -> Text -> [PersistValue] -> IO [a])
+        -> DirectQueryCap
+```
+
+Each backend populates this at connection setup with its own concrete `env`:
+
+```haskell
+-- PostgreSQL backend
+mkPgDirectQueryCap :: PgConnection -> DirectQueryCap
+mkPgDirectQueryCap conn = MkDirectQueryCap (Proxy @PgRowEnv) $
+    \decoder sql params -> do
+        ret <- pgExecParams conn sql params
+        decodeAllRows decoder ret  -- builds PgRowEnv per row
+
+-- SQLite backend
+mkSqliteDirectQueryCap :: Sqlite.Connection -> DirectQueryCap
+mkSqliteDirectQueryCap conn = MkDirectQueryCap (Proxy @SqliteRowEnv) $
+    \decoder sql params -> do
+        stmt <- Sqlite.prepare conn sql
+        bindParams stmt params
+        decodeAllRows decoder stmt  -- builds SqliteRowEnv per row
+```
+
+The backend's lambda receives a `RowDecoder env a` with `env` already fixed to its concrete type. It doesn't need `FromRow PgRowEnv a` or `FromRow SqliteRowEnv a`–  it already has the fully-resolved decoder. It just constructs `env` values and feeds them in.
+
+**Call site: everything lines up**
+
+```haskell
+rawSqlDirectCompat
+    :: forall record m. (DirectEntity record, MonadIO m)
+    => Text -> [PersistValue] -> ReaderT SqlBackend m (Maybe [record])
+rawSqlDirectCompat sql pvs = do
+    backend <- ask
+    case connDirectQueryCap backend of
+        Nothing -> pure Nothing  -- backend doesn't support direct path
+        Just (MkDirectQueryCap (proxy :: Proxy env) queryFn) ->
+            case lookupDirectDecoder @record proxy of
+                Nothing -> pure Nothing  -- entity doesn't support this env
+                Just decoder -> liftIO $ Just <$> queryFn decoder sql pvs
+```
+
+Type trace:
+
+- Pattern-matching `MkDirectQueryCap` binds existential `env` with `Typeable env`
+- `lookupDirectDecoder @record proxy` tests `env` against known envs via `eqTypeRep`
+- If it matches, `decoder :: RowDecoder env record` with the same existential `env`
+- `queryFn :: RowDecoder env a -> ...`–  same `env`
+- `queryFn decoder sql pvs` typechecks; `a` unifies with `record`
+
+The dictionary resolution happens inside `lookupDirectDecoder` (at the entity's definition site, where the `FieldDecode` instances are in scope), not at the backend's definition site. That asymmetry is what makes this work where the rank-2 approach fails.
+
+**Composability for tuples and `Entity`**
+
+```haskell
+instance (DirectEntity a, DirectEntity b) => DirectEntity (a, b) where
+    lookupDirectDecoder proxy = do
+        da <- lookupDirectDecoder @a proxy
+        db <- lookupDirectDecoder @b proxy
+        pure $ RowDecoder $ \env onErr onOk ->
+            runRowDecoder da env onErr $ \va ->
+                runRowDecoder db env onErr $ \vb ->
+                    onOk (va, vb)
+
+instance (DirectEntity (Key record), DirectEntity record)
+    => DirectEntity (Entity record) where
+    lookupDirectDecoder proxy = do
+        dk <- lookupDirectDecoder @(Key record) proxy
+        dv <- lookupDirectDecoder @record proxy
+        pure $ RowDecoder $ \env onErr onOk ->
+            runRowDecoder dk env onErr $ \k ->
+                runRowDecoder dv env onErr $ \v ->
+                    onOk (Entity k v)
+```
+
+`Maybe` short-circuits the composition: if either inner `lookupDirectDecoder` returns `Nothing` (e.g. because one component doesn't support this backend's `env`), the whole tuple/entity returns `Nothing`.
+
+**Concrete backends bypass this entirely**
+
+The `Typeable` mechanism is strictly the `SqlBackend` compatibility bridge. With a concrete backend type, normal static dispatch applies:
+
+```
+ReaderT PgBackend m a     →  static FromRow (Env PgBackend) record
+                              no Typeable, no Maybe, full specialization
+
+ReaderT SqlBackend m a    →  DirectEntity record
+                              Typeable-based lookupDirectDecoder
+                              graceful fallback if env doesn't match
+```
+
+There is no overlap: `SqlBackend` and concrete backends are different types. Library code (esqueleto, persistent's default `PersistQueryRead` impl) that works with `SqlBackend` gets the dynamic path. Application code that uses the concrete backend type gets the static path. Both share the same TH-generated `FromRow` instances and the same `FieldRunner` hot loop– the only difference is how the initial decoder is resolved.
+
+**Cost**
+
+- One `eqTypeRep` call per query setup (fingerprint comparison, negligible)
+- `Typeable env` constraint on the backend's env type (trivially derivable, already holds for any concrete type in GHC)
+- `lookupDirectDecoder` returns `Nothing` if the entity wasn't generated for that backend's env → graceful fallback to `PersistValue` path
+- Default `lookupDirectDecoder _ = Nothing` keeps full backward compatibility
+
+**What TH generates**
+
+For `mpsDirectEnvTypes = [''PgRowEnv, ''SqliteRowEnv]`, a single `mkPersist` call emits:
+
+```haskell
+-- Polymorphic: works for both the concrete-backend and SqlBackend paths
+instance (FieldDecode env Text, FieldDecode env (Maybe Int))
+      => FromRow env User where
+    rowReader = User <$> nextField "name" <*> nextField "age"
+    prepareRow env ctr onErr onOk = do
+        col0 <- advanceCounter ctr
+        prepareField env "name" col0 onErr $ \r0 -> do
+            col1 <- advanceCounter ctr
+            prepareField env "age" col1 onErr $ \r1 ->
+                onOk $ RowDecoder $ \env' onErr' onOk' ->
+                    runField r0 env' onErr' $ \v0 ->
+                        runField r1 env' onErr' $ \v1 ->
+                            onOk' (User v0 v1)
+    {-# SPECIALIZE instance FromRow PgRowEnv User #-}
+    {-# SPECIALIZE instance FromRow SqliteRowEnv User #-}
+
+-- SqlBackend bridge: chains eqTypeRep for each env in mpsDirectEnvTypes
+instance DirectEntity User where
+    lookupDirectDecoder _ =
+        case eqTypeRep (typeRep @env) (typeRep @PgRowEnv) of
+            Just HRefl -> Just $ RowDecoder $ \env' onErr onOk -> do
+                ctr <- newCounter
+                prepareRow env' ctr onErr $ \d -> runRowDecoder d env' onErr onOk
+            Nothing -> case eqTypeRep (typeRep @env) (typeRep @SqliteRowEnv) of
+                Just HRefl -> Just $ RowDecoder $ \env' onErr onOk -> do
+                    ctr <- newCounter
+                    prepareRow env' ctr onErr $ \d -> runRowDecoder d env' onErr onOk
+                Nothing -> Nothing
+```
+
+The same entity works with both backends through `SqlBackend`. At runtime, the connection determines which branch fires.
+
+## Compound types: value-level codecs
+
+`FieldDecode` operates at the column level– it gets `env` (with a result pointer and column index) and decodes one result-set column into one Haskell value. This is sufficient for scalar types and embedded entities (which flatten into multiple columns and are handled by `FromRow`'s applicative composition).
+
+However, backends with compound wire-format types need a second layer. PostgreSQL has arrays, composites, ranges, and nested combinations thereof– all encoded as a single column whose binary payload contains structured sub-values. These sub-values are not result-set columns, so `FieldDecode` can't recurse into them.
+
+### The two-layer architecture
+
+```
+PostgreSQL binary wire format
+         │
+         ▼
+   PgDecode / PgDecoder     ← value-level: operates on raw bytes
+         │                     composes for arrays, composites, ranges
+         │
+         ▼
+   FieldDecode PgRowEnv      ← column-level: wraps PgDecode
+         │                     adds column metadata lookup, prepare/run split
+         │
+         ▼
+   FromRow PgRowEnv record   ← row-level: sequences FieldDecode across columns
+                                TH-generated, applicative composition
+```
+
+The value-level layer is backend-specific. Other backends define their own if needed (MongoDB doesn't need one– BSON provides typed access; SQLite doesn't– it has no compound column types).
+
+### `PgDecoder`: a reader over `OidCache`
+
+Both encode and decode of compound types need access to an `OidCache`– a mapping from dynamically-assigned PostgreSQL OIDs (composites, enums, domains) to their type metadata, populated at connection time from `pg_type`.
+
+`PgDecoder` wraps `postgresql-binary`'s `PD.Value` in a reader so the cache is threaded without manual plumbing:
+
+```haskell
+newtype PgDecoder a = PgDecoder { runPgDecoder :: OidCache -> PD.Value a }
+
+instance Functor PgDecoder
+instance Applicative PgDecoder
+instance Monad PgDecoder
+```
+
+`PgComposite` wraps `PD.Composite` the same way:
+
+```haskell
+newtype PgComposite a = PgComposite (OidCache -> PD.Composite a)
+
+instance Functor PgComposite
+instance Applicative PgComposite
+```
+
+### DSL combinators
+
+```haskell
+pgValue         :: PD.Value a -> PgDecoder a                 -- lift raw decoder
+pgComposite     :: PgComposite a -> PgDecoder a              -- composite → value
+pgField         :: PgDecoder a -> PgComposite a              -- non-nullable sub-field
+pgFieldNullable :: PgDecoder a -> PgComposite (Maybe a)      -- nullable sub-field
+pgArray         :: PgDecoder a -> PgDecoder [a]              -- array of non-nullable
+pgArrayNullable :: PgDecoder a -> PgDecoder [Maybe a]        -- array of nullable
+```
+
+### `PgDecode` class
+
+```haskell
+class PgDecode a where
+    pgDecoder :: PgDecoder a
+```
+
+Scalar instances are one-liners wrapping `postgresql-binary` decoders:
+
+```haskell
+instance PgDecode Text    where pgDecoder = pgValue PD.text_strict
+instance PgDecode Int64   where pgDecoder = pgValue PD.int
+instance PgDecode Bool    where pgDecoder = pgValue PD.bool
+instance PgDecode UTCTime where pgDecoder = pgValue PD.timestamptz_int
+-- ...etc.
+```
+
+These don't replace the existing `FieldDecode PgRowEnv Text` instances– the scalar `FieldDecode` instances still handle OID dispatch at the column level (accepting `PgText`, `PgVarchar`, `PgBpchar`, etc. for `Text`). `PgDecode` is used only when composing inside compound types.
+
+Arrays get a single generic instance:
+
+```haskell
+instance PgDecode a => PgDecode [a] where
+    pgDecoder = pgArray pgDecoder
+
+instance PgDecode a => PgDecode [Maybe a] where
+    pgDecoder = pgArrayNullable pgDecoder
+```
+
+A composite type like:
+
+```sql
+CREATE TYPE address AS (street text, city text, zip text);
+```
+
+becomes:
+
+```haskell
+instance PgDecode Address where
+    pgDecoder = pgComposite $ Address
+        <$> pgField pgDecoder
+        <*> pgField pgDecoder
+        <*> pgField pgDecoder
+```
+
+And `FieldDecode` for composite columns is a one-liner:
+
+```haskell
+instance FieldDecode PgRowEnv Address where
+    prepareField = compositeFieldDecode  -- provided helper
+```
+
+Arrays of composites, composites containing arrays, nested composites– all compose through `pgDecoder` without duplication:
+
+```haskell
+-- [Address] works automatically via PgDecode [a]
+instance FieldDecode PgRowEnv [Address] where
+    -- generic instance: PgDecode a => FieldDecode PgRowEnv [a]
+    -- resolves via PgDecode Address above
+```
+
+### `PgEncode`: symmetric encode side
+
+```haskell
+newtype PgEncoder a = PgEncoder { runPgEncoder :: OidCache -> a -> PE.Encoding }
+
+class PgEncode a where
+    pgEncoder  :: PgEncoder a
+    pgTypeOid' :: OidCache -> Proxy a -> Word32
+```
+
+Scalar instances are pure (ignoring the cache); composite instances use it to look up dynamically-assigned OIDs:
+
+```haskell
+instance PgEncode Text where
+    pgEncoder  = pgConst PE.text_strict
+    pgTypeOid' _ _ = scalarOidWord32 PgText
+
+instance PgEncode Address where
+    pgTypeOid' cache _ = lookupCompositeOid cache "address"
+    pgEncoder = pgCompositeEncoder $ \cache (Address s c z) ->
+        pgEncodeField cache s
+        <> pgEncodeField cache c
+        <> pgEncodeField cache z
+```
+
+`pgEncodeField` produces a `PE.Composite` field tagged with the value's OID:
+
+```haskell
+pgEncodeField :: PgEncode a => OidCache -> a -> PE.Composite
+```
+
+Arrays compose generically:
+
+```haskell
+instance PgEncode a => PgEncode [a] where
+    pgEncoder = pgArrayEncoder
+    pgTypeOid' cache _ = lookupArrayOid cache (pgTypeOid' cache (Proxy @a))
+```
+
+### OidCache: bridging PostgreSQL's dynamic type system
+
+`OidCache` is populated once at connection setup from `pg_type`:
+
+```sql
+SELECT oid, typname, typtype, typarray, typrelid
+FROM pg_type
+WHERE typtype IN ('c', 'e', 'd', 'r')
+```
+
+This maps dynamic OIDs to structured `PgType` values:
+
+```haskell
+data PgType
+    = Scalar !PgScalar
+    | Array  !PgScalar
+    | Composite !Text !Int     -- type name, array OID
+    | CompositeArray !Text     -- element type name
+    | Enum !Text !Int          -- type name, array OID
+    | EnumArray !Text          -- element type name
+    | Unrecognized !Int
+```
+
+`PgRowEnv` carries the cache so `FieldDecode` instances can validate composite/enum OIDs at prepare time rather than blindly accepting any `Unrecognized` OID:
+
+```haskell
+data PgRowEnv = PgRowEnv
+    { pgResult   :: !LibPQ.Result
+    , pgRow      :: !LibPQ.Row
+    , pgCols     :: !(V.Vector (LibPQ.Column, PgType))
+    , pgRowCache :: !OidCache
+    }
+```
+
+On the encode side, `PgParam` closes over the cache as a function rather than a flat triple, so composite/enum types can resolve their OIDs at send time without changing `FieldEncode`'s pure signature:
+
+```haskell
+newtype PgParam = PgParam
+    { materializeParam :: OidCache -> Maybe (LibPQ.Oid, ByteString, LibPQ.Format) }
+```
+
+The cache is applied once when the backend sends parameters to `libpq`.
+
+### `PersistField` compatibility
+
+`PersistField` instances are still required for all entity field types. The `PersistValue`-based path serves as the fallback for:
+
+- `SqlBackend` when `lookupDirectDecoder` returns `Nothing`
+- Entities not generated with `mpsDirectEnvTypes`
+- Any backend that doesn't populate `connDirectQueryCap`
+
+Beyond the fallback, `PersistField` is baked into `PersistEntity` itself– the existing TH-generated `fromPersistValues`/`toPersistFields` use it, and migration/schema introspection depends on it.
+
+For custom types, authors write both:
+
+- `PersistField` (required by `PersistEntity`, used by fallback and existing code)
+- `FieldDecode`/`FieldEncode` (used by the direct path for backends they care about)
+
+For built-in types (`Text`, `Int`, `Bool`, `UTCTime`, etc.), persistent core provides `PersistField`, and the backend packages provide `FieldDecode`/`FieldEncode`. TH generates `FromRow` and `DirectEntity`. Users of standard types see no additional work.
+
+For custom types that don't have native `FieldDecode` instances, a bridge helper can decode via `PersistField` at the cost of a per-field `PersistValue` allocation for that field only– the rest of the row still decodes directly.

--- a/persistent-postgresql-ng/ARCHITECTURE.md
+++ b/persistent-postgresql-ng/ARCHITECTURE.md
@@ -1,0 +1,408 @@
+# persistent-postgresql-ng Architecture
+
+A PostgreSQL backend for the [persistent](https://hackage.haskell.org/package/persistent) library that uses the **binary wire protocol** and **libpq pipeline mode** to reduce round-trips and improve throughput.
+
+## Motivation
+
+The standard `persistent-postgresql` backend sends every operation as a synchronous request-response pair over the text protocol via `postgresql-simple`. For workloads that issue many small DML statements (deletes, updates, replaces) this means one network round-trip per operation.
+
+`persistent-postgresql-ng` changes two things:
+
+1. **Binary protocol**–  parameters and results use PostgreSQL's binary format via `postgresql-binary`, avoiding text serialization overhead.
+2. **Automatic pipelining**–  DML operations are sent eagerly without waiting for a response. Results are deferred until a read operation or transaction commit forces them to be consumed.
+
+The pipelining design is inspired by [Hedis](https://hackage.haskell.org/package/hedis), where commands are sent eagerly and replies are read lazily. Instead of lazy IO, this library uses a pending-result counter with explicit drain points.
+
+## Module Overview
+
+```
+Database.Persist.Postgresql
+├── Pipeline.hs                      -- SqlBackend construction, statement execution, pipeline lifecycle
+├── Pipeline/
+│   ├── Internal.hs                  -- PgConn type, libpq wrappers, pipeline mode primitives
+│   └── FFI.hs                       -- C bindings for chunked-row mode detection
+├── Internal.hs                      -- Escape functions, PgInterval, re-exports from Migration
+├── Internal/
+│   ├── Decoding.hs                  -- Binary result column → PersistValue decoding
+│   ├── Encoding.hs                  -- PersistValue → binary parameter encoding
+│   ├── DirectDecode.hs              -- PgRowEnv, FieldDecode instances, compositeFieldDecode
+│   ├── DirectEncode.hs              -- PgParam ADT, FieldEncode instances
+│   ├── PgCodec.hs                   -- PgDecode/PgEncode classes, PgDecoder/PgEncoder reader types, DSL
+│   ├── PgType.hs                    -- OID classification (PgType/PgScalar), OidCache
+│   ├── Migration.hs                 -- DDL migration logic (adapted from persistent-postgresql)
+│   └── Placeholders.hs             -- ? → $1,$2,... placeholder rewriting
+├── JSON.hs                          -- JSON column support
+└── CustomType.hs                    -- Custom PostgreSQL type support
+```
+
+## Connection Lifecycle
+
+### Opening
+
+`openPgConn` (in `Connection.hs`) does three things:
+
+1. Calls `LibPQ.connectdb` to establish a TCP/Unix socket connection.
+2. Queries the server version (via `LibPQ.serverVersion` or `SHOW server_version` as fallback).
+3. **Enables nonblocking mode** via `LibPQ.setnonblocking`–  required to prevent deadlock in pipeline mode (see below).
+4. **Enters pipeline mode** via `LibPQ.enterPipelineMode`–  this stays on for the lifetime of the connection.
+
+The result is a `PgConn`:
+
+```haskell
+data PgConn = PgConn
+    { pgConn      :: !LibPQ.Connection
+    , pgVersion   :: !(NonEmpty Word)
+    , pgPending   :: !(IORef Int)
+    , pgFetchMode :: !FetchMode
+    , pgOidCache  :: !(IORef OidCache)
+    }
+```
+
+- `pgPending` tracks the number of fire-and-forget query results that have been sent but not yet read.
+- `pgFetchMode` controls how result rows are fetched: `FetchAll` (default), `FetchSingleRow`, or `FetchChunked n` (PG17+ libpq).
+- `pgOidCache` maps dynamically-assigned OIDs (composites, enums, domains) to `PgType` values. Starts empty; populated at connection time or on first encounter. Used by `FieldDecode` instances for OID validation and by `PgEncode` for composite/enum OID lookup.
+
+### Closing
+
+`closePgConn` drains any pending results (via `pipelineSync` + drain), exits pipeline mode, and calls `LibPQ.finish`.
+
+### Nonblocking Mode and Buffer Management
+
+The connection is set to nonblocking mode before entering pipeline mode. This is critical: in blocking mode, `LibPQ.flush` blocks until the entire send buffer is written to the socket. If the server's send buffer is also full (because we haven't consumed its results), both sides block and deadlock.
+
+In nonblocking mode, `LibPQ.flush` returns `FlushWriting` when the socket buffer is full. Our `pgFlush` handles this by:
+
+1. Calling `threadWaitWrite` (GHC's I/O manager) to wait for socket writability without busy-waiting.
+2. Calling `consumeInput` to read any pending server data–  this prevents the server from blocking on *its* send buffer.
+3. Retrying `flush` until `FlushOk`.
+
+This cooperative flush loop ensures neither client nor server blocks indefinitely, even under heavy pipeline load.
+
+### Connection Pooling
+
+Each pooled connection has its own independent `pgPending` counter and lazy reply stream. There is no cross-connection pipelining–  operations on one connection do not affect another.
+
+When a connection is returned to the pool, `closePgConn` drains any pending results before closing. If the pool reuses a connection (via `runSqlPool`), persistent's transaction management (`connCommit` / `connRollback`) ensures the pipeline is clean before the connection is returned.
+
+## Pipeline Mode
+
+### How libpq Pipeline Mode Works
+
+In normal (non-pipeline) mode, `execParams` sends a query and blocks until the server responds. In pipeline mode:
+
+- **`sendQueryParams`** queues a query in the client's send buffer without waiting for a response.
+- **`pipelineSync`** inserts a sync point–  the server processes all queued queries and sends back results in order.
+- **`sendFlushRequest`** asks the server to flush its output buffer without a full sync point.
+- **`getResult`** reads the next result from the connection.
+
+Each query's result follows a protocol:
+- `getResult` → `Just result` (the actual result)
+- `getResult` → `Nothing` (NULL separator marking end of that query's results)
+
+A `pipelineSync` result is different:
+- `getResult` → `Just result` with status `PipelineSync` (no NULL separator follows)
+
+### Automatic Pipelining Strategy
+
+Pipeline mode is **always on**. Operations fall into three categories:
+
+**Hedis-style lazy reads** (`pipelinedGet`, `pipelinedInsert`, `pipelinedGetBy`, `pipelinedCount`, `pipelinedExists`):
+Sends the query with `sendQueryParams` into the output buffer (no flush), pops a lazy reply from the reply stream (no IO forced). The result is returned as an `unsafeInterleaveIO` thunk. When the caller inspects the value, the thunk fires: flushes the send buffer (sending ALL queued queries in one batch), reads the result. Operations that use this path:
+
+- `get`, `getBy`, `count`, `exists`–  return lazy results
+- `insert`–  sends INSERT RETURNING, returns lazy `Key`
+
+This means `mapM get keys` sends all 100 queries before reading any results, achieving **20-29× speedup** at realistic network latencies.
+
+**Fire-and-forget** (via `stmtExecute` → `execute'`):
+Sends the query with `sendQueryParams`, increments `pgPending`, returns immediately. No round-trip. Operations that use this path:
+
+- `delete`, `update`, `updateWhere`, `deleteWhere`
+- `replace`, `insertKey`, `repsert`, `putMany`
+- `rawExecute`, `insert_`
+
+**Conduit-based reads** (via `stmtQuery` → `withStmt'`):
+Drains pending fire-and-forget results, then sends the query, pops from the reply stream, and reads the result eagerly (for conduit streaming compatibility). Operations that use this path:
+
+- `selectList`, `selectFirst`, `selectSourceRes`, `selectKeysRes`
+- `rawSql`, `rawQuery`
+- `insertMany` (needs RETURNING for multiple keys)
+
+**Note on `rawExecuteCount`:** persistent's `rawExecuteCount` goes through `stmtExecute`, so it always returns 0 in this backend (the actual affected row count is never read). This affects esqueleto's `deleteCount`, `updateCount`, and `insertSelectWithConflictCount`. The non-count variants (`delete`, `update`, `insertSelectWithConflict`) work correctly since they discard the return value.
+
+### Lazy Reply Stream
+
+All pipeline results are read through a single lazy reply stream, inspired by [Hedis](https://www.iankduncan.com/engineering/2026-02-17-archive-redis-pipelining).
+
+```haskell
+data PgConn = PgConn
+    { ...
+    , pgReplies :: !(IORef [LibPQ.Result])  -- lazy reply stream
+    }
+```
+
+The stream is built at connection time with `unsafeInterleaveIO`:
+
+```haskell
+mkReplyStream :: PgConn -> IO [LibPQ.Result]
+mkReplyStream pc = go
+  where
+    go = unsafeInterleaveIO $ do
+        pgFlush pc                    -- flush send buffer
+        ret <- readResultAndSep pc    -- read one result + NULL separator
+        rest <- go                    -- next element (lazy thunk)
+        return (ret : rest)
+```
+
+`pgRecvResult` pops using `head`/`tail` (not pattern matching) to keep the cons cell lazy:
+
+```haskell
+pgRecvResult :: PgConn -> IO LibPQ.Result
+pgRecvResult pc = atomicModifyIORef (pgReplies pc) (\xs -> (tail xs, head xs))
+```
+
+`atomicModifyIORef` is lazy in the function result–  neither `head` nor `tail` is evaluated. The IO only fires when the caller forces the returned `LibPQ.Result`. This is the key property that enables automatic pipelining: multiple `pgRecvResult` calls accumulate unevaluated thunks, and the first force triggers a flush that sends all queued queries at once.
+
+The ordering guarantee: each thunk N is created inside thunk N-1's `unsafeInterleaveIO` body, so results are always read in pipeline order regardless of which thunk the caller forces first.
+
+### Drain Points
+
+Results accumulate in the server's output buffer and are read at these drain points:
+
+1. **`withStmt'` (any read operation)**–  calls `drainPending` before executing the read query.
+2. **`connCommit`**–  drains all pending results plus the COMMIT result, verifying none failed.
+3. **`connRollback`**–  drains everything to the sync point, ignoring errors.
+
+### Transaction Lifecycle
+
+```
+connBegin:   sendQueryParams "BEGIN"  → increment pgPending (fire-and-forget)
+             [user DML operations     → each increments pgPending]
+             [user read operations    → each drains all pending first]
+connCommit:  sendQueryParams "COMMIT" → pipelineSync
+             → drain (N pending + 1 COMMIT) results
+             → read PipelineSync marker
+             → throw if any query failed
+```
+
+BEGIN is pipelined with the first user query–  zero extra round-trips for transaction setup.
+
+### Examples
+
+**100 deletes then select (fire-and-forget pipelining):**
+
+```haskell
+forM_ keys delete          -- 100x sendQueryParams, pgPending = 100
+selectList [] []           -- drainPending (reads 100 results in one pass)
+                           -- then sends SELECT and reads its result
+```
+
+Without pipelining: 101 round-trips. With pipelining: ~2 round-trips.
+
+**100 gets (Hedis-style lazy pipelining):**
+
+```haskell
+results <- mapM get keys   -- 100x send SELECT (no flush, no read)
+                           -- 100x pop lazy reply from stream
+print results              -- forces first thunk → flushes ALL 100 queries
+                           -- reads 100 results sequentially (already buffered)
+```
+
+Without pipelining: 100 round-trips. With pipelining: 1 flush + 100 sequential reads.
+At 1ms/direction: **14ms** (pipeline) vs **280ms** (sequential)–  **20× faster**.
+
+**100 inserts (pipelined RETURNING):**
+
+```haskell
+keys <- mapM insert recs   -- 100x send INSERT RETURNING (no flush, no read)
+                           -- 100x pop lazy reply
+evaluate (length keys)     -- forces first thunk → flushes ALL 100 queries
+                           -- reads 100 keys sequentially
+```
+
+Without pipelining: 100 round-trips. With pipelining: 1 flush + 100 sequential reads.
+At 5ms/direction: **41ms** (pipeline) vs **1.2s** (sequential)–  **29× faster**.
+
+### Error Handling
+
+**Mid-transaction error (during `drainPending`):**
+1. All N pending results are drained and the counter is reset to 0.
+2. Errors are collected; the first error is thrown.
+3. The exception propagates to persistent, which calls `connRollback`.
+4. Rollback sends ROLLBACK + sync → `drainToSync` consumes everything (including `PipelineAbort` status for queries after the failed one) → connection is clean.
+
+**Commit-time error:**
+1. All N+1 results (pending + COMMIT) are drained, sync marker is consumed.
+2. Pipeline is fully clean before the error is thrown.
+3. persistent calls `connRollback` → sends into an empty pipeline → clean drain.
+
+**Pipeline abort state:** After a query error in pipeline mode, PostgreSQL marks subsequent queued queries with `PipelineAbort` status until the next sync point. The `drainNResults` helper handles this by collecting errors and skipping aborted results. The sync in commit/rollback resets the abort state.
+
+## Binary Protocol
+
+### Encoding (`Encoding.hs`)
+
+`encodePersistValue` converts each `PersistValue` variant to a `(Oid, ByteString, Format)` triple using `postgresql-binary` encoders:
+
+| PersistValue | PostgreSQL Type | OID |
+|---|---|---|
+| `PersistText` | text | 25 |
+| `PersistInt64` | int8 | 20 |
+| `PersistDouble` | float8 | 701 |
+| `PersistBool` | bool | 16 |
+| `PersistDay` | date | 1082 |
+| `PersistUTCTime` | timestamptz | 1184 |
+| `PersistByteString` | bytea | 17 |
+| `PersistRational` | numeric | 1700 |
+| `PersistNull` | –  | (Nothing) |
+| `PersistArray` | typed array | inferred |
+| `PersistList` | unknown (JSON text) | 0 |
+| `PersistMap` | unknown (JSON text) | 0 |
+| `DbSpecific`/`Escaped` | unknown (text format) | 0 |
+
+`PersistArray` (used by the IN→ANY rewrite) infers the element type from the first non-null element and encodes as a native PostgreSQL array.
+
+`PersistLiteral_ Unescaped` values are inlined into the SQL text before encoding (see SQL Rewriting below) and should never reach the encoder.
+
+### Decoding (`Decoding.hs`)
+
+`decodePersistValue` dispatches on the column OID to the appropriate `postgresql-binary` decoder. Covers scalar types, array types (bool[], int8[], text[], timestamptz[], etc.), JSON/JSONB, UUID (binary → hex text), money, interval, and more. Unknown OIDs fall back to `PersistLiteralEscaped` with raw bytes.
+
+## Direct Decode/Encode Path
+
+In addition to the `PersistValue`-based path, the backend supports a direct codec path that bypasses `PersistValue` entirely. See the [RFC](../RFC-direct-decode.md) for the full design rationale.
+
+### Three layers
+
+| Layer | Type | Scope | Purpose |
+|-------|------|-------|---------|
+| `FromRow` / `RowReader` | Backend-agnostic (in `persistent` core) | Row | Sequence field decoders across columns |
+| `FieldDecode` / `FieldRunner` | Backend-agnostic (in `persistent` core) | Column | Prepare-once OID dispatch, per-row decode |
+| `PgDecode` / `PgDecoder` | PostgreSQL-specific (`PgCodec.hs`) | Value | Compose inside arrays/composites |
+
+### `PgRowEnv`–  the row environment
+
+```haskell
+data PgRowEnv = PgRowEnv
+    { pgResult   :: !LibPQ.Result
+    , pgRow      :: !LibPQ.Row
+    , pgCols     :: !(V.Vector (LibPQ.Column, PgType))
+    , pgRowCache :: !OidCache
+    }
+```
+
+`FieldDecode PgRowEnv` instances inspect `pgCols` to select the right `postgresql-binary` decoder once per result set (via `prepareRow`), then read binary data from `pgResult`/`pgRow` on each row.
+
+### Prepare-once execution
+
+`FromRow` exposes `prepareRow` which calls `prepareField` for each column once, captures the `FieldRunner`s in a `RowDecoder` closure, and reuses them across all rows. The per-row loop calls only `runField`–  no OID dispatch, no vector lookup, no branching on column types.
+
+### `PgParam`–  encoded parameters
+
+```haskell
+data PgParam
+    = PgNull
+    | PgValue {-# UNPACK #-} !LibPQ.Oid !ByteString !LibPQ.Format
+```
+
+Unpacked ADT replacing `Maybe (Oid, ByteString, Format)`. Converted to libpq's representation via `pgParamToLibPQ` at the send boundary.
+
+### Value-level codecs (`PgCodec.hs`)
+
+For compound types (arrays, composites), `PgDecode` / `PgEncode` compose through PostgreSQL's binary wire format:
+
+```haskell
+newtype PgDecoder a = PgDecoder { runPgDecoder :: OidCache -> PD.Value a }
+
+class PgDecode a where pgDecoder :: PgDecoder a
+class PgEncode a where pgEncoder :: PgEncoder a; pgTypeOid' :: OidCache -> Proxy a -> Word32
+```
+
+DSL: `pgValue`, `pgComposite`, `pgField`, `pgFieldNullable`, `pgArray`, `pgArrayNullable`. Generic `FieldDecode PgRowEnv [a]` instance via `PgDecode`.
+
+### `SqlBackend` bridge (`DirectEntity`)
+
+`SqlBackend` stores a `DirectQueryCap` that existentially hides `PgRowEnv`. Entities with `DirectEntity` instances use `Typeable`/`eqTypeRep` to recover the concrete env at query time. See `rawSqlDirectCompat` in `DirectRaw.hs`.
+
+### `HasDirectQuery`–  concrete backend path
+
+For code that retains the concrete backend type (e.g. `WriteBackend PostgreSQLBackend`), `HasDirectQuery` provides zero-overhead static dispatch with no `Typeable` involved. The `SqlBackend` bridge is only for code that flows through the erased `SqlBackend` type.
+
+## SQL Rewriting
+
+Three transformations happen between persistent's generated SQL and what gets sent to PostgreSQL:
+
+### 1. Unescaped Literal Inlining (`inlineUnescaped`)
+
+`PersistLiteral_ Unescaped` values are raw SQL fragments (e.g., `EXCLUDED."field_name"`). These can't be sent as bind parameters–  they're spliced directly into the SQL text, and removed from the parameter list.
+
+### 2. IN → ANY Collapsing (`collapseInClauses`)
+
+Rewrites:
+- `IN (?,?,?)` → `= ANY(?)` with parameters collapsed into a single `PersistArray`
+- `NOT IN (?,?,?)` → `<> ALL(?)` with the same collapsing
+
+This reduces the number of bind parameters and lets PostgreSQL use its native array comparison operators. The rewriter is SQL-aware: it skips string literals, quoted identifiers, and comments.
+
+### 3. Placeholder Rewriting (`rewritePlaceholders`)
+
+Converts `?` placeholders to `$1, $2, ...` numbered parameters as required by libpq's `sendQueryParams`. `??` (persistent's column-expansion escape) becomes a literal `?`.
+
+## Pipeline Helpers
+
+Six internal functions implement the libpq pipeline result protocol:
+
+| Function | Purpose |
+|---|---|
+| `drainOneResult` | Read one result + NULL separator, free it, return error if any |
+| `readOneQueryResult` | Read one result + NULL separator, return it (caller frees), throw on error |
+| `drainNResults` | Drain N results collecting errors, does NOT throw |
+| `drainSyncResult` | Read PipelineSync result (no NULL separator after it) |
+| `drainToSync` | Drain everything until PipelineSync, ignoring all errors |
+| `drainPending` | Flush + drain all pending fire-and-forget results, throw if any failed |
+
+## API Surface
+
+### Drop-in replacement for `persistent-postgresql`
+
+```haskell
+createPostgresqlPipelinePool :: ConnectionString -> Int -> m (Pool SqlBackend)
+withPostgresqlPipelinePool   :: ConnectionString -> Int -> (Pool SqlBackend -> m a) -> m a
+withPostgresqlPipelineConn   :: ConnectionString -> (SqlBackend -> m a) -> m a
+
+getPipelineConn :: backend -> Maybe PgConn
+createRawPostgresqlPipelinePool :: ConnectionString -> Int -> m (Pool (RawPostgresqlPipeline SqlBackend))
+```
+
+All standard persistent operations (`insert`, `get`, `selectList`, `delete`, `update`, `upsert`, etc.) work transparently. No user code changes required.
+
+### Direct decode/encode (zero-`PersistValue` path)
+
+For code with the concrete backend type:
+
+```haskell
+rawQueryDirect :: (FromRow (Env backend) a, HasDirectQuery backend)
+    => Text -> ParamBuilder (Param backend) -> ReaderT backend m (Acquire (ConduitM () a m ()))
+rawSqlDirect  :: (FromRow (Env backend) a, HasDirectQuery backend)
+    => Text -> ParamBuilder (Param backend) -> ReaderT backend m [a]
+```
+
+For code through `SqlBackend`:
+
+```haskell
+rawSqlDirectCompat :: (DirectEntity a)
+    => Text -> [PersistValue] -> ReaderT SqlBackend m (Maybe [a])
+```
+
+Backend-specific codec modules:
+
+```haskell
+-- Re-exported from Database.Persist.Postgresql.Internal.DirectDecode
+PgRowEnv (..)          -- row environment
+compositeFieldDecode   -- one-liner for composite FieldDecode instances
+
+-- Re-exported from Database.Persist.Postgresql.Internal.PgCodec
+PgDecode (..), PgEncode (..)  -- value-level codec classes
+pgValue, pgComposite, pgField, pgFieldNullable, pgArray, pgArrayNullable  -- decode DSL
+pgConst, pgEncodeField, pgArrayEncoder, pgCompositeEncoder                -- encode DSL
+```

--- a/persistent-postgresql-ng/README.md
+++ b/persistent-postgresql-ng/README.md
@@ -1,0 +1,158 @@
+# persistent-postgresql-ng
+
+A PostgreSQL backend for [persistent](https://hackage.haskell.org/package/persistent) that uses the **binary wire protocol** and **libpq pipeline mode**.
+
+Mostly a drop-in replacement for `persistent-postgresql`. All standard persistent operations work without code changes aside from type signatures and import changes.
+
+## What's different
+
+| Feature | persistent-postgresql | persistent-postgresql-ng |
+|---------|----------------------|--------------------------|
+| Wire protocol | Text (via postgresql-simple) | Binary (via postgresql-binary) |
+| Automatic pipelining | No | Yes–  Hedis-style lazy reply stream |
+| Bulk insert | `INSERT ... VALUES (?,?,...), (?,?,...), ...` | `INSERT ... SELECT * FROM UNNEST($1::type[], ...)` |
+| IN clauses | `IN (?,?,?,...)` | `= ANY($1)` |
+| Direct decode path | No | Yes–  zero `PersistValue` allocation |
+| Result fetch modes | All-at-once only | All-at-once, single-row, chunked (PG17+) |
+
+## Benchmarks
+
+Measured against `persistent-postgresql` on the same PostgreSQL 16 instance. Three network conditions: localhost (0ms), 1ms added latency per direction (2ms RTT), and 5ms per direction (10ms RTT).
+
+Latency was introduced using a TCP delay proxy (`bench/delay-proxy.py`).
+
+### 0ms latency (localhost, TCP loopback)
+
+![Benchmark: 0ms latency](bench/bench-0ms.svg)
+
+
+| Benchmark | pipeline | simple | speedup |
+|-----------|----------|--------|---------|
+| **get ×100 (pipelined reads)** | 1.7ms | 4.7ms | **2.8×** |
+| **insert ×100 (pipelined RETURNING)** | 10.8ms | 12.8ms | 1.2× |
+| **upsert ×100 (pipelined RETURNING)** | 8.9ms | 12.7ms | **1.4×** |
+| insertMany ×1000 (UNNEST) | 5.3ms | 14.1ms | **2.7×** |
+| delete ×100 then select | 4.5ms | 7.5ms | **1.7×** |
+| mixed DML ×100 then select | 14.6ms | 29.9ms | **2.0×** |
+| selectList ×100 | 8.6ms | 11.2ms | 1.3× |
+
+At zero latency, the advantage comes from the binary protocol and UNNEST-based bulk inserts. Individual `get` and `insert` are comparable because round-trip time is negligible.
+
+### 1ms latency per direction (2ms RTT, nearby datacenter)
+
+![Benchmark: 1ms latency](bench/bench-1ms.svg)
+
+
+| Benchmark | pipeline | simple | speedup |
+|-----------|----------|--------|---------|
+| **get ×100 (pipelined reads)** | **11ms** | 310ms | **28×** |
+| **insert ×100 (pipelined RETURNING)** | **13ms** | 314ms | **24×** |
+| **upsert ×100 (pipelined RETURNING)** | **13ms** | 321ms | **25×** |
+| insertMany ×1000 (UNNEST) | 8.6ms | 31.0ms | **3.6×** |
+| selectList ×100 | 16.6ms | 25.8ms | **1.6×** |
+| select IN ×20 | 17.4ms | 24.8ms | **1.4×** |
+
+With even modest latency, the automatic pipelining dominates. `mapM get keys`, `mapM insert records`, and `forM_ records upsert` all send queries before reading results–  one flush instead of 100 round-trips.
+
+### 5ms latency per direction (10ms RTT, cross-region)
+
+![Benchmark: 5ms latency](bench/bench-5ms.svg)
+
+
+| Benchmark | pipeline | simple | speedup |
+|-----------|----------|--------|---------|
+| **get ×100 (pipelined reads)** | **50ms** | 1.19s | **24×** |
+| **insert ×100 (pipelined RETURNING)** | **41ms** | 1.20s | **29×** |
+| insertMany ×1000 (UNNEST) | 22.8ms | 72.6ms | **3.2×** |
+| selectList ×100 | 47.9ms | 74.0ms | **1.5×** |
+| select IN ×20 | 44.1ms | 70.3ms | **1.6×** |
+
+The speedup scales linearly with latency. At 10ms RTT, 100 sequential round-trips cost 1000ms minimum. The pipeline pays one RTT for the flush and reads all 100 results from the server's already-buffered responses.
+
+### Attributing the speedup: binary protocol vs pipelining
+
+The improvements come from three independent sources. The 0ms column isolates the binary protocol effect (pipelining has no benefit when round-trips are free). The 1ms column shows the combined effect, and the difference reveals the pipelining contribution.
+
+| Benchmark | 0ms: pipeline / simple | 1ms: pipeline / simple | Source of speedup |
+|-----------|:---:|:---:|---|
+| **get ×100** | 1.7ms / 4.7ms (2.8×) | 11ms / 310ms (**28×**) | 0ms: binary decode. 1ms: **Hedis-style lazy pipelining** (100 queries in 1 flush) |
+| **insert ×100** | 10.8ms / 12.8ms (1.2×) | 13ms / 314ms (**24×**) | 0ms: binary encode. 1ms: **lazy RETURNING pipelining** |
+| **delete ×100** | 8.4ms / 12.9ms (1.5×) | 25ms / 592ms (**24×**) | 0ms: binary protocol. 1ms: **fire-and-forget pipelining** |
+| **update ×100** | 8.3ms / 12.5ms (1.5×) | 25ms / 555ms (**22×**) | 0ms: binary protocol. 1ms: **fire-and-forget pipelining** |
+| **replace ×100** | 11.1ms / 11.5ms (1.0×) | 27ms / 602ms (**22×**) | 0ms: ~neutral. 1ms: **fire-and-forget pipelining** |
+| **insertMany ×1000** | 7.2ms / 16.7ms (2.3×) | 8.6ms / 31.0ms (**3.6×**) | 0ms: **UNNEST** (1 query vs N). 1ms: UNNEST + fewer round-trips |
+| **selectList ×100** | 13.5ms / 15.6ms (1.2×) | 16.6ms / 25.8ms (**1.6×**) | 0ms: binary decode. 1ms: binary + pipelined setup |
+| **upsert ×100** | 8.9ms / 12.7ms (1.4×) | 13ms / 321ms (**25×**) | 0ms: binary protocol. 1ms: **lazy RETURNING pipelining** |
+| **deleteWhere ×100** | 90ms / 99ms (1.1×) | 119ms / 750ms (**6.3×**) | 0ms: ~neutral. 1ms: **fire-and-forget pipelining** |
+
+**Summary of sources:**
+
+| Source | Typical gain at 0ms | Typical gain at 1ms/dir |
+|--------|:---:|:---:|
+| Binary protocol (encode/decode) | 1.2-2.8× | 1.2-2.8× |
+| UNNEST bulk insert | 2.3× | 3.6× |
+| Fire-and-forget DML pipelining | 1.0× | 20-24× |
+| Hedis-style lazy pipelining (get, insert, upsert) | 1.0× | 24-28× |
+| Combined (best case) | 2.8× | **28×** |
+
+The binary protocol provides a constant-factor improvement regardless of latency. Pipelining provides a latency-proportional improvement that dominates at any non-zero network distance.
+
+### Running benchmarks
+
+```bash
+# Baseline (direct connection)
+stack bench persistent-postgresql-ng
+
+# With artificial latency via TCP proxy
+python3 bench/delay-proxy.py 15432 localhost 5432 1 &  # 1ms per direction
+PGPORT=15432 PGHOST=127.0.0.1 stack bench persistent-postgresql-ng
+kill %1
+
+# With system-level latency (macOS, requires root)
+sudo bench/run-with-latency.sh 1   # 1ms via dummynet
+```
+
+## Automatic pipelining (Hedis-style)
+
+All read operations (`get`, `getBy`, `insert` with RETURNING, `count`, `exists`) use a [Hedis-style](https://www.iankduncan.com/engineering/2026-02-17-archive-redis-pipelining) lazy reply stream for automatic optimal pipelining. No API changes are required–  standard persistent code like `mapM get keys` is automatically pipelined.
+
+The technique:
+
+1. At connection time, an infinite lazy list of server replies is created using `unsafeInterleaveIO`. Each element, when forced, flushes the send buffer and reads one result.
+2. Each command **sends** eagerly (writes to the output buffer) and **receives** lazily (pops an unevaluated thunk from the reply list via `atomicModifyIORef`).
+3. The actual network read happens when the caller inspects the result value. If 100 `get` calls are sequenced before any result is inspected, all 100 queries are sent in one flush and results are read sequentially from the server's response buffer.
+
+The ordering guarantee comes from the lazy list structure: each thunk N is created inside thunk N-1's `unsafeInterleaveIO` body, so replies are always read in pipeline order regardless of evaluation order.
+
+Write operations (`delete`, `update`, `replace`, `deleteWhere`, `updateWhere`) remain fire-and-forget–  they send the query and don't read the result until a subsequent read operation (or transaction commit) drains them.
+
+## Direct decode path
+
+In addition to the standard `PersistValue`-based path, the backend supports a direct codec path that bypasses `PersistValue` entirely. See the [RFC](../RFC-direct-decode.md) for full design details.
+
+```haskell
+-- Switch one import to opt in:
+import Database.Persist.Sql.Experimental  -- instead of Database.Persist.Sql
+```
+
+For code with the concrete backend type (zero overhead, full specialization):
+
+```haskell
+rawSqlDirect
+    "SELECT name, age FROM users WHERE age > $1"
+    (writeParam (18 :: Int))
+    :: ReaderT (WriteBackend PostgreSQLBackend) m [(Text, Int64)]
+```
+
+For code through `SqlBackend` (uses `DirectEntity` + `Typeable` bridge):
+
+```haskell
+rawSqlDirectCompat
+    "SELECT name, age FROM users WHERE age > $1"
+    [toPersistValue (18 :: Int)]
+    :: ReaderT SqlBackend m (Maybe [(Text, Int64)])
+```
+
+## Architecture
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for detailed internals: pipeline mode, binary protocol, connection lifecycle, error handling, and the direct decode/encode layer.

--- a/persistent-postgresql-ng/bench/bench-0ms.svg
+++ b/persistent-postgresql-ng/bench/bench-0ms.svg
@@ -1,0 +1,1823 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="855.48875pt" height="424.340681pt" viewBox="0 0 855.48875 424.340681" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-02-19T22:23:56.086805</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.9.4, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 424.340681 
+L 855.48875 424.340681 
+L 855.48875 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 42.53875 363.304622 
+L 848.28875 363.304622 
+L 848.28875 23.837812 
+L 42.53875 23.837812 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 79.16375 363.304622 
+L 112.459205 363.304622 
+L 112.459205 312.484619 
+L 79.16375 312.484619 
+z
+" clip-path="url(#p266e51618a)" style="fill: #6c757d"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 174.29362 363.304622 
+L 207.589075 363.304622 
+L 207.589075 224.901209 
+L 174.29362 224.901209 
+z
+" clip-path="url(#p266e51618a)" style="fill: #6c757d"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 269.42349 363.304622 
+L 302.718945 363.304622 
+L 302.718945 225.982485 
+L 269.42349 225.982485 
+z
+" clip-path="url(#p266e51618a)" style="fill: #6c757d"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 364.55336 363.304622 
+L 397.848815 363.304622 
+L 397.848815 223.819932 
+L 364.55336 223.819932 
+z
+" clip-path="url(#p266e51618a)" style="fill: #6c757d"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 459.683231 363.304622 
+L 492.978685 363.304622 
+L 492.978685 228.145039 
+L 459.683231 228.145039 
+z
+" clip-path="url(#p266e51618a)" style="fill: #6c757d"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 554.813101 363.304622 
+L 588.108555 363.304622 
+L 588.108555 210.844612 
+L 554.813101 210.844612 
+z
+" clip-path="url(#p266e51618a)" style="fill: #6c757d"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 649.942971 363.304622 
+L 683.238425 363.304622 
+L 683.238425 242.201635 
+L 649.942971 242.201635 
+z
+" clip-path="url(#p266e51618a)" style="fill: #6c757d"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 745.072841 363.304622 
+L 778.368295 363.304622 
+L 778.368295 40.002899 
+L 745.072841 40.002899 
+z
+" clip-path="url(#p266e51618a)" style="fill: #6c757d"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 112.459205 363.304622 
+L 145.754659 363.304622 
+L 145.754659 344.922919 
+L 112.459205 344.922919 
+z
+" clip-path="url(#p266e51618a)" style="fill: #0d6efd"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 207.589075 363.304622 
+L 240.884529 363.304622 
+L 240.884529 246.526742 
+L 207.589075 246.526742 
+z
+" clip-path="url(#p266e51618a)" style="fill: #0d6efd"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 302.718945 363.304622 
+L 336.014399 363.304622 
+L 336.014399 267.070999 
+L 302.718945 267.070999 
+z
+" clip-path="url(#p266e51618a)" style="fill: #0d6efd"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 397.848815 363.304622 
+L 431.144269 363.304622 
+L 431.144269 259.502062 
+L 397.848815 259.502062 
+z
+" clip-path="url(#p266e51618a)" style="fill: #0d6efd"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 492.978685 363.304622 
+L 526.27414 363.304622 
+L 526.27414 261.664615 
+L 492.978685 261.664615 
+z
+" clip-path="url(#p266e51618a)" style="fill: #0d6efd"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 588.108555 363.304622 
+L 621.40401 363.304622 
+L 621.40401 305.996959 
+L 588.108555 305.996959 
+z
+" clip-path="url(#p266e51618a)" style="fill: #0d6efd"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 683.238425 363.304622 
+L 716.53388 363.304622 
+L 716.53388 270.314829 
+L 683.238425 270.314829 
+z
+" clip-path="url(#p266e51618a)" style="fill: #0d6efd"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 778.368295 363.304622 
+L 811.66375 363.304622 
+L 811.66375 205.438229 
+L 778.368295 205.438229 
+z
+" clip-path="url(#p266e51618a)" style="fill: #0d6efd"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m12088a5167" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m12088a5167" x="112.459205" y="363.304622" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- get x100 -->
+      <g transform="translate(71.153299 396.042561) rotate(-25) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-67"/>
+       <use xlink:href="#DejaVuSans-65" x="63.476562"/>
+       <use xlink:href="#DejaVuSans-74" x="125"/>
+       <use xlink:href="#DejaVuSans-20" x="164.208984"/>
+       <use xlink:href="#DejaVuSans-78" x="195.996094"/>
+       <use xlink:href="#DejaVuSans-31" x="255.175781"/>
+       <use xlink:href="#DejaVuSans-30" x="318.798828"/>
+       <use xlink:href="#DejaVuSans-30" x="382.421875"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m12088a5167" x="207.589075" y="363.304622" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- insert x100 -->
+      <g transform="translate(155.328174 401.150959) rotate(-25) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-69"/>
+       <use xlink:href="#DejaVuSans-6e" x="27.783203"/>
+       <use xlink:href="#DejaVuSans-73" x="91.162109"/>
+       <use xlink:href="#DejaVuSans-65" x="143.261719"/>
+       <use xlink:href="#DejaVuSans-72" x="204.785156"/>
+       <use xlink:href="#DejaVuSans-74" x="245.898438"/>
+       <use xlink:href="#DejaVuSans-20" x="285.107422"/>
+       <use xlink:href="#DejaVuSans-78" x="316.894531"/>
+       <use xlink:href="#DejaVuSans-31" x="376.074219"/>
+       <use xlink:href="#DejaVuSans-30" x="439.697266"/>
+       <use xlink:href="#DejaVuSans-30" x="503.320312"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m12088a5167" x="302.718945" y="363.304622" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- upsert x100 -->
+      <g transform="translate(247.222242 402.659839) rotate(-25) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-75"/>
+       <use xlink:href="#DejaVuSans-70" x="63.378906"/>
+       <use xlink:href="#DejaVuSans-73" x="126.855469"/>
+       <use xlink:href="#DejaVuSans-65" x="178.955078"/>
+       <use xlink:href="#DejaVuSans-72" x="240.478516"/>
+       <use xlink:href="#DejaVuSans-74" x="281.591797"/>
+       <use xlink:href="#DejaVuSans-20" x="320.800781"/>
+       <use xlink:href="#DejaVuSans-78" x="352.587891"/>
+       <use xlink:href="#DejaVuSans-31" x="411.767578"/>
+       <use xlink:href="#DejaVuSans-30" x="475.390625"/>
+       <use xlink:href="#DejaVuSans-30" x="539.013672"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m12088a5167" x="397.848815" y="363.304622" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- delete x100 -->
+      <g transform="translate(342.871823 402.417493) rotate(-25) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-64"/>
+       <use xlink:href="#DejaVuSans-65" x="63.476562"/>
+       <use xlink:href="#DejaVuSans-6c" x="125"/>
+       <use xlink:href="#DejaVuSans-65" x="152.783203"/>
+       <use xlink:href="#DejaVuSans-74" x="214.306641"/>
+       <use xlink:href="#DejaVuSans-65" x="253.515625"/>
+       <use xlink:href="#DejaVuSans-20" x="315.039062"/>
+       <use xlink:href="#DejaVuSans-78" x="346.826172"/>
+       <use xlink:href="#DejaVuSans-31" x="406.005859"/>
+       <use xlink:href="#DejaVuSans-30" x="469.628906"/>
+       <use xlink:href="#DejaVuSans-30" x="533.251953"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m12088a5167" x="492.978685" y="363.304622" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- update x100 -->
+      <g transform="translate(434.621448 403.993727) rotate(-25) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-75"/>
+       <use xlink:href="#DejaVuSans-70" x="63.378906"/>
+       <use xlink:href="#DejaVuSans-64" x="126.855469"/>
+       <use xlink:href="#DejaVuSans-61" x="190.332031"/>
+       <use xlink:href="#DejaVuSans-74" x="251.611328"/>
+       <use xlink:href="#DejaVuSans-65" x="290.820312"/>
+       <use xlink:href="#DejaVuSans-20" x="352.34375"/>
+       <use xlink:href="#DejaVuSans-78" x="384.130859"/>
+       <use xlink:href="#DejaVuSans-31" x="443.310547"/>
+       <use xlink:href="#DejaVuSans-30" x="506.933594"/>
+       <use xlink:href="#DejaVuSans-30" x="570.556641"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m12088a5167" x="588.108555" y="363.304622" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- insertMany x1000 -->
+      <g transform="translate(505.599632 415.255844) rotate(-25) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-69"/>
+       <use xlink:href="#DejaVuSans-6e" x="27.783203"/>
+       <use xlink:href="#DejaVuSans-73" x="91.162109"/>
+       <use xlink:href="#DejaVuSans-65" x="143.261719"/>
+       <use xlink:href="#DejaVuSans-72" x="204.785156"/>
+       <use xlink:href="#DejaVuSans-74" x="245.898438"/>
+       <use xlink:href="#DejaVuSans-4d" x="285.107422"/>
+       <use xlink:href="#DejaVuSans-61" x="371.386719"/>
+       <use xlink:href="#DejaVuSans-6e" x="432.666016"/>
+       <use xlink:href="#DejaVuSans-79" x="496.044922"/>
+       <use xlink:href="#DejaVuSans-20" x="555.224609"/>
+       <use xlink:href="#DejaVuSans-78" x="587.011719"/>
+       <use xlink:href="#DejaVuSans-31" x="646.191406"/>
+       <use xlink:href="#DejaVuSans-30" x="709.814453"/>
+       <use xlink:href="#DejaVuSans-30" x="773.4375"/>
+       <use xlink:href="#DejaVuSans-30" x="837.060547"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m12088a5167" x="683.238425" y="363.304622" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- selectList x100 -->
+      <g transform="translate(614.045146 409.046657) rotate(-25) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-4c" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-73"/>
+       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
+       <use xlink:href="#DejaVuSans-6c" x="113.623047"/>
+       <use xlink:href="#DejaVuSans-65" x="141.40625"/>
+       <use xlink:href="#DejaVuSans-63" x="202.929688"/>
+       <use xlink:href="#DejaVuSans-74" x="257.910156"/>
+       <use xlink:href="#DejaVuSans-4c" x="297.119141"/>
+       <use xlink:href="#DejaVuSans-69" x="352.832031"/>
+       <use xlink:href="#DejaVuSans-73" x="380.615234"/>
+       <use xlink:href="#DejaVuSans-74" x="432.714844"/>
+       <use xlink:href="#DejaVuSans-20" x="471.923828"/>
+       <use xlink:href="#DejaVuSans-78" x="503.710938"/>
+       <use xlink:href="#DejaVuSans-31" x="562.890625"/>
+       <use xlink:href="#DejaVuSans-30" x="626.513672"/>
+       <use xlink:href="#DejaVuSans-30" x="690.136719"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m12088a5167" x="778.368295" y="363.304622" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- mixed DML x100 -->
+      <g transform="translate(701.460071 412.644195) rotate(-25) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-44" d="M 1259 4147 
+L 1259 519 
+L 2022 519 
+Q 2988 519 3436 956 
+Q 3884 1394 3884 2338 
+Q 3884 3275 3436 3711 
+Q 2988 4147 2022 4147 
+L 1259 4147 
+z
+M 628 4666 
+L 1925 4666 
+Q 3281 4666 3915 4102 
+Q 4550 3538 4550 2338 
+Q 4550 1131 3912 565 
+Q 3275 0 1925 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-6d"/>
+       <use xlink:href="#DejaVuSans-69" x="97.412109"/>
+       <use xlink:href="#DejaVuSans-78" x="125.195312"/>
+       <use xlink:href="#DejaVuSans-65" x="181.25"/>
+       <use xlink:href="#DejaVuSans-64" x="242.773438"/>
+       <use xlink:href="#DejaVuSans-20" x="306.25"/>
+       <use xlink:href="#DejaVuSans-44" x="338.037109"/>
+       <use xlink:href="#DejaVuSans-4d" x="415.039062"/>
+       <use xlink:href="#DejaVuSans-4c" x="501.318359"/>
+       <use xlink:href="#DejaVuSans-20" x="557.03125"/>
+       <use xlink:href="#DejaVuSans-78" x="588.818359"/>
+       <use xlink:href="#DejaVuSans-31" x="647.998047"/>
+       <use xlink:href="#DejaVuSans-30" x="711.621094"/>
+       <use xlink:href="#DejaVuSans-30" x="775.244141"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_9">
+      <path d="M 42.53875 363.304622 
+L 848.28875 363.304622 
+" clip-path="url(#p266e51618a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_10">
+      <defs>
+       <path id="m710c204304" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m710c204304" x="42.53875" y="363.304622" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 0 -->
+      <g transform="translate(29.17625 367.103841) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_11">
+      <path d="M 42.53875 309.240789 
+L 848.28875 309.240789 
+" clip-path="url(#p266e51618a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_12">
+      <g>
+       <use xlink:href="#m710c204304" x="42.53875" y="309.240789" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 5 -->
+      <g transform="translate(29.17625 313.040007) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-35"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_13">
+      <path d="M 42.53875 255.176955 
+L 848.28875 255.176955 
+" clip-path="url(#p266e51618a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_14">
+      <g>
+       <use xlink:href="#m710c204304" x="42.53875" y="255.176955" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 10 -->
+      <g transform="translate(22.81375 258.976174) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_15">
+      <path d="M 42.53875 201.113122 
+L 848.28875 201.113122 
+" clip-path="url(#p266e51618a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_16">
+      <g>
+       <use xlink:href="#m710c204304" x="42.53875" y="201.113122" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 15 -->
+      <g transform="translate(22.81375 204.912341) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_17">
+      <path d="M 42.53875 147.049289 
+L 848.28875 147.049289 
+" clip-path="url(#p266e51618a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_18">
+      <g>
+       <use xlink:href="#m710c204304" x="42.53875" y="147.049289" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 20 -->
+      <g transform="translate(22.81375 150.848507) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_19">
+      <path d="M 42.53875 92.985455 
+L 848.28875 92.985455 
+" clip-path="url(#p266e51618a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_20">
+      <g>
+       <use xlink:href="#m710c204304" x="42.53875" y="92.985455" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 25 -->
+      <g transform="translate(22.81375 96.784674) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-35" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_21">
+      <path d="M 42.53875 38.921622 
+L 848.28875 38.921622 
+" clip-path="url(#p266e51618a)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_22">
+      <g>
+       <use xlink:href="#m710c204304" x="42.53875" y="38.921622" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 30 -->
+      <g transform="translate(22.81375 42.720841) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_16">
+     <!-- Time (ms) -->
+     <g transform="translate(16.318125 223.81028) rotate(-90) scale(0.12 -0.12)">
+      <defs>
+       <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-54"/>
+      <use xlink:href="#DejaVuSans-69" x="57.958984"/>
+      <use xlink:href="#DejaVuSans-6d" x="85.742188"/>
+      <use xlink:href="#DejaVuSans-65" x="183.154297"/>
+      <use xlink:href="#DejaVuSans-20" x="244.677734"/>
+      <use xlink:href="#DejaVuSans-28" x="276.464844"/>
+      <use xlink:href="#DejaVuSans-6d" x="315.478516"/>
+      <use xlink:href="#DejaVuSans-73" x="412.890625"/>
+      <use xlink:href="#DejaVuSans-29" x="464.990234"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_19">
+    <path d="M 42.53875 363.304622 
+L 42.53875 23.837812 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 848.28875 363.304622 
+L 848.28875 23.837812 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_21">
+    <path d="M 42.53875 363.304622 
+L 848.28875 363.304622 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 42.53875 23.837812 
+L 848.28875 23.837812 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_17">
+    <!-- 3x -->
+    <g style="fill: #0a58ca" transform="translate(123.073416 339.922919) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-Bold-33" d="M 2981 2516 
+Q 3453 2394 3698 2092 
+Q 3944 1791 3944 1325 
+Q 3944 631 3412 270 
+Q 2881 -91 1863 -91 
+Q 1503 -91 1142 -33 
+Q 781 25 428 141 
+L 428 1069 
+Q 766 900 1098 814 
+Q 1431 728 1753 728 
+Q 2231 728 2486 893 
+Q 2741 1059 2741 1369 
+Q 2741 1688 2480 1852 
+Q 2219 2016 1709 2016 
+L 1228 2016 
+L 1228 2791 
+L 1734 2791 
+Q 2188 2791 2409 2933 
+Q 2631 3075 2631 3366 
+Q 2631 3634 2415 3781 
+Q 2200 3928 1806 3928 
+Q 1516 3928 1219 3862 
+Q 922 3797 628 3669 
+L 628 4550 
+Q 984 4650 1334 4700 
+Q 1684 4750 2022 4750 
+Q 2931 4750 3382 4451 
+Q 3834 4153 3834 3553 
+Q 3834 3144 3618 2883 
+Q 3403 2622 2981 2516 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-78" d="M 1422 1791 
+L 159 3500 
+L 1344 3500 
+L 2059 2463 
+L 2784 3500 
+L 3969 3500 
+L 2706 1797 
+L 4031 0 
+L 2847 0 
+L 2059 1106 
+L 1281 0 
+L 97 0 
+L 1422 1791 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-33"/>
+     <use xlink:href="#DejaVuSans-Bold-78" x="69.580078"/>
+    </g>
+   </g>
+   <g id="text_18">
+    <!-- 1x -->
+    <g style="fill: #0a58ca" transform="translate(313.333156 262.070999) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-Bold-31" d="M 750 831 
+L 1813 831 
+L 1813 3847 
+L 722 3622 
+L 722 4441 
+L 1806 4666 
+L 2950 4666 
+L 2950 831 
+L 4013 831 
+L 4013 0 
+L 750 0 
+L 750 831 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-31"/>
+     <use xlink:href="#DejaVuSans-Bold-78" x="69.580078"/>
+    </g>
+   </g>
+   <g id="text_19">
+    <!-- 1x -->
+    <g style="fill: #0a58ca" transform="translate(408.463027 254.502062) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSans-Bold-31"/>
+     <use xlink:href="#DejaVuSans-Bold-78" x="69.580078"/>
+    </g>
+   </g>
+   <g id="text_20">
+    <!-- 1x -->
+    <g style="fill: #0a58ca" transform="translate(503.592897 256.664615) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSans-Bold-31"/>
+     <use xlink:href="#DejaVuSans-Bold-78" x="69.580078"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- 3x -->
+    <g style="fill: #0a58ca" transform="translate(598.722767 300.996959) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSans-Bold-33"/>
+     <use xlink:href="#DejaVuSans-Bold-78" x="69.580078"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- 1x -->
+    <g style="fill: #0a58ca" transform="translate(693.852637 265.314829) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSans-Bold-31"/>
+     <use xlink:href="#DejaVuSans-Bold-78" x="69.580078"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- 2x -->
+    <g style="fill: #0a58ca" transform="translate(788.982507 200.438229) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-Bold-32" d="M 1844 884 
+L 3897 884 
+L 3897 0 
+L 506 0 
+L 506 884 
+L 2209 2388 
+Q 2438 2594 2547 2791 
+Q 2656 2988 2656 3200 
+Q 2656 3528 2436 3728 
+Q 2216 3928 1850 3928 
+Q 1569 3928 1234 3808 
+Q 900 3688 519 3450 
+L 519 4475 
+Q 925 4609 1322 4679 
+Q 1719 4750 2100 4750 
+Q 2938 4750 3402 4381 
+Q 3866 4013 3866 3353 
+Q 3866 2972 3669 2642 
+Q 3472 2313 2841 1759 
+L 1844 884 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-78" x="69.580078"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- Benchmark: 0ms latency (localhost) -->
+    <g transform="translate(303.551094 17.837812) scale(0.14 -0.14)">
+     <defs>
+      <path id="DejaVuSans-Bold-42" d="M 2456 2859 
+Q 2741 2859 2887 2984 
+Q 3034 3109 3034 3353 
+Q 3034 3594 2887 3720 
+Q 2741 3847 2456 3847 
+L 1791 3847 
+L 1791 2859 
+L 2456 2859 
+z
+M 2497 819 
+Q 2859 819 3042 972 
+Q 3225 1125 3225 1434 
+Q 3225 1738 3044 1889 
+Q 2863 2041 2497 2041 
+L 1791 2041 
+L 1791 819 
+L 2497 819 
+z
+M 3616 2497 
+Q 4003 2384 4215 2081 
+Q 4428 1778 4428 1338 
+Q 4428 663 3972 331 
+Q 3516 0 2584 0 
+L 588 0 
+L 588 4666 
+L 2394 4666 
+Q 3366 4666 3802 4372 
+Q 4238 4078 4238 3431 
+Q 4238 3091 4078 2852 
+Q 3919 2613 3616 2497 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-65" d="M 4031 1759 
+L 4031 1441 
+L 1416 1441 
+Q 1456 1047 1700 850 
+Q 1944 653 2381 653 
+Q 2734 653 3104 758 
+Q 3475 863 3866 1075 
+L 3866 213 
+Q 3469 63 3072 -14 
+Q 2675 -91 2278 -91 
+Q 1328 -91 801 392 
+Q 275 875 275 1747 
+Q 275 2603 792 3093 
+Q 1309 3584 2216 3584 
+Q 3041 3584 3536 3087 
+Q 4031 2591 4031 1759 
+z
+M 2881 2131 
+Q 2881 2450 2695 2645 
+Q 2509 2841 2209 2841 
+Q 1884 2841 1681 2658 
+Q 1478 2475 1428 2131 
+L 2881 2131 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6e" d="M 4056 2131 
+L 4056 0 
+L 2931 0 
+L 2931 347 
+L 2931 1631 
+Q 2931 2084 2911 2256 
+Q 2891 2428 2841 2509 
+Q 2775 2619 2662 2680 
+Q 2550 2741 2406 2741 
+Q 2056 2741 1856 2470 
+Q 1656 2200 1656 1722 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1909 3294 2193 3439 
+Q 2478 3584 2822 3584 
+Q 3428 3584 3742 3212 
+Q 4056 2841 4056 2131 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-63" d="M 3366 3391 
+L 3366 2478 
+Q 3138 2634 2908 2709 
+Q 2678 2784 2431 2784 
+Q 1963 2784 1702 2511 
+Q 1441 2238 1441 1747 
+Q 1441 1256 1702 982 
+Q 1963 709 2431 709 
+Q 2694 709 2930 787 
+Q 3166 866 3366 1019 
+L 3366 103 
+Q 3103 6 2833 -42 
+Q 2563 -91 2291 -91 
+Q 1344 -91 809 395 
+Q 275 881 275 1747 
+Q 275 2613 809 3098 
+Q 1344 3584 2291 3584 
+Q 2566 3584 2833 3536 
+Q 3100 3488 3366 3391 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-68" d="M 4056 2131 
+L 4056 0 
+L 2931 0 
+L 2931 347 
+L 2931 1625 
+Q 2931 2084 2911 2256 
+Q 2891 2428 2841 2509 
+Q 2775 2619 2662 2680 
+Q 2550 2741 2406 2741 
+Q 2056 2741 1856 2470 
+Q 1656 2200 1656 1722 
+L 1656 0 
+L 538 0 
+L 538 4863 
+L 1656 4863 
+L 1656 2988 
+Q 1909 3294 2193 3439 
+Q 2478 3584 2822 3584 
+Q 3428 3584 3742 3212 
+Q 4056 2841 4056 2131 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
+Q 3994 3244 4286 3414 
+Q 4578 3584 4928 3584 
+Q 5531 3584 5847 3212 
+Q 6163 2841 6163 2131 
+L 6163 0 
+L 5038 0 
+L 5038 1825 
+Q 5041 1866 5042 1909 
+Q 5044 1953 5044 2034 
+Q 5044 2406 4934 2573 
+Q 4825 2741 4581 2741 
+Q 4263 2741 4089 2478 
+Q 3916 2216 3909 1719 
+L 3909 0 
+L 2784 0 
+L 2784 1825 
+Q 2784 2406 2684 2573 
+Q 2584 2741 2328 2741 
+Q 2006 2741 1831 2477 
+Q 1656 2213 1656 1722 
+L 1656 0 
+L 531 0 
+L 531 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1863 3284 2130 3434 
+Q 2397 3584 2719 3584 
+Q 3081 3584 3359 3409 
+Q 3638 3234 3781 2919 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-61" d="M 2106 1575 
+Q 1756 1575 1579 1456 
+Q 1403 1338 1403 1106 
+Q 1403 894 1545 773 
+Q 1688 653 1941 653 
+Q 2256 653 2472 879 
+Q 2688 1106 2688 1447 
+L 2688 1575 
+L 2106 1575 
+z
+M 3816 1997 
+L 3816 0 
+L 2688 0 
+L 2688 519 
+Q 2463 200 2181 54 
+Q 1900 -91 1497 -91 
+Q 953 -91 614 226 
+Q 275 544 275 1050 
+Q 275 1666 698 1953 
+Q 1122 2241 2028 2241 
+L 2688 2241 
+L 2688 2328 
+Q 2688 2594 2478 2717 
+Q 2269 2841 1825 2841 
+Q 1466 2841 1156 2769 
+Q 847 2697 581 2553 
+L 581 3406 
+Q 941 3494 1303 3539 
+Q 1666 3584 2028 3584 
+Q 2975 3584 3395 3211 
+Q 3816 2838 3816 1997 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-72" d="M 3138 2547 
+Q 2991 2616 2845 2648 
+Q 2700 2681 2553 2681 
+Q 2122 2681 1889 2404 
+Q 1656 2128 1656 1613 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2925 
+Q 1872 3269 2151 3426 
+Q 2431 3584 2822 3584 
+Q 2878 3584 2943 3579 
+Q 3009 3575 3134 3559 
+L 3138 2547 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6b" d="M 538 4863 
+L 1656 4863 
+L 1656 2216 
+L 2944 3500 
+L 4244 3500 
+L 2534 1894 
+L 4378 0 
+L 3022 0 
+L 1656 1459 
+L 1656 0 
+L 538 0 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-3a" d="M 716 3500 
+L 1844 3500 
+L 1844 2291 
+L 716 2291 
+L 716 3500 
+z
+M 716 1209 
+L 1844 1209 
+L 1844 0 
+L 716 0 
+L 716 1209 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-30" d="M 2944 2338 
+Q 2944 3213 2780 3570 
+Q 2616 3928 2228 3928 
+Q 1841 3928 1675 3570 
+Q 1509 3213 1509 2338 
+Q 1509 1453 1675 1090 
+Q 1841 728 2228 728 
+Q 2613 728 2778 1090 
+Q 2944 1453 2944 2338 
+z
+M 4147 2328 
+Q 4147 1169 3647 539 
+Q 3147 -91 2228 -91 
+Q 1306 -91 806 539 
+Q 306 1169 306 2328 
+Q 306 3491 806 4120 
+Q 1306 4750 2228 4750 
+Q 3147 4750 3647 4120 
+Q 4147 3491 4147 2328 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-73" d="M 3272 3391 
+L 3272 2541 
+Q 2913 2691 2578 2766 
+Q 2244 2841 1947 2841 
+Q 1628 2841 1473 2761 
+Q 1319 2681 1319 2516 
+Q 1319 2381 1436 2309 
+Q 1553 2238 1856 2203 
+L 2053 2175 
+Q 2913 2066 3209 1816 
+Q 3506 1566 3506 1031 
+Q 3506 472 3093 190 
+Q 2681 -91 1863 -91 
+Q 1516 -91 1145 -36 
+Q 775 19 384 128 
+L 384 978 
+Q 719 816 1070 734 
+Q 1422 653 1784 653 
+Q 2113 653 2278 743 
+Q 2444 834 2444 1013 
+Q 2444 1163 2330 1236 
+Q 2216 1309 1875 1350 
+L 1678 1375 
+Q 931 1469 631 1722 
+Q 331 1975 331 2491 
+Q 331 3047 712 3315 
+Q 1094 3584 1881 3584 
+Q 2191 3584 2531 3537 
+Q 2872 3491 3272 3391 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6c" d="M 538 4863 
+L 1656 4863 
+L 1656 0 
+L 538 0 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-74" d="M 1759 4494 
+L 1759 3500 
+L 2913 3500 
+L 2913 2700 
+L 1759 2700 
+L 1759 1216 
+Q 1759 972 1856 886 
+Q 1953 800 2241 800 
+L 2816 800 
+L 2816 0 
+L 1856 0 
+Q 1194 0 917 276 
+Q 641 553 641 1216 
+L 641 2700 
+L 84 2700 
+L 84 3500 
+L 641 3500 
+L 641 4494 
+L 1759 4494 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-79" d="M 78 3500 
+L 1197 3500 
+L 2138 1125 
+L 2938 3500 
+L 4056 3500 
+L 2584 -331 
+Q 2363 -916 2067 -1148 
+Q 1772 -1381 1288 -1381 
+L 641 -1381 
+L 641 -647 
+L 991 -647 
+Q 1275 -647 1404 -556 
+Q 1534 -466 1606 -231 
+L 1638 -134 
+L 78 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-28" d="M 2413 -844 
+L 1484 -844 
+Q 1006 -72 778 623 
+Q 550 1319 550 2003 
+Q 550 2688 779 3389 
+Q 1009 4091 1484 4856 
+L 2413 4856 
+Q 2013 4116 1813 3408 
+Q 1613 2700 1613 2009 
+Q 1613 1319 1811 609 
+Q 2009 -100 2413 -844 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6f" d="M 2203 2784 
+Q 1831 2784 1636 2517 
+Q 1441 2250 1441 1747 
+Q 1441 1244 1636 976 
+Q 1831 709 2203 709 
+Q 2569 709 2762 976 
+Q 2956 1244 2956 1747 
+Q 2956 2250 2762 2517 
+Q 2569 2784 2203 2784 
+z
+M 2203 3584 
+Q 3106 3584 3614 3096 
+Q 4122 2609 4122 1747 
+Q 4122 884 3614 396 
+Q 3106 -91 2203 -91 
+Q 1297 -91 786 396 
+Q 275 884 275 1747 
+Q 275 2609 786 3096 
+Q 1297 3584 2203 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-29" d="M 513 -844 
+Q 913 -100 1113 609 
+Q 1313 1319 1313 2009 
+Q 1313 2700 1113 3408 
+Q 913 4116 513 4856 
+L 1441 4856 
+Q 1916 4091 2145 3389 
+Q 2375 2688 2375 2003 
+Q 2375 1319 2147 623 
+Q 1919 -72 1441 -844 
+L 513 -844 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-42"/>
+     <use xlink:href="#DejaVuSans-Bold-65" x="76.220703"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" x="144.042969"/>
+     <use xlink:href="#DejaVuSans-Bold-63" x="215.234375"/>
+     <use xlink:href="#DejaVuSans-Bold-68" x="274.511719"/>
+     <use xlink:href="#DejaVuSans-Bold-6d" x="345.703125"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="449.902344"/>
+     <use xlink:href="#DejaVuSans-Bold-72" x="517.382812"/>
+     <use xlink:href="#DejaVuSans-Bold-6b" x="566.699219"/>
+     <use xlink:href="#DejaVuSans-Bold-3a" x="633.203125"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="673.193359"/>
+     <use xlink:href="#DejaVuSans-Bold-30" x="708.007812"/>
+     <use xlink:href="#DejaVuSans-Bold-6d" x="777.587891"/>
+     <use xlink:href="#DejaVuSans-Bold-73" x="881.787109"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="941.308594"/>
+     <use xlink:href="#DejaVuSans-Bold-6c" x="976.123047"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="1010.400391"/>
+     <use xlink:href="#DejaVuSans-Bold-74" x="1077.880859"/>
+     <use xlink:href="#DejaVuSans-Bold-65" x="1125.683594"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" x="1193.505859"/>
+     <use xlink:href="#DejaVuSans-Bold-63" x="1264.697266"/>
+     <use xlink:href="#DejaVuSans-Bold-79" x="1323.974609"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="1389.160156"/>
+     <use xlink:href="#DejaVuSans-Bold-28" x="1423.974609"/>
+     <use xlink:href="#DejaVuSans-Bold-6c" x="1469.677734"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" x="1503.955078"/>
+     <use xlink:href="#DejaVuSans-Bold-63" x="1572.65625"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="1631.933594"/>
+     <use xlink:href="#DejaVuSans-Bold-6c" x="1699.414062"/>
+     <use xlink:href="#DejaVuSans-Bold-68" x="1733.691406"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" x="1804.882812"/>
+     <use xlink:href="#DejaVuSans-Bold-73" x="1873.583984"/>
+     <use xlink:href="#DejaVuSans-Bold-74" x="1933.105469"/>
+     <use xlink:href="#DejaVuSans-Bold-29" x="1980.908203"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_23">
+     <path d="M 50.23875 64.929687 
+L 220.0375 64.929687 
+Q 222.2375 64.929687 222.2375 62.729687 
+L 222.2375 31.537812 
+Q 222.2375 29.337812 220.0375 29.337812 
+L 50.23875 29.337812 
+Q 48.03875 29.337812 48.03875 31.537812 
+L 48.03875 62.729687 
+Q 48.03875 64.929687 50.23875 64.929687 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="patch_24">
+     <path d="M 52.43875 42.096094 
+L 74.43875 42.096094 
+L 74.43875 34.396094 
+L 52.43875 34.396094 
+z
+" style="fill: #6c757d"/>
+    </g>
+    <g id="text_25">
+     <!-- persistent-postgresql -->
+     <g transform="translate(83.23875 42.096094) scale(0.11 -0.11)">
+      <defs>
+       <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-71" d="M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+M 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 -1331 
+L 2906 -1331 
+L 2906 525 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-70"/>
+      <use xlink:href="#DejaVuSans-65" x="63.476562"/>
+      <use xlink:href="#DejaVuSans-72" x="125"/>
+      <use xlink:href="#DejaVuSans-73" x="166.113281"/>
+      <use xlink:href="#DejaVuSans-69" x="218.212891"/>
+      <use xlink:href="#DejaVuSans-73" x="245.996094"/>
+      <use xlink:href="#DejaVuSans-74" x="298.095703"/>
+      <use xlink:href="#DejaVuSans-65" x="337.304688"/>
+      <use xlink:href="#DejaVuSans-6e" x="398.828125"/>
+      <use xlink:href="#DejaVuSans-74" x="462.207031"/>
+      <use xlink:href="#DejaVuSans-2d" x="501.416016"/>
+      <use xlink:href="#DejaVuSans-70" x="537.5"/>
+      <use xlink:href="#DejaVuSans-6f" x="600.976562"/>
+      <use xlink:href="#DejaVuSans-73" x="662.158203"/>
+      <use xlink:href="#DejaVuSans-74" x="714.257812"/>
+      <use xlink:href="#DejaVuSans-67" x="753.466797"/>
+      <use xlink:href="#DejaVuSans-72" x="816.943359"/>
+      <use xlink:href="#DejaVuSans-65" x="855.806641"/>
+      <use xlink:href="#DejaVuSans-73" x="917.330078"/>
+      <use xlink:href="#DejaVuSans-71" x="969.429688"/>
+      <use xlink:href="#DejaVuSans-6c" x="1032.90625"/>
+     </g>
+    </g>
+    <g id="patch_25">
+     <path d="M 52.43875 58.242031 
+L 74.43875 58.242031 
+L 74.43875 50.542031 
+L 52.43875 50.542031 
+z
+" style="fill: #0d6efd"/>
+    </g>
+    <g id="text_26">
+     <!-- persistent-postgresql-ng -->
+     <g transform="translate(83.23875 58.242031) scale(0.11 -0.11)">
+      <use xlink:href="#DejaVuSans-70"/>
+      <use xlink:href="#DejaVuSans-65" x="63.476562"/>
+      <use xlink:href="#DejaVuSans-72" x="125"/>
+      <use xlink:href="#DejaVuSans-73" x="166.113281"/>
+      <use xlink:href="#DejaVuSans-69" x="218.212891"/>
+      <use xlink:href="#DejaVuSans-73" x="245.996094"/>
+      <use xlink:href="#DejaVuSans-74" x="298.095703"/>
+      <use xlink:href="#DejaVuSans-65" x="337.304688"/>
+      <use xlink:href="#DejaVuSans-6e" x="398.828125"/>
+      <use xlink:href="#DejaVuSans-74" x="462.207031"/>
+      <use xlink:href="#DejaVuSans-2d" x="501.416016"/>
+      <use xlink:href="#DejaVuSans-70" x="537.5"/>
+      <use xlink:href="#DejaVuSans-6f" x="600.976562"/>
+      <use xlink:href="#DejaVuSans-73" x="662.158203"/>
+      <use xlink:href="#DejaVuSans-74" x="714.257812"/>
+      <use xlink:href="#DejaVuSans-67" x="753.466797"/>
+      <use xlink:href="#DejaVuSans-72" x="816.943359"/>
+      <use xlink:href="#DejaVuSans-65" x="855.806641"/>
+      <use xlink:href="#DejaVuSans-73" x="917.330078"/>
+      <use xlink:href="#DejaVuSans-71" x="969.429688"/>
+      <use xlink:href="#DejaVuSans-6c" x="1032.90625"/>
+      <use xlink:href="#DejaVuSans-2d" x="1060.689453"/>
+      <use xlink:href="#DejaVuSans-6e" x="1096.773438"/>
+      <use xlink:href="#DejaVuSans-67" x="1160.152344"/>
+     </g>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p266e51618a">
+   <rect x="42.53875" y="23.837812" width="805.75" height="339.46681"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/persistent-postgresql-ng/bench/bench-1ms.svg
+++ b/persistent-postgresql-ng/bench/bench-1ms.svg
@@ -1,0 +1,2173 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="855.55125pt" height="424.327606pt" viewBox="0 0 855.55125 424.327606" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-02-19T22:23:56.179526</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.9.4, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 424.327606 
+L 855.55125 424.327606 
+L 855.55125 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 48.90125 362.429802 
+L 848.35125 362.429802 
+L 848.35125 23.837812 
+L 48.90125 23.837812 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 85.239886 362.429802 
+L 114.47787 362.429802 
+L 114.47787 229.142797 
+L 85.239886 229.142797 
+z
+" clip-path="url(#pd8aee19cb6)" style="fill: #6c757d"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 168.776981 362.429802 
+L 198.014965 362.429802 
+L 198.014965 227.422964 
+L 168.776981 227.422964 
+z
+" clip-path="url(#pd8aee19cb6)" style="fill: #6c757d"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 252.314077 362.429802 
+L 281.55206 362.429802 
+L 281.55206 224.413258 
+L 252.314077 224.413258 
+z
+" clip-path="url(#pd8aee19cb6)" style="fill: #6c757d"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 335.851172 362.429802 
+L 365.089155 362.429802 
+L 365.089155 107.894618 
+L 335.851172 107.894618 
+z
+" clip-path="url(#pd8aee19cb6)" style="fill: #6c757d"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 419.388267 362.429802 
+L 448.62625 362.429802 
+L 448.62625 123.803067 
+L 419.388267 123.803067 
+z
+" clip-path="url(#pd8aee19cb6)" style="fill: #6c757d"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 502.925362 362.429802 
+L 532.163345 362.429802 
+L 532.163345 103.595037 
+L 502.925362 103.595037 
+z
+" clip-path="url(#pd8aee19cb6)" style="fill: #6c757d"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 586.462457 362.429802 
+L 615.70044 362.429802 
+L 615.70044 349.101102 
+L 586.462457 349.101102 
+z
+" clip-path="url(#pd8aee19cb6)" style="fill: #6c757d"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 669.999552 362.429802 
+L 699.237535 362.429802 
+L 699.237535 351.336884 
+L 669.999552 351.336884 
+z
+" clip-path="url(#pd8aee19cb6)" style="fill: #6c757d"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 753.536647 362.429802 
+L 782.77463 362.429802 
+L 782.77463 39.961241 
+L 753.536647 39.961241 
+z
+" clip-path="url(#pd8aee19cb6)" style="fill: #6c757d"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 114.47787 362.429802 
+L 143.715853 362.429802 
+L 143.715853 357.700263 
+L 114.47787 357.700263 
+z
+" clip-path="url(#pd8aee19cb6)" style="fill: #0d6efd"/>
+   </g>
+   <g id="patch_13">
+    <path d="M 198.014965 362.429802 
+L 227.252948 362.429802 
+L 227.252948 356.840347 
+L 198.014965 356.840347 
+z
+" clip-path="url(#pd8aee19cb6)" style="fill: #0d6efd"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 281.55206 362.429802 
+L 310.790043 362.429802 
+L 310.790043 356.840347 
+L 281.55206 356.840347 
+z
+" clip-path="url(#pd8aee19cb6)" style="fill: #0d6efd"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 365.089155 362.429802 
+L 394.327138 362.429802 
+L 394.327138 351.68085 
+L 365.089155 351.68085 
+z
+" clip-path="url(#pd8aee19cb6)" style="fill: #0d6efd"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 448.62625 362.429802 
+L 477.864233 362.429802 
+L 477.864233 351.68085 
+L 448.62625 351.68085 
+z
+" clip-path="url(#pd8aee19cb6)" style="fill: #0d6efd"/>
+   </g>
+   <g id="patch_17">
+    <path d="M 532.163345 362.429802 
+L 561.401328 362.429802 
+L 561.401328 350.820934 
+L 532.163345 350.820934 
+z
+" clip-path="url(#pd8aee19cb6)" style="fill: #0d6efd"/>
+   </g>
+   <g id="patch_18">
+    <path d="M 615.70044 362.429802 
+L 644.938423 362.429802 
+L 644.938423 358.732163 
+L 615.70044 358.732163 
+z
+" clip-path="url(#pd8aee19cb6)" style="fill: #0d6efd"/>
+   </g>
+   <g id="patch_19">
+    <path d="M 699.237535 362.429802 
+L 728.475519 362.429802 
+L 728.475519 355.292498 
+L 699.237535 355.292498 
+z
+" clip-path="url(#pd8aee19cb6)" style="fill: #0d6efd"/>
+   </g>
+   <g id="patch_20">
+    <path d="M 782.77463 362.429802 
+L 812.012614 362.429802 
+L 812.012614 311.264791 
+L 782.77463 311.264791 
+z
+" clip-path="url(#pd8aee19cb6)" style="fill: #0d6efd"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m8a27cea125" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m8a27cea125" x="114.47787" y="362.429802" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- get x100 -->
+      <g transform="translate(73.171964 395.167741) rotate(-25) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-67"/>
+       <use xlink:href="#DejaVuSans-65" x="63.476562"/>
+       <use xlink:href="#DejaVuSans-74" x="125"/>
+       <use xlink:href="#DejaVuSans-20" x="164.208984"/>
+       <use xlink:href="#DejaVuSans-78" x="195.996094"/>
+       <use xlink:href="#DejaVuSans-31" x="255.175781"/>
+       <use xlink:href="#DejaVuSans-30" x="318.798828"/>
+       <use xlink:href="#DejaVuSans-30" x="382.421875"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m8a27cea125" x="198.014965" y="362.429802" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- insert x100 -->
+      <g transform="translate(145.754064 400.276139) rotate(-25) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-69"/>
+       <use xlink:href="#DejaVuSans-6e" x="27.783203"/>
+       <use xlink:href="#DejaVuSans-73" x="91.162109"/>
+       <use xlink:href="#DejaVuSans-65" x="143.261719"/>
+       <use xlink:href="#DejaVuSans-72" x="204.785156"/>
+       <use xlink:href="#DejaVuSans-74" x="245.898438"/>
+       <use xlink:href="#DejaVuSans-20" x="285.107422"/>
+       <use xlink:href="#DejaVuSans-78" x="316.894531"/>
+       <use xlink:href="#DejaVuSans-31" x="376.074219"/>
+       <use xlink:href="#DejaVuSans-30" x="439.697266"/>
+       <use xlink:href="#DejaVuSans-30" x="503.320312"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m8a27cea125" x="281.55206" y="362.429802" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- upsert x100 -->
+      <g transform="translate(226.055357 401.785019) rotate(-25) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-75" d="M 544 1381 
+L 544 3500 
+L 1119 3500 
+L 1119 1403 
+Q 1119 906 1312 657 
+Q 1506 409 1894 409 
+Q 2359 409 2629 706 
+Q 2900 1003 2900 1516 
+L 2900 3500 
+L 3475 3500 
+L 3475 0 
+L 2900 0 
+L 2900 538 
+Q 2691 219 2414 64 
+Q 2138 -91 1772 -91 
+Q 1169 -91 856 284 
+Q 544 659 544 1381 
+z
+M 1991 3584 
+L 1991 3584 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-75"/>
+       <use xlink:href="#DejaVuSans-70" x="63.378906"/>
+       <use xlink:href="#DejaVuSans-73" x="126.855469"/>
+       <use xlink:href="#DejaVuSans-65" x="178.955078"/>
+       <use xlink:href="#DejaVuSans-72" x="240.478516"/>
+       <use xlink:href="#DejaVuSans-74" x="281.591797"/>
+       <use xlink:href="#DejaVuSans-20" x="320.800781"/>
+       <use xlink:href="#DejaVuSans-78" x="352.587891"/>
+       <use xlink:href="#DejaVuSans-31" x="411.767578"/>
+       <use xlink:href="#DejaVuSans-30" x="475.390625"/>
+       <use xlink:href="#DejaVuSans-30" x="539.013672"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m8a27cea125" x="365.089155" y="362.429802" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- delete x100 -->
+      <g transform="translate(310.112163 401.542674) rotate(-25) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-64" d="M 2906 2969 
+L 2906 4863 
+L 3481 4863 
+L 3481 0 
+L 2906 0 
+L 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+z
+M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-64"/>
+       <use xlink:href="#DejaVuSans-65" x="63.476562"/>
+       <use xlink:href="#DejaVuSans-6c" x="125"/>
+       <use xlink:href="#DejaVuSans-65" x="152.783203"/>
+       <use xlink:href="#DejaVuSans-74" x="214.306641"/>
+       <use xlink:href="#DejaVuSans-65" x="253.515625"/>
+       <use xlink:href="#DejaVuSans-20" x="315.039062"/>
+       <use xlink:href="#DejaVuSans-78" x="346.826172"/>
+       <use xlink:href="#DejaVuSans-31" x="406.005859"/>
+       <use xlink:href="#DejaVuSans-30" x="469.628906"/>
+       <use xlink:href="#DejaVuSans-30" x="533.251953"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m8a27cea125" x="448.62625" y="362.429802" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- update x100 -->
+      <g transform="translate(390.269013 403.118908) rotate(-25) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-75"/>
+       <use xlink:href="#DejaVuSans-70" x="63.378906"/>
+       <use xlink:href="#DejaVuSans-64" x="126.855469"/>
+       <use xlink:href="#DejaVuSans-61" x="190.332031"/>
+       <use xlink:href="#DejaVuSans-74" x="251.611328"/>
+       <use xlink:href="#DejaVuSans-65" x="290.820312"/>
+       <use xlink:href="#DejaVuSans-20" x="352.34375"/>
+       <use xlink:href="#DejaVuSans-78" x="384.130859"/>
+       <use xlink:href="#DejaVuSans-31" x="443.310547"/>
+       <use xlink:href="#DejaVuSans-30" x="506.933594"/>
+       <use xlink:href="#DejaVuSans-30" x="570.556641"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_6">
+     <g id="line2d_6">
+      <g>
+       <use xlink:href="#m8a27cea125" x="532.163345" y="362.429802" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- replace x100 -->
+      <g transform="translate(472.256888 403.841321) rotate(-25) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-72"/>
+       <use xlink:href="#DejaVuSans-65" x="38.863281"/>
+       <use xlink:href="#DejaVuSans-70" x="100.386719"/>
+       <use xlink:href="#DejaVuSans-6c" x="163.863281"/>
+       <use xlink:href="#DejaVuSans-61" x="191.646484"/>
+       <use xlink:href="#DejaVuSans-63" x="252.925781"/>
+       <use xlink:href="#DejaVuSans-65" x="307.90625"/>
+       <use xlink:href="#DejaVuSans-20" x="369.429688"/>
+       <use xlink:href="#DejaVuSans-78" x="401.216797"/>
+       <use xlink:href="#DejaVuSans-31" x="460.396484"/>
+       <use xlink:href="#DejaVuSans-30" x="524.019531"/>
+       <use xlink:href="#DejaVuSans-30" x="587.642578"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_7">
+     <g id="line2d_7">
+      <g>
+       <use xlink:href="#m8a27cea125" x="615.70044" y="362.429802" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- insertMany x1000 -->
+      <g transform="translate(533.191517 414.381024) rotate(-25) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-69"/>
+       <use xlink:href="#DejaVuSans-6e" x="27.783203"/>
+       <use xlink:href="#DejaVuSans-73" x="91.162109"/>
+       <use xlink:href="#DejaVuSans-65" x="143.261719"/>
+       <use xlink:href="#DejaVuSans-72" x="204.785156"/>
+       <use xlink:href="#DejaVuSans-74" x="245.898438"/>
+       <use xlink:href="#DejaVuSans-4d" x="285.107422"/>
+       <use xlink:href="#DejaVuSans-61" x="371.386719"/>
+       <use xlink:href="#DejaVuSans-6e" x="432.666016"/>
+       <use xlink:href="#DejaVuSans-79" x="496.044922"/>
+       <use xlink:href="#DejaVuSans-20" x="555.224609"/>
+       <use xlink:href="#DejaVuSans-78" x="587.011719"/>
+       <use xlink:href="#DejaVuSans-31" x="646.191406"/>
+       <use xlink:href="#DejaVuSans-30" x="709.814453"/>
+       <use xlink:href="#DejaVuSans-30" x="773.4375"/>
+       <use xlink:href="#DejaVuSans-30" x="837.060547"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_8">
+     <g id="line2d_8">
+      <g>
+       <use xlink:href="#m8a27cea125" x="699.237535" y="362.429802" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- selectList x100 -->
+      <g transform="translate(630.044256 408.171837) rotate(-25) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-4c" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-73"/>
+       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
+       <use xlink:href="#DejaVuSans-6c" x="113.623047"/>
+       <use xlink:href="#DejaVuSans-65" x="141.40625"/>
+       <use xlink:href="#DejaVuSans-63" x="202.929688"/>
+       <use xlink:href="#DejaVuSans-74" x="257.910156"/>
+       <use xlink:href="#DejaVuSans-4c" x="297.119141"/>
+       <use xlink:href="#DejaVuSans-69" x="352.832031"/>
+       <use xlink:href="#DejaVuSans-73" x="380.615234"/>
+       <use xlink:href="#DejaVuSans-74" x="432.714844"/>
+       <use xlink:href="#DejaVuSans-20" x="471.923828"/>
+       <use xlink:href="#DejaVuSans-78" x="503.710938"/>
+       <use xlink:href="#DejaVuSans-31" x="562.890625"/>
+       <use xlink:href="#DejaVuSans-30" x="626.513672"/>
+       <use xlink:href="#DejaVuSans-30" x="690.136719"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_9">
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m8a27cea125" x="782.77463" y="362.429802" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- deleteWhere x100 -->
+      <g transform="translate(698.417689 415.242769) rotate(-25) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-57" d="M 213 4666 
+L 850 4666 
+L 1831 722 
+L 2809 4666 
+L 3519 4666 
+L 4500 722 
+L 5478 4666 
+L 6119 4666 
+L 4947 0 
+L 4153 0 
+L 3169 4050 
+L 2175 0 
+L 1381 0 
+L 213 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-68" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 4863 
+L 1159 4863 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-64"/>
+       <use xlink:href="#DejaVuSans-65" x="63.476562"/>
+       <use xlink:href="#DejaVuSans-6c" x="125"/>
+       <use xlink:href="#DejaVuSans-65" x="152.783203"/>
+       <use xlink:href="#DejaVuSans-74" x="214.306641"/>
+       <use xlink:href="#DejaVuSans-65" x="253.515625"/>
+       <use xlink:href="#DejaVuSans-57" x="315.039062"/>
+       <use xlink:href="#DejaVuSans-68" x="413.916016"/>
+       <use xlink:href="#DejaVuSans-65" x="477.294922"/>
+       <use xlink:href="#DejaVuSans-72" x="538.818359"/>
+       <use xlink:href="#DejaVuSans-65" x="577.681641"/>
+       <use xlink:href="#DejaVuSans-20" x="639.205078"/>
+       <use xlink:href="#DejaVuSans-78" x="670.992188"/>
+       <use xlink:href="#DejaVuSans-31" x="730.171875"/>
+       <use xlink:href="#DejaVuSans-30" x="793.794922"/>
+       <use xlink:href="#DejaVuSans-30" x="857.417969"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_10">
+      <path d="M 48.90125 362.429802 
+L 848.35125 362.429802 
+" clip-path="url(#pd8aee19cb6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_11">
+      <defs>
+       <path id="mfdf2d095f4" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#mfdf2d095f4" x="48.90125" y="362.429802" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 0 -->
+      <g transform="translate(35.53875 366.229021) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_12">
+      <path d="M 48.90125 319.433994 
+L 848.35125 319.433994 
+" clip-path="url(#pd8aee19cb6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#mfdf2d095f4" x="48.90125" y="319.433994" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 100 -->
+      <g transform="translate(22.81375 323.233213) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_14">
+      <path d="M 48.90125 276.438186 
+L 848.35125 276.438186 
+" clip-path="url(#pd8aee19cb6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#mfdf2d095f4" x="48.90125" y="276.438186" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 200 -->
+      <g transform="translate(22.81375 280.237405) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_16">
+      <path d="M 48.90125 233.442378 
+L 848.35125 233.442378 
+" clip-path="url(#pd8aee19cb6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#mfdf2d095f4" x="48.90125" y="233.442378" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_13">
+      <!-- 300 -->
+      <g transform="translate(22.81375 237.241596) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-33" d="M 2597 2516 
+Q 3050 2419 3304 2112 
+Q 3559 1806 3559 1356 
+Q 3559 666 3084 287 
+Q 2609 -91 1734 -91 
+Q 1441 -91 1130 -33 
+Q 819 25 488 141 
+L 488 750 
+Q 750 597 1062 519 
+Q 1375 441 1716 441 
+Q 2309 441 2620 675 
+Q 2931 909 2931 1356 
+Q 2931 1769 2642 2001 
+Q 2353 2234 1838 2234 
+L 1294 2234 
+L 1294 2753 
+L 1863 2753 
+Q 2328 2753 2575 2939 
+Q 2822 3125 2822 3475 
+Q 2822 3834 2567 4026 
+Q 2313 4219 1838 4219 
+Q 1578 4219 1281 4162 
+Q 984 4106 628 3988 
+L 628 4550 
+Q 988 4650 1302 4700 
+Q 1616 4750 1894 4750 
+Q 2613 4750 3031 4423 
+Q 3450 4097 3450 3541 
+Q 3450 3153 3228 2886 
+Q 3006 2619 2597 2516 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-33"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_18">
+      <path d="M 48.90125 190.446569 
+L 848.35125 190.446569 
+" clip-path="url(#pd8aee19cb6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#mfdf2d095f4" x="48.90125" y="190.446569" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_14">
+      <!-- 400 -->
+      <g transform="translate(22.81375 194.245788) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_20">
+      <path d="M 48.90125 147.450761 
+L 848.35125 147.450761 
+" clip-path="url(#pd8aee19cb6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_21">
+      <g>
+       <use xlink:href="#mfdf2d095f4" x="48.90125" y="147.450761" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_15">
+      <!-- 500 -->
+      <g transform="translate(22.81375 151.24998) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-35" d="M 691 4666 
+L 3169 4666 
+L 3169 4134 
+L 1269 4134 
+L 1269 2991 
+Q 1406 3038 1543 3061 
+Q 1681 3084 1819 3084 
+Q 2600 3084 3056 2656 
+Q 3513 2228 3513 1497 
+Q 3513 744 3044 326 
+Q 2575 -91 1722 -91 
+Q 1428 -91 1123 -41 
+Q 819 9 494 109 
+L 494 744 
+Q 775 591 1075 516 
+Q 1375 441 1709 441 
+Q 2250 441 2565 725 
+Q 2881 1009 2881 1497 
+Q 2881 1984 2565 2268 
+Q 2250 2553 1709 2553 
+Q 1456 2553 1204 2497 
+Q 953 2441 691 2322 
+L 691 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-35"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_22">
+      <path d="M 48.90125 104.454953 
+L 848.35125 104.454953 
+" clip-path="url(#pd8aee19cb6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_23">
+      <g>
+       <use xlink:href="#mfdf2d095f4" x="48.90125" y="104.454953" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_16">
+      <!-- 600 -->
+      <g transform="translate(22.81375 108.254172) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_8">
+     <g id="line2d_24">
+      <path d="M 48.90125 61.459145 
+L 848.35125 61.459145 
+" clip-path="url(#pd8aee19cb6)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_25">
+      <g>
+       <use xlink:href="#mfdf2d095f4" x="48.90125" y="61.459145" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_17">
+      <!-- 700 -->
+      <g transform="translate(22.81375 65.258363) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-37" d="M 525 4666 
+L 3525 4666 
+L 3525 4397 
+L 1831 0 
+L 1172 0 
+L 2766 4134 
+L 525 4134 
+L 525 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-37"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_18">
+     <!-- Time (ms) -->
+     <g transform="translate(16.318125 223.37287) rotate(-90) scale(0.12 -0.12)">
+      <defs>
+       <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-54"/>
+      <use xlink:href="#DejaVuSans-69" x="57.958984"/>
+      <use xlink:href="#DejaVuSans-6d" x="85.742188"/>
+      <use xlink:href="#DejaVuSans-65" x="183.154297"/>
+      <use xlink:href="#DejaVuSans-20" x="244.677734"/>
+      <use xlink:href="#DejaVuSans-28" x="276.464844"/>
+      <use xlink:href="#DejaVuSans-6d" x="315.478516"/>
+      <use xlink:href="#DejaVuSans-73" x="412.890625"/>
+      <use xlink:href="#DejaVuSans-29" x="464.990234"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_21">
+    <path d="M 48.90125 362.429802 
+L 48.90125 23.837812 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_22">
+    <path d="M 848.35125 362.429802 
+L 848.35125 23.837812 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_23">
+    <path d="M 48.90125 362.429802 
+L 848.35125 362.429802 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_24">
+    <path d="M 48.90125 23.837812 
+L 848.35125 23.837812 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_19">
+    <!-- 28x -->
+    <g style="fill: #0a58ca" transform="translate(119.93233 352.700263) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-Bold-32" d="M 1844 884 
+L 3897 884 
+L 3897 0 
+L 506 0 
+L 506 884 
+L 2209 2388 
+Q 2438 2594 2547 2791 
+Q 2656 2988 2656 3200 
+Q 2656 3528 2436 3728 
+Q 2216 3928 1850 3928 
+Q 1569 3928 1234 3808 
+Q 900 3688 519 3450 
+L 519 4475 
+Q 925 4609 1322 4679 
+Q 1719 4750 2100 4750 
+Q 2938 4750 3402 4381 
+Q 3866 4013 3866 3353 
+Q 3866 2972 3669 2642 
+Q 3472 2313 2841 1759 
+L 1844 884 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-38" d="M 2228 2088 
+Q 1891 2088 1709 1903 
+Q 1528 1719 1528 1375 
+Q 1528 1031 1709 848 
+Q 1891 666 2228 666 
+Q 2563 666 2741 848 
+Q 2919 1031 2919 1375 
+Q 2919 1722 2741 1905 
+Q 2563 2088 2228 2088 
+z
+M 1350 2484 
+Q 925 2613 709 2878 
+Q 494 3144 494 3541 
+Q 494 4131 934 4440 
+Q 1375 4750 2228 4750 
+Q 3075 4750 3515 4442 
+Q 3956 4134 3956 3541 
+Q 3956 3144 3739 2878 
+Q 3522 2613 3097 2484 
+Q 3572 2353 3814 2058 
+Q 4056 1763 4056 1313 
+Q 4056 619 3595 264 
+Q 3134 -91 2228 -91 
+Q 1319 -91 855 264 
+Q 391 619 391 1313 
+Q 391 1763 633 2058 
+Q 875 2353 1350 2484 
+z
+M 1631 3419 
+Q 1631 3141 1786 2991 
+Q 1941 2841 2228 2841 
+Q 2509 2841 2662 2991 
+Q 2816 3141 2816 3419 
+Q 2816 3697 2662 3845 
+Q 2509 3994 2228 3994 
+Q 1941 3994 1786 3844 
+Q 1631 3694 1631 3419 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-78" d="M 1422 1791 
+L 159 3500 
+L 1344 3500 
+L 2059 2463 
+L 2784 3500 
+L 3969 3500 
+L 2706 1797 
+L 4031 0 
+L 2847 0 
+L 2059 1106 
+L 1281 0 
+L 97 0 
+L 1422 1791 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-38" x="69.580078"/>
+     <use xlink:href="#DejaVuSans-Bold-78" x="139.160156"/>
+    </g>
+   </g>
+   <g id="text_20">
+    <!-- 24x -->
+    <g style="fill: #0a58ca" transform="translate(203.469425 351.840347) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
+L 1038 1722 
+L 2356 1722 
+L 2356 3675 
+z
+M 2156 4666 
+L 3494 4666 
+L 3494 1722 
+L 4159 1722 
+L 4159 850 
+L 3494 850 
+L 3494 0 
+L 2356 0 
+L 2356 850 
+L 288 850 
+L 288 1881 
+L 2156 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-34" x="69.580078"/>
+     <use xlink:href="#DejaVuSans-Bold-78" x="139.160156"/>
+    </g>
+   </g>
+   <g id="text_21">
+    <!-- 25x -->
+    <g style="fill: #0a58ca" transform="translate(287.00652 351.840347) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-Bold-35" d="M 678 4666 
+L 3669 4666 
+L 3669 3781 
+L 1638 3781 
+L 1638 3059 
+Q 1775 3097 1914 3117 
+Q 2053 3138 2203 3138 
+Q 3056 3138 3531 2711 
+Q 4006 2284 4006 1522 
+Q 4006 766 3489 337 
+Q 2972 -91 2053 -91 
+Q 1656 -91 1267 -14 
+Q 878 63 494 219 
+L 494 1166 
+Q 875 947 1217 837 
+Q 1559 728 1863 728 
+Q 2300 728 2551 942 
+Q 2803 1156 2803 1522 
+Q 2803 1891 2551 2103 
+Q 2300 2316 1863 2316 
+Q 1603 2316 1309 2248 
+Q 1016 2181 678 2041 
+L 678 4666 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-35" x="69.580078"/>
+     <use xlink:href="#DejaVuSans-Bold-78" x="139.160156"/>
+    </g>
+   </g>
+   <g id="text_22">
+    <!-- 24x -->
+    <g style="fill: #0a58ca" transform="translate(370.543615 346.68085) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-34" x="69.580078"/>
+     <use xlink:href="#DejaVuSans-Bold-78" x="139.160156"/>
+    </g>
+   </g>
+   <g id="text_23">
+    <!-- 22x -->
+    <g style="fill: #0a58ca" transform="translate(454.08071 346.68085) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-32" x="69.580078"/>
+     <use xlink:href="#DejaVuSans-Bold-78" x="139.160156"/>
+    </g>
+   </g>
+   <g id="text_24">
+    <!-- 22x -->
+    <g style="fill: #0a58ca" transform="translate(537.617805 345.820934) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-32" x="69.580078"/>
+     <use xlink:href="#DejaVuSans-Bold-78" x="139.160156"/>
+    </g>
+   </g>
+   <g id="text_25">
+    <!-- 4x -->
+    <g style="fill: #0a58ca" transform="translate(624.285916 353.732163) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSans-Bold-34"/>
+     <use xlink:href="#DejaVuSans-Bold-78" x="69.580078"/>
+    </g>
+   </g>
+   <g id="text_26">
+    <!-- 2x -->
+    <g style="fill: #0a58ca" transform="translate(707.823011 350.292498) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-78" x="69.580078"/>
+    </g>
+   </g>
+   <g id="text_27">
+    <!-- 6x -->
+    <g style="fill: #0a58ca" transform="translate(791.360106 306.264791) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-Bold-36" d="M 2316 2303 
+Q 2000 2303 1842 2098 
+Q 1684 1894 1684 1484 
+Q 1684 1075 1842 870 
+Q 2000 666 2316 666 
+Q 2634 666 2792 870 
+Q 2950 1075 2950 1484 
+Q 2950 1894 2792 2098 
+Q 2634 2303 2316 2303 
+z
+M 3803 4544 
+L 3803 3681 
+Q 3506 3822 3243 3889 
+Q 2981 3956 2731 3956 
+Q 2194 3956 1894 3657 
+Q 1594 3359 1544 2772 
+Q 1750 2925 1990 3001 
+Q 2231 3078 2516 3078 
+Q 3231 3078 3670 2659 
+Q 4109 2241 4109 1563 
+Q 4109 813 3618 361 
+Q 3128 -91 2303 -91 
+Q 1394 -91 895 523 
+Q 397 1138 397 2266 
+Q 397 3422 980 4083 
+Q 1563 4744 2578 4744 
+Q 2900 4744 3203 4694 
+Q 3506 4644 3803 4544 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-36"/>
+     <use xlink:href="#DejaVuSans-Bold-78" x="69.580078"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- Benchmark: 1ms latency per direction (2ms RTT) -->
+    <g transform="translate(255.617656 17.837812) scale(0.14 -0.14)">
+     <defs>
+      <path id="DejaVuSans-Bold-42" d="M 2456 2859 
+Q 2741 2859 2887 2984 
+Q 3034 3109 3034 3353 
+Q 3034 3594 2887 3720 
+Q 2741 3847 2456 3847 
+L 1791 3847 
+L 1791 2859 
+L 2456 2859 
+z
+M 2497 819 
+Q 2859 819 3042 972 
+Q 3225 1125 3225 1434 
+Q 3225 1738 3044 1889 
+Q 2863 2041 2497 2041 
+L 1791 2041 
+L 1791 819 
+L 2497 819 
+z
+M 3616 2497 
+Q 4003 2384 4215 2081 
+Q 4428 1778 4428 1338 
+Q 4428 663 3972 331 
+Q 3516 0 2584 0 
+L 588 0 
+L 588 4666 
+L 2394 4666 
+Q 3366 4666 3802 4372 
+Q 4238 4078 4238 3431 
+Q 4238 3091 4078 2852 
+Q 3919 2613 3616 2497 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-65" d="M 4031 1759 
+L 4031 1441 
+L 1416 1441 
+Q 1456 1047 1700 850 
+Q 1944 653 2381 653 
+Q 2734 653 3104 758 
+Q 3475 863 3866 1075 
+L 3866 213 
+Q 3469 63 3072 -14 
+Q 2675 -91 2278 -91 
+Q 1328 -91 801 392 
+Q 275 875 275 1747 
+Q 275 2603 792 3093 
+Q 1309 3584 2216 3584 
+Q 3041 3584 3536 3087 
+Q 4031 2591 4031 1759 
+z
+M 2881 2131 
+Q 2881 2450 2695 2645 
+Q 2509 2841 2209 2841 
+Q 1884 2841 1681 2658 
+Q 1478 2475 1428 2131 
+L 2881 2131 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6e" d="M 4056 2131 
+L 4056 0 
+L 2931 0 
+L 2931 347 
+L 2931 1631 
+Q 2931 2084 2911 2256 
+Q 2891 2428 2841 2509 
+Q 2775 2619 2662 2680 
+Q 2550 2741 2406 2741 
+Q 2056 2741 1856 2470 
+Q 1656 2200 1656 1722 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1909 3294 2193 3439 
+Q 2478 3584 2822 3584 
+Q 3428 3584 3742 3212 
+Q 4056 2841 4056 2131 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-63" d="M 3366 3391 
+L 3366 2478 
+Q 3138 2634 2908 2709 
+Q 2678 2784 2431 2784 
+Q 1963 2784 1702 2511 
+Q 1441 2238 1441 1747 
+Q 1441 1256 1702 982 
+Q 1963 709 2431 709 
+Q 2694 709 2930 787 
+Q 3166 866 3366 1019 
+L 3366 103 
+Q 3103 6 2833 -42 
+Q 2563 -91 2291 -91 
+Q 1344 -91 809 395 
+Q 275 881 275 1747 
+Q 275 2613 809 3098 
+Q 1344 3584 2291 3584 
+Q 2566 3584 2833 3536 
+Q 3100 3488 3366 3391 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-68" d="M 4056 2131 
+L 4056 0 
+L 2931 0 
+L 2931 347 
+L 2931 1625 
+Q 2931 2084 2911 2256 
+Q 2891 2428 2841 2509 
+Q 2775 2619 2662 2680 
+Q 2550 2741 2406 2741 
+Q 2056 2741 1856 2470 
+Q 1656 2200 1656 1722 
+L 1656 0 
+L 538 0 
+L 538 4863 
+L 1656 4863 
+L 1656 2988 
+Q 1909 3294 2193 3439 
+Q 2478 3584 2822 3584 
+Q 3428 3584 3742 3212 
+Q 4056 2841 4056 2131 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
+Q 3994 3244 4286 3414 
+Q 4578 3584 4928 3584 
+Q 5531 3584 5847 3212 
+Q 6163 2841 6163 2131 
+L 6163 0 
+L 5038 0 
+L 5038 1825 
+Q 5041 1866 5042 1909 
+Q 5044 1953 5044 2034 
+Q 5044 2406 4934 2573 
+Q 4825 2741 4581 2741 
+Q 4263 2741 4089 2478 
+Q 3916 2216 3909 1719 
+L 3909 0 
+L 2784 0 
+L 2784 1825 
+Q 2784 2406 2684 2573 
+Q 2584 2741 2328 2741 
+Q 2006 2741 1831 2477 
+Q 1656 2213 1656 1722 
+L 1656 0 
+L 531 0 
+L 531 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1863 3284 2130 3434 
+Q 2397 3584 2719 3584 
+Q 3081 3584 3359 3409 
+Q 3638 3234 3781 2919 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-61" d="M 2106 1575 
+Q 1756 1575 1579 1456 
+Q 1403 1338 1403 1106 
+Q 1403 894 1545 773 
+Q 1688 653 1941 653 
+Q 2256 653 2472 879 
+Q 2688 1106 2688 1447 
+L 2688 1575 
+L 2106 1575 
+z
+M 3816 1997 
+L 3816 0 
+L 2688 0 
+L 2688 519 
+Q 2463 200 2181 54 
+Q 1900 -91 1497 -91 
+Q 953 -91 614 226 
+Q 275 544 275 1050 
+Q 275 1666 698 1953 
+Q 1122 2241 2028 2241 
+L 2688 2241 
+L 2688 2328 
+Q 2688 2594 2478 2717 
+Q 2269 2841 1825 2841 
+Q 1466 2841 1156 2769 
+Q 847 2697 581 2553 
+L 581 3406 
+Q 941 3494 1303 3539 
+Q 1666 3584 2028 3584 
+Q 2975 3584 3395 3211 
+Q 3816 2838 3816 1997 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-72" d="M 3138 2547 
+Q 2991 2616 2845 2648 
+Q 2700 2681 2553 2681 
+Q 2122 2681 1889 2404 
+Q 1656 2128 1656 1613 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2925 
+Q 1872 3269 2151 3426 
+Q 2431 3584 2822 3584 
+Q 2878 3584 2943 3579 
+Q 3009 3575 3134 3559 
+L 3138 2547 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6b" d="M 538 4863 
+L 1656 4863 
+L 1656 2216 
+L 2944 3500 
+L 4244 3500 
+L 2534 1894 
+L 4378 0 
+L 3022 0 
+L 1656 1459 
+L 1656 0 
+L 538 0 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-3a" d="M 716 3500 
+L 1844 3500 
+L 1844 2291 
+L 716 2291 
+L 716 3500 
+z
+M 716 1209 
+L 1844 1209 
+L 1844 0 
+L 716 0 
+L 716 1209 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-31" d="M 750 831 
+L 1813 831 
+L 1813 3847 
+L 722 3622 
+L 722 4441 
+L 1806 4666 
+L 2950 4666 
+L 2950 831 
+L 4013 831 
+L 4013 0 
+L 750 0 
+L 750 831 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-73" d="M 3272 3391 
+L 3272 2541 
+Q 2913 2691 2578 2766 
+Q 2244 2841 1947 2841 
+Q 1628 2841 1473 2761 
+Q 1319 2681 1319 2516 
+Q 1319 2381 1436 2309 
+Q 1553 2238 1856 2203 
+L 2053 2175 
+Q 2913 2066 3209 1816 
+Q 3506 1566 3506 1031 
+Q 3506 472 3093 190 
+Q 2681 -91 1863 -91 
+Q 1516 -91 1145 -36 
+Q 775 19 384 128 
+L 384 978 
+Q 719 816 1070 734 
+Q 1422 653 1784 653 
+Q 2113 653 2278 743 
+Q 2444 834 2444 1013 
+Q 2444 1163 2330 1236 
+Q 2216 1309 1875 1350 
+L 1678 1375 
+Q 931 1469 631 1722 
+Q 331 1975 331 2491 
+Q 331 3047 712 3315 
+Q 1094 3584 1881 3584 
+Q 2191 3584 2531 3537 
+Q 2872 3491 3272 3391 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6c" d="M 538 4863 
+L 1656 4863 
+L 1656 0 
+L 538 0 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-74" d="M 1759 4494 
+L 1759 3500 
+L 2913 3500 
+L 2913 2700 
+L 1759 2700 
+L 1759 1216 
+Q 1759 972 1856 886 
+Q 1953 800 2241 800 
+L 2816 800 
+L 2816 0 
+L 1856 0 
+Q 1194 0 917 276 
+Q 641 553 641 1216 
+L 641 2700 
+L 84 2700 
+L 84 3500 
+L 641 3500 
+L 641 4494 
+L 1759 4494 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-79" d="M 78 3500 
+L 1197 3500 
+L 2138 1125 
+L 2938 3500 
+L 4056 3500 
+L 2584 -331 
+Q 2363 -916 2067 -1148 
+Q 1772 -1381 1288 -1381 
+L 641 -1381 
+L 641 -647 
+L 991 -647 
+Q 1275 -647 1404 -556 
+Q 1534 -466 1606 -231 
+L 1638 -134 
+L 78 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-70" d="M 1656 506 
+L 1656 -1331 
+L 538 -1331 
+L 538 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1888 3294 2169 3439 
+Q 2450 3584 2816 3584 
+Q 3463 3584 3878 3070 
+Q 4294 2556 4294 1747 
+Q 4294 938 3878 423 
+Q 3463 -91 2816 -91 
+Q 2450 -91 2169 54 
+Q 1888 200 1656 506 
+z
+M 2400 2772 
+Q 2041 2772 1848 2508 
+Q 1656 2244 1656 1747 
+Q 1656 1250 1848 986 
+Q 2041 722 2400 722 
+Q 2759 722 2948 984 
+Q 3138 1247 3138 1747 
+Q 3138 2247 2948 2509 
+Q 2759 2772 2400 2772 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-64" d="M 2919 2988 
+L 2919 4863 
+L 4044 4863 
+L 4044 0 
+L 2919 0 
+L 2919 506 
+Q 2688 197 2409 53 
+Q 2131 -91 1766 -91 
+Q 1119 -91 703 423 
+Q 288 938 288 1747 
+Q 288 2556 703 3070 
+Q 1119 3584 1766 3584 
+Q 2128 3584 2408 3439 
+Q 2688 3294 2919 2988 
+z
+M 2181 722 
+Q 2541 722 2730 984 
+Q 2919 1247 2919 1747 
+Q 2919 2247 2730 2509 
+Q 2541 2772 2181 2772 
+Q 1825 2772 1636 2509 
+Q 1447 2247 1447 1747 
+Q 1447 1247 1636 984 
+Q 1825 722 2181 722 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-69" d="M 538 3500 
+L 1656 3500 
+L 1656 0 
+L 538 0 
+L 538 3500 
+z
+M 538 4863 
+L 1656 4863 
+L 1656 3950 
+L 538 3950 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6f" d="M 2203 2784 
+Q 1831 2784 1636 2517 
+Q 1441 2250 1441 1747 
+Q 1441 1244 1636 976 
+Q 1831 709 2203 709 
+Q 2569 709 2762 976 
+Q 2956 1244 2956 1747 
+Q 2956 2250 2762 2517 
+Q 2569 2784 2203 2784 
+z
+M 2203 3584 
+Q 3106 3584 3614 3096 
+Q 4122 2609 4122 1747 
+Q 4122 884 3614 396 
+Q 3106 -91 2203 -91 
+Q 1297 -91 786 396 
+Q 275 884 275 1747 
+Q 275 2609 786 3096 
+Q 1297 3584 2203 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-28" d="M 2413 -844 
+L 1484 -844 
+Q 1006 -72 778 623 
+Q 550 1319 550 2003 
+Q 550 2688 779 3389 
+Q 1009 4091 1484 4856 
+L 2413 4856 
+Q 2013 4116 1813 3408 
+Q 1613 2700 1613 2009 
+Q 1613 1319 1811 609 
+Q 2009 -100 2413 -844 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-52" d="M 2297 2597 
+Q 2675 2597 2839 2737 
+Q 3003 2878 3003 3200 
+Q 3003 3519 2839 3656 
+Q 2675 3794 2297 3794 
+L 1791 3794 
+L 1791 2597 
+L 2297 2597 
+z
+M 1791 1766 
+L 1791 0 
+L 588 0 
+L 588 4666 
+L 2425 4666 
+Q 3347 4666 3776 4356 
+Q 4206 4047 4206 3378 
+Q 4206 2916 3982 2619 
+Q 3759 2322 3309 2181 
+Q 3556 2125 3751 1926 
+Q 3947 1728 4147 1325 
+L 4800 0 
+L 3519 0 
+L 2950 1159 
+Q 2778 1509 2601 1637 
+Q 2425 1766 2131 1766 
+L 1791 1766 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-54" d="M 31 4666 
+L 4331 4666 
+L 4331 3756 
+L 2784 3756 
+L 2784 0 
+L 1581 0 
+L 1581 3756 
+L 31 3756 
+L 31 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-29" d="M 513 -844 
+Q 913 -100 1113 609 
+Q 1313 1319 1313 2009 
+Q 1313 2700 1113 3408 
+Q 913 4116 513 4856 
+L 1441 4856 
+Q 1916 4091 2145 3389 
+Q 2375 2688 2375 2003 
+Q 2375 1319 2147 623 
+Q 1919 -72 1441 -844 
+L 513 -844 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-42"/>
+     <use xlink:href="#DejaVuSans-Bold-65" x="76.220703"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" x="144.042969"/>
+     <use xlink:href="#DejaVuSans-Bold-63" x="215.234375"/>
+     <use xlink:href="#DejaVuSans-Bold-68" x="274.511719"/>
+     <use xlink:href="#DejaVuSans-Bold-6d" x="345.703125"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="449.902344"/>
+     <use xlink:href="#DejaVuSans-Bold-72" x="517.382812"/>
+     <use xlink:href="#DejaVuSans-Bold-6b" x="566.699219"/>
+     <use xlink:href="#DejaVuSans-Bold-3a" x="633.203125"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="673.193359"/>
+     <use xlink:href="#DejaVuSans-Bold-31" x="708.007812"/>
+     <use xlink:href="#DejaVuSans-Bold-6d" x="777.587891"/>
+     <use xlink:href="#DejaVuSans-Bold-73" x="881.787109"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="941.308594"/>
+     <use xlink:href="#DejaVuSans-Bold-6c" x="976.123047"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="1010.400391"/>
+     <use xlink:href="#DejaVuSans-Bold-74" x="1077.880859"/>
+     <use xlink:href="#DejaVuSans-Bold-65" x="1125.683594"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" x="1193.505859"/>
+     <use xlink:href="#DejaVuSans-Bold-63" x="1264.697266"/>
+     <use xlink:href="#DejaVuSans-Bold-79" x="1323.974609"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="1389.160156"/>
+     <use xlink:href="#DejaVuSans-Bold-70" x="1423.974609"/>
+     <use xlink:href="#DejaVuSans-Bold-65" x="1495.556641"/>
+     <use xlink:href="#DejaVuSans-Bold-72" x="1563.378906"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="1612.695312"/>
+     <use xlink:href="#DejaVuSans-Bold-64" x="1647.509766"/>
+     <use xlink:href="#DejaVuSans-Bold-69" x="1719.091797"/>
+     <use xlink:href="#DejaVuSans-Bold-72" x="1753.369141"/>
+     <use xlink:href="#DejaVuSans-Bold-65" x="1802.685547"/>
+     <use xlink:href="#DejaVuSans-Bold-63" x="1870.507812"/>
+     <use xlink:href="#DejaVuSans-Bold-74" x="1929.785156"/>
+     <use xlink:href="#DejaVuSans-Bold-69" x="1977.587891"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" x="2011.865234"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" x="2080.566406"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="2151.757812"/>
+     <use xlink:href="#DejaVuSans-Bold-28" x="2186.572266"/>
+     <use xlink:href="#DejaVuSans-Bold-32" x="2232.275391"/>
+     <use xlink:href="#DejaVuSans-Bold-6d" x="2301.855469"/>
+     <use xlink:href="#DejaVuSans-Bold-73" x="2406.054688"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="2465.576172"/>
+     <use xlink:href="#DejaVuSans-Bold-52" x="2500.390625"/>
+     <use xlink:href="#DejaVuSans-Bold-54" x="2572.892578"/>
+     <use xlink:href="#DejaVuSans-Bold-54" x="2643.355469"/>
+     <use xlink:href="#DejaVuSans-Bold-29" x="2711.568359"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_25">
+     <path d="M 56.60125 64.929687 
+L 226.4 64.929687 
+Q 228.6 64.929687 228.6 62.729687 
+L 228.6 31.537812 
+Q 228.6 29.337812 226.4 29.337812 
+L 56.60125 29.337812 
+Q 54.40125 29.337812 54.40125 31.537812 
+L 54.40125 62.729687 
+Q 54.40125 64.929687 56.60125 64.929687 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="patch_26">
+     <path d="M 58.80125 42.096094 
+L 80.80125 42.096094 
+L 80.80125 34.396094 
+L 58.80125 34.396094 
+z
+" style="fill: #6c757d"/>
+    </g>
+    <g id="text_29">
+     <!-- persistent-postgresql -->
+     <g transform="translate(89.60125 42.096094) scale(0.11 -0.11)">
+      <defs>
+       <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-71" d="M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+M 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 -1331 
+L 2906 -1331 
+L 2906 525 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-70"/>
+      <use xlink:href="#DejaVuSans-65" x="63.476562"/>
+      <use xlink:href="#DejaVuSans-72" x="125"/>
+      <use xlink:href="#DejaVuSans-73" x="166.113281"/>
+      <use xlink:href="#DejaVuSans-69" x="218.212891"/>
+      <use xlink:href="#DejaVuSans-73" x="245.996094"/>
+      <use xlink:href="#DejaVuSans-74" x="298.095703"/>
+      <use xlink:href="#DejaVuSans-65" x="337.304688"/>
+      <use xlink:href="#DejaVuSans-6e" x="398.828125"/>
+      <use xlink:href="#DejaVuSans-74" x="462.207031"/>
+      <use xlink:href="#DejaVuSans-2d" x="501.416016"/>
+      <use xlink:href="#DejaVuSans-70" x="537.5"/>
+      <use xlink:href="#DejaVuSans-6f" x="600.976562"/>
+      <use xlink:href="#DejaVuSans-73" x="662.158203"/>
+      <use xlink:href="#DejaVuSans-74" x="714.257812"/>
+      <use xlink:href="#DejaVuSans-67" x="753.466797"/>
+      <use xlink:href="#DejaVuSans-72" x="816.943359"/>
+      <use xlink:href="#DejaVuSans-65" x="855.806641"/>
+      <use xlink:href="#DejaVuSans-73" x="917.330078"/>
+      <use xlink:href="#DejaVuSans-71" x="969.429688"/>
+      <use xlink:href="#DejaVuSans-6c" x="1032.90625"/>
+     </g>
+    </g>
+    <g id="patch_27">
+     <path d="M 58.80125 58.242031 
+L 80.80125 58.242031 
+L 80.80125 50.542031 
+L 58.80125 50.542031 
+z
+" style="fill: #0d6efd"/>
+    </g>
+    <g id="text_30">
+     <!-- persistent-postgresql-ng -->
+     <g transform="translate(89.60125 58.242031) scale(0.11 -0.11)">
+      <use xlink:href="#DejaVuSans-70"/>
+      <use xlink:href="#DejaVuSans-65" x="63.476562"/>
+      <use xlink:href="#DejaVuSans-72" x="125"/>
+      <use xlink:href="#DejaVuSans-73" x="166.113281"/>
+      <use xlink:href="#DejaVuSans-69" x="218.212891"/>
+      <use xlink:href="#DejaVuSans-73" x="245.996094"/>
+      <use xlink:href="#DejaVuSans-74" x="298.095703"/>
+      <use xlink:href="#DejaVuSans-65" x="337.304688"/>
+      <use xlink:href="#DejaVuSans-6e" x="398.828125"/>
+      <use xlink:href="#DejaVuSans-74" x="462.207031"/>
+      <use xlink:href="#DejaVuSans-2d" x="501.416016"/>
+      <use xlink:href="#DejaVuSans-70" x="537.5"/>
+      <use xlink:href="#DejaVuSans-6f" x="600.976562"/>
+      <use xlink:href="#DejaVuSans-73" x="662.158203"/>
+      <use xlink:href="#DejaVuSans-74" x="714.257812"/>
+      <use xlink:href="#DejaVuSans-67" x="753.466797"/>
+      <use xlink:href="#DejaVuSans-72" x="816.943359"/>
+      <use xlink:href="#DejaVuSans-65" x="855.806641"/>
+      <use xlink:href="#DejaVuSans-73" x="917.330078"/>
+      <use xlink:href="#DejaVuSans-71" x="969.429688"/>
+      <use xlink:href="#DejaVuSans-6c" x="1032.90625"/>
+      <use xlink:href="#DejaVuSans-2d" x="1060.689453"/>
+      <use xlink:href="#DejaVuSans-6e" x="1096.773438"/>
+      <use xlink:href="#DejaVuSans-67" x="1160.152344"/>
+     </g>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pd8aee19cb6">
+   <rect x="48.90125" y="23.837812" width="799.45" height="338.59199"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/persistent-postgresql-ng/bench/bench-5ms.svg
+++ b/persistent-postgresql-ng/bench/bench-5ms.svg
@@ -1,0 +1,1871 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="855.61375pt" height="424.340681pt" viewBox="0 0 855.61375 424.340681" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2026-02-19T22:23:56.258854</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.9.4, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 424.340681 
+L 855.61375 424.340681 
+L 855.61375 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 55.26375 363.304622 
+L 848.41375 363.304622 
+L 848.41375 23.837812 
+L 55.26375 23.837812 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 91.316023 363.304622 
+L 145.010897 363.304622 
+L 145.010897 42.69708 
+L 91.316023 42.69708 
+z
+" clip-path="url(#pdaba22e8e0)" style="fill: #6c757d"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 244.729949 363.304622 
+L 298.424824 363.304622 
+L 298.424824 40.002899 
+L 244.729949 40.002899 
+z
+" clip-path="url(#pdaba22e8e0)" style="fill: #6c757d"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 398.143876 363.304622 
+L 451.83875 363.304622 
+L 451.83875 343.744868 
+L 398.143876 343.744868 
+z
+" clip-path="url(#pdaba22e8e0)" style="fill: #6c757d"/>
+   </g>
+   <g id="patch_6">
+    <path d="M 551.557802 363.304622 
+L 605.252676 363.304622 
+L 605.252676 343.367682 
+L 551.557802 343.367682 
+z
+" clip-path="url(#pdaba22e8e0)" style="fill: #6c757d"/>
+   </g>
+   <g id="patch_7">
+    <path d="M 704.971729 363.304622 
+L 758.666603 363.304622 
+L 758.666603 344.364529 
+L 704.971729 344.364529 
+z
+" clip-path="url(#pdaba22e8e0)" style="fill: #6c757d"/>
+   </g>
+   <g id="patch_8">
+    <path d="M 145.010897 363.304622 
+L 198.705771 363.304622 
+L 198.705771 349.833717 
+L 145.010897 349.833717 
+z
+" clip-path="url(#pdaba22e8e0)" style="fill: #0d6efd"/>
+   </g>
+   <g id="patch_9">
+    <path d="M 298.424824 363.304622 
+L 352.119698 363.304622 
+L 352.119698 352.25848 
+L 298.424824 352.25848 
+z
+" clip-path="url(#pdaba22e8e0)" style="fill: #0d6efd"/>
+   </g>
+   <g id="patch_10">
+    <path d="M 451.83875 363.304622 
+L 505.533624 363.304622 
+L 505.533624 357.161889 
+L 451.83875 357.161889 
+z
+" clip-path="url(#pdaba22e8e0)" style="fill: #0d6efd"/>
+   </g>
+   <g id="patch_11">
+    <path d="M 605.252676 363.304622 
+L 658.947551 363.304622 
+L 658.947551 350.399495 
+L 605.252676 350.399495 
+z
+" clip-path="url(#pdaba22e8e0)" style="fill: #0d6efd"/>
+   </g>
+   <g id="patch_12">
+    <path d="M 758.666603 363.304622 
+L 812.361477 363.304622 
+L 812.361477 351.423284 
+L 758.666603 351.423284 
+z
+" clip-path="url(#pdaba22e8e0)" style="fill: #0d6efd"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="ma562f5981e" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#ma562f5981e" x="145.010897" y="363.304622" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <!-- get x100 -->
+      <g transform="translate(103.704991 396.042561) rotate(-25) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-67" d="M 2906 1791 
+Q 2906 2416 2648 2759 
+Q 2391 3103 1925 3103 
+Q 1463 3103 1205 2759 
+Q 947 2416 947 1791 
+Q 947 1169 1205 825 
+Q 1463 481 1925 481 
+Q 2391 481 2648 825 
+Q 2906 1169 2906 1791 
+z
+M 3481 434 
+Q 3481 -459 3084 -895 
+Q 2688 -1331 1869 -1331 
+Q 1566 -1331 1297 -1286 
+Q 1028 -1241 775 -1147 
+L 775 -588 
+Q 1028 -725 1275 -790 
+Q 1522 -856 1778 -856 
+Q 2344 -856 2625 -561 
+Q 2906 -266 2906 331 
+L 2906 616 
+Q 2728 306 2450 153 
+Q 2172 0 1784 0 
+Q 1141 0 747 490 
+Q 353 981 353 1791 
+Q 353 2603 747 3093 
+Q 1141 3584 1784 3584 
+Q 2172 3584 2450 3431 
+Q 2728 3278 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 434 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-65" d="M 3597 1894 
+L 3597 1613 
+L 953 1613 
+Q 991 1019 1311 708 
+Q 1631 397 2203 397 
+Q 2534 397 2845 478 
+Q 3156 559 3463 722 
+L 3463 178 
+Q 3153 47 2828 -22 
+Q 2503 -91 2169 -91 
+Q 1331 -91 842 396 
+Q 353 884 353 1716 
+Q 353 2575 817 3079 
+Q 1281 3584 2069 3584 
+Q 2775 3584 3186 3129 
+Q 3597 2675 3597 1894 
+z
+M 3022 2063 
+Q 3016 2534 2758 2815 
+Q 2500 3097 2075 3097 
+Q 1594 3097 1305 2825 
+Q 1016 2553 972 2059 
+L 3022 2063 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-74" d="M 1172 4494 
+L 1172 3500 
+L 2356 3500 
+L 2356 3053 
+L 1172 3053 
+L 1172 1153 
+Q 1172 725 1289 603 
+Q 1406 481 1766 481 
+L 2356 481 
+L 2356 0 
+L 1766 0 
+Q 1100 0 847 248 
+Q 594 497 594 1153 
+L 594 3053 
+L 172 3053 
+L 172 3500 
+L 594 3500 
+L 594 4494 
+L 1172 4494 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-78" d="M 3513 3500 
+L 2247 1797 
+L 3578 0 
+L 2900 0 
+L 1881 1375 
+L 863 0 
+L 184 0 
+L 1544 1831 
+L 300 3500 
+L 978 3500 
+L 1906 2253 
+L 2834 3500 
+L 3513 3500 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-31" d="M 794 531 
+L 1825 531 
+L 1825 4091 
+L 703 3866 
+L 703 4441 
+L 1819 4666 
+L 2450 4666 
+L 2450 531 
+L 3481 531 
+L 3481 0 
+L 794 0 
+L 794 531 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-30" d="M 2034 4250 
+Q 1547 4250 1301 3770 
+Q 1056 3291 1056 2328 
+Q 1056 1369 1301 889 
+Q 1547 409 2034 409 
+Q 2525 409 2770 889 
+Q 3016 1369 3016 2328 
+Q 3016 3291 2770 3770 
+Q 2525 4250 2034 4250 
+z
+M 2034 4750 
+Q 2819 4750 3233 4129 
+Q 3647 3509 3647 2328 
+Q 3647 1150 3233 529 
+Q 2819 -91 2034 -91 
+Q 1250 -91 836 529 
+Q 422 1150 422 2328 
+Q 422 3509 836 4129 
+Q 1250 4750 2034 4750 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-67"/>
+       <use xlink:href="#DejaVuSans-65" x="63.476562"/>
+       <use xlink:href="#DejaVuSans-74" x="125"/>
+       <use xlink:href="#DejaVuSans-20" x="164.208984"/>
+       <use xlink:href="#DejaVuSans-78" x="195.996094"/>
+       <use xlink:href="#DejaVuSans-31" x="255.175781"/>
+       <use xlink:href="#DejaVuSans-30" x="318.798828"/>
+       <use xlink:href="#DejaVuSans-30" x="382.421875"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#ma562f5981e" x="298.424824" y="363.304622" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <!-- insert x100 -->
+      <g transform="translate(246.163922 401.150959) rotate(-25) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-69" d="M 603 3500 
+L 1178 3500 
+L 1178 0 
+L 603 0 
+L 603 3500 
+z
+M 603 4863 
+L 1178 4863 
+L 1178 4134 
+L 603 4134 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-6e" d="M 3513 2113 
+L 3513 0 
+L 2938 0 
+L 2938 2094 
+Q 2938 2591 2744 2837 
+Q 2550 3084 2163 3084 
+Q 1697 3084 1428 2787 
+Q 1159 2491 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1366 3272 1645 3428 
+Q 1925 3584 2291 3584 
+Q 2894 3584 3203 3211 
+Q 3513 2838 3513 2113 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-73" d="M 2834 3397 
+L 2834 2853 
+Q 2591 2978 2328 3040 
+Q 2066 3103 1784 3103 
+Q 1356 3103 1142 2972 
+Q 928 2841 928 2578 
+Q 928 2378 1081 2264 
+Q 1234 2150 1697 2047 
+L 1894 2003 
+Q 2506 1872 2764 1633 
+Q 3022 1394 3022 966 
+Q 3022 478 2636 193 
+Q 2250 -91 1575 -91 
+Q 1294 -91 989 -36 
+Q 684 19 347 128 
+L 347 722 
+Q 666 556 975 473 
+Q 1284 391 1588 391 
+Q 1994 391 2212 530 
+Q 2431 669 2431 922 
+Q 2431 1156 2273 1281 
+Q 2116 1406 1581 1522 
+L 1381 1569 
+Q 847 1681 609 1914 
+Q 372 2147 372 2553 
+Q 372 3047 722 3315 
+Q 1072 3584 1716 3584 
+Q 2034 3584 2315 3537 
+Q 2597 3491 2834 3397 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-72" d="M 2631 2963 
+Q 2534 3019 2420 3045 
+Q 2306 3072 2169 3072 
+Q 1681 3072 1420 2755 
+Q 1159 2438 1159 1844 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1341 3275 1631 3429 
+Q 1922 3584 2338 3584 
+Q 2397 3584 2469 3576 
+Q 2541 3569 2628 3553 
+L 2631 2963 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-69"/>
+       <use xlink:href="#DejaVuSans-6e" x="27.783203"/>
+       <use xlink:href="#DejaVuSans-73" x="91.162109"/>
+       <use xlink:href="#DejaVuSans-65" x="143.261719"/>
+       <use xlink:href="#DejaVuSans-72" x="204.785156"/>
+       <use xlink:href="#DejaVuSans-74" x="245.898438"/>
+       <use xlink:href="#DejaVuSans-20" x="285.107422"/>
+       <use xlink:href="#DejaVuSans-78" x="316.894531"/>
+       <use xlink:href="#DejaVuSans-31" x="376.074219"/>
+       <use xlink:href="#DejaVuSans-30" x="439.697266"/>
+       <use xlink:href="#DejaVuSans-30" x="503.320312"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#ma562f5981e" x="451.83875" y="363.304622" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <!-- insertMany x1000 -->
+      <g transform="translate(369.329827 415.255844) rotate(-25) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-4d" d="M 628 4666 
+L 1569 4666 
+L 2759 1491 
+L 3956 4666 
+L 4897 4666 
+L 4897 0 
+L 4281 0 
+L 4281 4097 
+L 3078 897 
+L 2444 897 
+L 1241 4097 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-61" d="M 2194 1759 
+Q 1497 1759 1228 1600 
+Q 959 1441 959 1056 
+Q 959 750 1161 570 
+Q 1363 391 1709 391 
+Q 2188 391 2477 730 
+Q 2766 1069 2766 1631 
+L 2766 1759 
+L 2194 1759 
+z
+M 3341 1997 
+L 3341 0 
+L 2766 0 
+L 2766 531 
+Q 2569 213 2275 61 
+Q 1981 -91 1556 -91 
+Q 1019 -91 701 211 
+Q 384 513 384 1019 
+Q 384 1609 779 1909 
+Q 1175 2209 1959 2209 
+L 2766 2209 
+L 2766 2266 
+Q 2766 2663 2505 2880 
+Q 2244 3097 1772 3097 
+Q 1472 3097 1187 3025 
+Q 903 2953 641 2809 
+L 641 3341 
+Q 956 3463 1253 3523 
+Q 1550 3584 1831 3584 
+Q 2591 3584 2966 3190 
+Q 3341 2797 3341 1997 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-79" d="M 2059 -325 
+Q 1816 -950 1584 -1140 
+Q 1353 -1331 966 -1331 
+L 506 -1331 
+L 506 -850 
+L 844 -850 
+Q 1081 -850 1212 -737 
+Q 1344 -625 1503 -206 
+L 1606 56 
+L 191 3500 
+L 800 3500 
+L 1894 763 
+L 2988 3500 
+L 3597 3500 
+L 2059 -325 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-69"/>
+       <use xlink:href="#DejaVuSans-6e" x="27.783203"/>
+       <use xlink:href="#DejaVuSans-73" x="91.162109"/>
+       <use xlink:href="#DejaVuSans-65" x="143.261719"/>
+       <use xlink:href="#DejaVuSans-72" x="204.785156"/>
+       <use xlink:href="#DejaVuSans-74" x="245.898438"/>
+       <use xlink:href="#DejaVuSans-4d" x="285.107422"/>
+       <use xlink:href="#DejaVuSans-61" x="371.386719"/>
+       <use xlink:href="#DejaVuSans-6e" x="432.666016"/>
+       <use xlink:href="#DejaVuSans-79" x="496.044922"/>
+       <use xlink:href="#DejaVuSans-20" x="555.224609"/>
+       <use xlink:href="#DejaVuSans-78" x="587.011719"/>
+       <use xlink:href="#DejaVuSans-31" x="646.191406"/>
+       <use xlink:href="#DejaVuSans-30" x="709.814453"/>
+       <use xlink:href="#DejaVuSans-30" x="773.4375"/>
+       <use xlink:href="#DejaVuSans-30" x="837.060547"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#ma562f5981e" x="605.252676" y="363.304622" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <!-- selectList x100 -->
+      <g transform="translate(536.059397 409.046657) rotate(-25) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-6c" d="M 603 4863 
+L 1178 4863 
+L 1178 0 
+L 603 0 
+L 603 4863 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-63" d="M 3122 3366 
+L 3122 2828 
+Q 2878 2963 2633 3030 
+Q 2388 3097 2138 3097 
+Q 1578 3097 1268 2742 
+Q 959 2388 959 1747 
+Q 959 1106 1268 751 
+Q 1578 397 2138 397 
+Q 2388 397 2633 464 
+Q 2878 531 3122 666 
+L 3122 134 
+Q 2881 22 2623 -34 
+Q 2366 -91 2075 -91 
+Q 1284 -91 818 406 
+Q 353 903 353 1747 
+Q 353 2603 823 3093 
+Q 1294 3584 2113 3584 
+Q 2378 3584 2631 3529 
+Q 2884 3475 3122 3366 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-4c" d="M 628 4666 
+L 1259 4666 
+L 1259 531 
+L 3531 531 
+L 3531 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-73"/>
+       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
+       <use xlink:href="#DejaVuSans-6c" x="113.623047"/>
+       <use xlink:href="#DejaVuSans-65" x="141.40625"/>
+       <use xlink:href="#DejaVuSans-63" x="202.929688"/>
+       <use xlink:href="#DejaVuSans-74" x="257.910156"/>
+       <use xlink:href="#DejaVuSans-4c" x="297.119141"/>
+       <use xlink:href="#DejaVuSans-69" x="352.832031"/>
+       <use xlink:href="#DejaVuSans-73" x="380.615234"/>
+       <use xlink:href="#DejaVuSans-74" x="432.714844"/>
+       <use xlink:href="#DejaVuSans-20" x="471.923828"/>
+       <use xlink:href="#DejaVuSans-78" x="503.710938"/>
+       <use xlink:href="#DejaVuSans-31" x="562.890625"/>
+       <use xlink:href="#DejaVuSans-30" x="626.513672"/>
+       <use xlink:href="#DejaVuSans-30" x="690.136719"/>
+      </g>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#ma562f5981e" x="758.666603" y="363.304622" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <!-- select IN x20 -->
+      <g transform="translate(698.747401 404.722084) rotate(-25) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-49" d="M 628 4666 
+L 1259 4666 
+L 1259 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-4e" d="M 628 4666 
+L 1478 4666 
+L 3547 763 
+L 3547 4666 
+L 4159 4666 
+L 4159 0 
+L 3309 0 
+L 1241 3903 
+L 1241 0 
+L 628 0 
+L 628 4666 
+z
+" transform="scale(0.015625)"/>
+        <path id="DejaVuSans-32" d="M 1228 531 
+L 3431 531 
+L 3431 0 
+L 469 0 
+L 469 531 
+Q 828 903 1448 1529 
+Q 2069 2156 2228 2338 
+Q 2531 2678 2651 2914 
+Q 2772 3150 2772 3378 
+Q 2772 3750 2511 3984 
+Q 2250 4219 1831 4219 
+Q 1534 4219 1204 4116 
+Q 875 4013 500 3803 
+L 500 4441 
+Q 881 4594 1212 4672 
+Q 1544 4750 1819 4750 
+Q 2544 4750 2975 4387 
+Q 3406 4025 3406 3419 
+Q 3406 3131 3298 2873 
+Q 3191 2616 2906 2266 
+Q 2828 2175 2409 1742 
+Q 1991 1309 1228 531 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-73"/>
+       <use xlink:href="#DejaVuSans-65" x="52.099609"/>
+       <use xlink:href="#DejaVuSans-6c" x="113.623047"/>
+       <use xlink:href="#DejaVuSans-65" x="141.40625"/>
+       <use xlink:href="#DejaVuSans-63" x="202.929688"/>
+       <use xlink:href="#DejaVuSans-74" x="257.910156"/>
+       <use xlink:href="#DejaVuSans-20" x="297.119141"/>
+       <use xlink:href="#DejaVuSans-49" x="328.90625"/>
+       <use xlink:href="#DejaVuSans-4e" x="358.398438"/>
+       <use xlink:href="#DejaVuSans-20" x="433.203125"/>
+       <use xlink:href="#DejaVuSans-78" x="464.990234"/>
+       <use xlink:href="#DejaVuSans-32" x="524.169922"/>
+       <use xlink:href="#DejaVuSans-30" x="587.792969"/>
+      </g>
+     </g>
+    </g>
+   </g>
+   <g id="matplotlib.axis_2">
+    <g id="ytick_1">
+     <g id="line2d_6">
+      <path d="M 55.26375 363.304622 
+L 848.41375 363.304622 
+" clip-path="url(#pdaba22e8e0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_7">
+      <defs>
+       <path id="m122a921f73" d="M 0 0 
+L -3.5 0 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m122a921f73" x="55.26375" y="363.304622" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_6">
+      <!-- 0 -->
+      <g transform="translate(41.90125 367.103841) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-30"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_2">
+     <g id="line2d_8">
+      <path d="M 55.26375 309.421002 
+L 848.41375 309.421002 
+" clip-path="url(#pdaba22e8e0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_9">
+      <g>
+       <use xlink:href="#m122a921f73" x="55.26375" y="309.421002" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_7">
+      <!-- 200 -->
+      <g transform="translate(29.17625 313.22022) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-32"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_3">
+     <g id="line2d_10">
+      <path d="M 55.26375 255.537381 
+L 848.41375 255.537381 
+" clip-path="url(#pdaba22e8e0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_11">
+      <g>
+       <use xlink:href="#m122a921f73" x="55.26375" y="255.537381" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_8">
+      <!-- 400 -->
+      <g transform="translate(29.17625 259.3366) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-34" d="M 2419 4116 
+L 825 1625 
+L 2419 1625 
+L 2419 4116 
+z
+M 2253 4666 
+L 3047 4666 
+L 3047 1625 
+L 3713 1625 
+L 3713 1100 
+L 3047 1100 
+L 3047 0 
+L 2419 0 
+L 2419 1100 
+L 313 1100 
+L 313 1709 
+L 2253 4666 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-34"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_4">
+     <g id="line2d_12">
+      <path d="M 55.26375 201.65376 
+L 848.41375 201.65376 
+" clip-path="url(#pdaba22e8e0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_13">
+      <g>
+       <use xlink:href="#m122a921f73" x="55.26375" y="201.65376" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_9">
+      <!-- 600 -->
+      <g transform="translate(29.17625 205.452979) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-36" d="M 2113 2584 
+Q 1688 2584 1439 2293 
+Q 1191 2003 1191 1497 
+Q 1191 994 1439 701 
+Q 1688 409 2113 409 
+Q 2538 409 2786 701 
+Q 3034 994 3034 1497 
+Q 3034 2003 2786 2293 
+Q 2538 2584 2113 2584 
+z
+M 3366 4563 
+L 3366 3988 
+Q 3128 4100 2886 4159 
+Q 2644 4219 2406 4219 
+Q 1781 4219 1451 3797 
+Q 1122 3375 1075 2522 
+Q 1259 2794 1537 2939 
+Q 1816 3084 2150 3084 
+Q 2853 3084 3261 2657 
+Q 3669 2231 3669 1497 
+Q 3669 778 3244 343 
+Q 2819 -91 2113 -91 
+Q 1303 -91 875 529 
+Q 447 1150 447 2328 
+Q 447 3434 972 4092 
+Q 1497 4750 2381 4750 
+Q 2619 4750 2861 4703 
+Q 3103 4656 3366 4563 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-36"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_5">
+     <g id="line2d_14">
+      <path d="M 55.26375 147.77014 
+L 848.41375 147.77014 
+" clip-path="url(#pdaba22e8e0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_15">
+      <g>
+       <use xlink:href="#m122a921f73" x="55.26375" y="147.77014" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_10">
+      <!-- 800 -->
+      <g transform="translate(29.17625 151.569359) scale(0.1 -0.1)">
+       <defs>
+        <path id="DejaVuSans-38" d="M 2034 2216 
+Q 1584 2216 1326 1975 
+Q 1069 1734 1069 1313 
+Q 1069 891 1326 650 
+Q 1584 409 2034 409 
+Q 2484 409 2743 651 
+Q 3003 894 3003 1313 
+Q 3003 1734 2745 1975 
+Q 2488 2216 2034 2216 
+z
+M 1403 2484 
+Q 997 2584 770 2862 
+Q 544 3141 544 3541 
+Q 544 4100 942 4425 
+Q 1341 4750 2034 4750 
+Q 2731 4750 3128 4425 
+Q 3525 4100 3525 3541 
+Q 3525 3141 3298 2862 
+Q 3072 2584 2669 2484 
+Q 3125 2378 3379 2068 
+Q 3634 1759 3634 1313 
+Q 3634 634 3220 271 
+Q 2806 -91 2034 -91 
+Q 1263 -91 848 271 
+Q 434 634 434 1313 
+Q 434 1759 690 2068 
+Q 947 2378 1403 2484 
+z
+M 1172 3481 
+Q 1172 3119 1398 2916 
+Q 1625 2713 2034 2713 
+Q 2441 2713 2670 2916 
+Q 2900 3119 2900 3481 
+Q 2900 3844 2670 4047 
+Q 2441 4250 2034 4250 
+Q 1625 4250 1398 4047 
+Q 1172 3844 1172 3481 
+z
+" transform="scale(0.015625)"/>
+       </defs>
+       <use xlink:href="#DejaVuSans-38"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_6">
+     <g id="line2d_16">
+      <path d="M 55.26375 93.886519 
+L 848.41375 93.886519 
+" clip-path="url(#pdaba22e8e0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_17">
+      <g>
+       <use xlink:href="#m122a921f73" x="55.26375" y="93.886519" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_11">
+      <!-- 1000 -->
+      <g transform="translate(22.81375 97.685738) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-30" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="190.869141"/>
+      </g>
+     </g>
+    </g>
+    <g id="ytick_7">
+     <g id="line2d_18">
+      <path d="M 55.26375 40.002899 
+L 848.41375 40.002899 
+" clip-path="url(#pdaba22e8e0)" style="fill: none; stroke: #b0b0b0; stroke-opacity: 0.3; stroke-width: 0.8; stroke-linecap: square"/>
+     </g>
+     <g id="line2d_19">
+      <g>
+       <use xlink:href="#m122a921f73" x="55.26375" y="40.002899" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_12">
+      <!-- 1200 -->
+      <g transform="translate(22.81375 43.802117) scale(0.1 -0.1)">
+       <use xlink:href="#DejaVuSans-31"/>
+       <use xlink:href="#DejaVuSans-32" x="63.623047"/>
+       <use xlink:href="#DejaVuSans-30" x="127.246094"/>
+       <use xlink:href="#DejaVuSans-30" x="190.869141"/>
+      </g>
+     </g>
+    </g>
+    <g id="text_13">
+     <!-- Time (ms) -->
+     <g transform="translate(16.318125 223.81028) rotate(-90) scale(0.12 -0.12)">
+      <defs>
+       <path id="DejaVuSans-54" d="M -19 4666 
+L 3928 4666 
+L 3928 4134 
+L 2272 4134 
+L 2272 0 
+L 1638 0 
+L 1638 4134 
+L -19 4134 
+L -19 4666 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6d" d="M 3328 2828 
+Q 3544 3216 3844 3400 
+Q 4144 3584 4550 3584 
+Q 5097 3584 5394 3201 
+Q 5691 2819 5691 2113 
+L 5691 0 
+L 5113 0 
+L 5113 2094 
+Q 5113 2597 4934 2840 
+Q 4756 3084 4391 3084 
+Q 3944 3084 3684 2787 
+Q 3425 2491 3425 1978 
+L 3425 0 
+L 2847 0 
+L 2847 2094 
+Q 2847 2600 2669 2842 
+Q 2491 3084 2119 3084 
+Q 1678 3084 1418 2786 
+Q 1159 2488 1159 1978 
+L 1159 0 
+L 581 0 
+L 581 3500 
+L 1159 3500 
+L 1159 2956 
+Q 1356 3278 1631 3431 
+Q 1906 3584 2284 3584 
+Q 2666 3584 2933 3390 
+Q 3200 3197 3328 2828 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-28" d="M 1984 4856 
+Q 1566 4138 1362 3434 
+Q 1159 2731 1159 2009 
+Q 1159 1288 1364 580 
+Q 1569 -128 1984 -844 
+L 1484 -844 
+Q 1016 -109 783 600 
+Q 550 1309 550 2009 
+Q 550 2706 781 3412 
+Q 1013 4119 1484 4856 
+L 1984 4856 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-29" d="M 513 4856 
+L 1013 4856 
+Q 1481 4119 1714 3412 
+Q 1947 2706 1947 2009 
+Q 1947 1309 1714 600 
+Q 1481 -109 1013 -844 
+L 513 -844 
+Q 928 -128 1133 580 
+Q 1338 1288 1338 2009 
+Q 1338 2731 1133 3434 
+Q 928 4138 513 4856 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-54"/>
+      <use xlink:href="#DejaVuSans-69" x="57.958984"/>
+      <use xlink:href="#DejaVuSans-6d" x="85.742188"/>
+      <use xlink:href="#DejaVuSans-65" x="183.154297"/>
+      <use xlink:href="#DejaVuSans-20" x="244.677734"/>
+      <use xlink:href="#DejaVuSans-28" x="276.464844"/>
+      <use xlink:href="#DejaVuSans-6d" x="315.478516"/>
+      <use xlink:href="#DejaVuSans-73" x="412.890625"/>
+      <use xlink:href="#DejaVuSans-29" x="464.990234"/>
+     </g>
+    </g>
+   </g>
+   <g id="patch_13">
+    <path d="M 55.26375 363.304622 
+L 55.26375 23.837812 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_14">
+    <path d="M 848.41375 363.304622 
+L 848.41375 23.837812 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_15">
+    <path d="M 55.26375 363.304622 
+L 848.41375 363.304622 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="patch_16">
+    <path d="M 55.26375 23.837812 
+L 848.41375 23.837812 
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+   <g id="text_14">
+    <!-- 24x -->
+    <g style="fill: #0a58ca" transform="translate(162.693803 344.833717) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-Bold-32" d="M 1844 884 
+L 3897 884 
+L 3897 0 
+L 506 0 
+L 506 884 
+L 2209 2388 
+Q 2438 2594 2547 2791 
+Q 2656 2988 2656 3200 
+Q 2656 3528 2436 3728 
+Q 2216 3928 1850 3928 
+Q 1569 3928 1234 3808 
+Q 900 3688 519 3450 
+L 519 4475 
+Q 925 4609 1322 4679 
+Q 1719 4750 2100 4750 
+Q 2938 4750 3402 4381 
+Q 3866 4013 3866 3353 
+Q 3866 2972 3669 2642 
+Q 3472 2313 2841 1759 
+L 1844 884 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-34" d="M 2356 3675 
+L 1038 1722 
+L 2356 1722 
+L 2356 3675 
+z
+M 2156 4666 
+L 3494 4666 
+L 3494 1722 
+L 4159 1722 
+L 4159 850 
+L 3494 850 
+L 3494 0 
+L 2356 0 
+L 2356 850 
+L 288 850 
+L 288 1881 
+L 2156 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-78" d="M 1422 1791 
+L 159 3500 
+L 1344 3500 
+L 2059 2463 
+L 2784 3500 
+L 3969 3500 
+L 2706 1797 
+L 4031 0 
+L 2847 0 
+L 2059 1106 
+L 1281 0 
+L 97 0 
+L 1422 1791 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-34" x="69.580078"/>
+     <use xlink:href="#DejaVuSans-Bold-78" x="139.160156"/>
+    </g>
+   </g>
+   <g id="text_15">
+    <!-- 29x -->
+    <g style="fill: #0a58ca" transform="translate(316.107729 347.25848) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-Bold-39" d="M 641 103 
+L 641 966 
+Q 928 831 1190 764 
+Q 1453 697 1709 697 
+Q 2247 697 2547 995 
+Q 2847 1294 2900 1881 
+Q 2688 1725 2447 1647 
+Q 2206 1569 1925 1569 
+Q 1209 1569 770 1986 
+Q 331 2403 331 3084 
+Q 331 3838 820 4291 
+Q 1309 4744 2131 4744 
+Q 3044 4744 3544 4128 
+Q 4044 3513 4044 2388 
+Q 4044 1231 3459 570 
+Q 2875 -91 1856 -91 
+Q 1528 -91 1228 -42 
+Q 928 6 641 103 
+z
+M 2125 2350 
+Q 2441 2350 2600 2554 
+Q 2759 2759 2759 3169 
+Q 2759 3575 2600 3781 
+Q 2441 3988 2125 3988 
+Q 1809 3988 1650 3781 
+Q 1491 3575 1491 3169 
+Q 1491 2759 1650 2554 
+Q 1809 2350 2125 2350 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-39" x="69.580078"/>
+     <use xlink:href="#DejaVuSans-Bold-78" x="139.160156"/>
+    </g>
+   </g>
+   <g id="text_16">
+    <!-- 3x -->
+    <g style="fill: #0a58ca" transform="translate(472.652672 352.161889) scale(0.09 -0.09)">
+     <defs>
+      <path id="DejaVuSans-Bold-33" d="M 2981 2516 
+Q 3453 2394 3698 2092 
+Q 3944 1791 3944 1325 
+Q 3944 631 3412 270 
+Q 2881 -91 1863 -91 
+Q 1503 -91 1142 -33 
+Q 781 25 428 141 
+L 428 1069 
+Q 766 900 1098 814 
+Q 1431 728 1753 728 
+Q 2231 728 2486 893 
+Q 2741 1059 2741 1369 
+Q 2741 1688 2480 1852 
+Q 2219 2016 1709 2016 
+L 1228 2016 
+L 1228 2791 
+L 1734 2791 
+Q 2188 2791 2409 2933 
+Q 2631 3075 2631 3366 
+Q 2631 3634 2415 3781 
+Q 2200 3928 1806 3928 
+Q 1516 3928 1219 3862 
+Q 922 3797 628 3669 
+L 628 4550 
+Q 984 4650 1334 4700 
+Q 1684 4750 2022 4750 
+Q 2931 4750 3382 4451 
+Q 3834 4153 3834 3553 
+Q 3834 3144 3618 2883 
+Q 3403 2622 2981 2516 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-33"/>
+     <use xlink:href="#DejaVuSans-Bold-78" x="69.580078"/>
+    </g>
+   </g>
+   <g id="text_17">
+    <!-- 2x -->
+    <g style="fill: #0a58ca" transform="translate(626.066598 345.399495) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-78" x="69.580078"/>
+    </g>
+   </g>
+   <g id="text_18">
+    <!-- 2x -->
+    <g style="fill: #0a58ca" transform="translate(779.480525 346.423284) scale(0.09 -0.09)">
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-78" x="69.580078"/>
+    </g>
+   </g>
+   <g id="text_19">
+    <!-- Benchmark: 5ms latency per direction (10ms RTT) -->
+    <g transform="translate(253.959688 17.837812) scale(0.14 -0.14)">
+     <defs>
+      <path id="DejaVuSans-Bold-42" d="M 2456 2859 
+Q 2741 2859 2887 2984 
+Q 3034 3109 3034 3353 
+Q 3034 3594 2887 3720 
+Q 2741 3847 2456 3847 
+L 1791 3847 
+L 1791 2859 
+L 2456 2859 
+z
+M 2497 819 
+Q 2859 819 3042 972 
+Q 3225 1125 3225 1434 
+Q 3225 1738 3044 1889 
+Q 2863 2041 2497 2041 
+L 1791 2041 
+L 1791 819 
+L 2497 819 
+z
+M 3616 2497 
+Q 4003 2384 4215 2081 
+Q 4428 1778 4428 1338 
+Q 4428 663 3972 331 
+Q 3516 0 2584 0 
+L 588 0 
+L 588 4666 
+L 2394 4666 
+Q 3366 4666 3802 4372 
+Q 4238 4078 4238 3431 
+Q 4238 3091 4078 2852 
+Q 3919 2613 3616 2497 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-65" d="M 4031 1759 
+L 4031 1441 
+L 1416 1441 
+Q 1456 1047 1700 850 
+Q 1944 653 2381 653 
+Q 2734 653 3104 758 
+Q 3475 863 3866 1075 
+L 3866 213 
+Q 3469 63 3072 -14 
+Q 2675 -91 2278 -91 
+Q 1328 -91 801 392 
+Q 275 875 275 1747 
+Q 275 2603 792 3093 
+Q 1309 3584 2216 3584 
+Q 3041 3584 3536 3087 
+Q 4031 2591 4031 1759 
+z
+M 2881 2131 
+Q 2881 2450 2695 2645 
+Q 2509 2841 2209 2841 
+Q 1884 2841 1681 2658 
+Q 1478 2475 1428 2131 
+L 2881 2131 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6e" d="M 4056 2131 
+L 4056 0 
+L 2931 0 
+L 2931 347 
+L 2931 1631 
+Q 2931 2084 2911 2256 
+Q 2891 2428 2841 2509 
+Q 2775 2619 2662 2680 
+Q 2550 2741 2406 2741 
+Q 2056 2741 1856 2470 
+Q 1656 2200 1656 1722 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1909 3294 2193 3439 
+Q 2478 3584 2822 3584 
+Q 3428 3584 3742 3212 
+Q 4056 2841 4056 2131 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-63" d="M 3366 3391 
+L 3366 2478 
+Q 3138 2634 2908 2709 
+Q 2678 2784 2431 2784 
+Q 1963 2784 1702 2511 
+Q 1441 2238 1441 1747 
+Q 1441 1256 1702 982 
+Q 1963 709 2431 709 
+Q 2694 709 2930 787 
+Q 3166 866 3366 1019 
+L 3366 103 
+Q 3103 6 2833 -42 
+Q 2563 -91 2291 -91 
+Q 1344 -91 809 395 
+Q 275 881 275 1747 
+Q 275 2613 809 3098 
+Q 1344 3584 2291 3584 
+Q 2566 3584 2833 3536 
+Q 3100 3488 3366 3391 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-68" d="M 4056 2131 
+L 4056 0 
+L 2931 0 
+L 2931 347 
+L 2931 1625 
+Q 2931 2084 2911 2256 
+Q 2891 2428 2841 2509 
+Q 2775 2619 2662 2680 
+Q 2550 2741 2406 2741 
+Q 2056 2741 1856 2470 
+Q 1656 2200 1656 1722 
+L 1656 0 
+L 538 0 
+L 538 4863 
+L 1656 4863 
+L 1656 2988 
+Q 1909 3294 2193 3439 
+Q 2478 3584 2822 3584 
+Q 3428 3584 3742 3212 
+Q 4056 2841 4056 2131 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6d" d="M 3781 2919 
+Q 3994 3244 4286 3414 
+Q 4578 3584 4928 3584 
+Q 5531 3584 5847 3212 
+Q 6163 2841 6163 2131 
+L 6163 0 
+L 5038 0 
+L 5038 1825 
+Q 5041 1866 5042 1909 
+Q 5044 1953 5044 2034 
+Q 5044 2406 4934 2573 
+Q 4825 2741 4581 2741 
+Q 4263 2741 4089 2478 
+Q 3916 2216 3909 1719 
+L 3909 0 
+L 2784 0 
+L 2784 1825 
+Q 2784 2406 2684 2573 
+Q 2584 2741 2328 2741 
+Q 2006 2741 1831 2477 
+Q 1656 2213 1656 1722 
+L 1656 0 
+L 531 0 
+L 531 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1863 3284 2130 3434 
+Q 2397 3584 2719 3584 
+Q 3081 3584 3359 3409 
+Q 3638 3234 3781 2919 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-61" d="M 2106 1575 
+Q 1756 1575 1579 1456 
+Q 1403 1338 1403 1106 
+Q 1403 894 1545 773 
+Q 1688 653 1941 653 
+Q 2256 653 2472 879 
+Q 2688 1106 2688 1447 
+L 2688 1575 
+L 2106 1575 
+z
+M 3816 1997 
+L 3816 0 
+L 2688 0 
+L 2688 519 
+Q 2463 200 2181 54 
+Q 1900 -91 1497 -91 
+Q 953 -91 614 226 
+Q 275 544 275 1050 
+Q 275 1666 698 1953 
+Q 1122 2241 2028 2241 
+L 2688 2241 
+L 2688 2328 
+Q 2688 2594 2478 2717 
+Q 2269 2841 1825 2841 
+Q 1466 2841 1156 2769 
+Q 847 2697 581 2553 
+L 581 3406 
+Q 941 3494 1303 3539 
+Q 1666 3584 2028 3584 
+Q 2975 3584 3395 3211 
+Q 3816 2838 3816 1997 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-72" d="M 3138 2547 
+Q 2991 2616 2845 2648 
+Q 2700 2681 2553 2681 
+Q 2122 2681 1889 2404 
+Q 1656 2128 1656 1613 
+L 1656 0 
+L 538 0 
+L 538 3500 
+L 1656 3500 
+L 1656 2925 
+Q 1872 3269 2151 3426 
+Q 2431 3584 2822 3584 
+Q 2878 3584 2943 3579 
+Q 3009 3575 3134 3559 
+L 3138 2547 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6b" d="M 538 4863 
+L 1656 4863 
+L 1656 2216 
+L 2944 3500 
+L 4244 3500 
+L 2534 1894 
+L 4378 0 
+L 3022 0 
+L 1656 1459 
+L 1656 0 
+L 538 0 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-3a" d="M 716 3500 
+L 1844 3500 
+L 1844 2291 
+L 716 2291 
+L 716 3500 
+z
+M 716 1209 
+L 1844 1209 
+L 1844 0 
+L 716 0 
+L 716 1209 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-35" d="M 678 4666 
+L 3669 4666 
+L 3669 3781 
+L 1638 3781 
+L 1638 3059 
+Q 1775 3097 1914 3117 
+Q 2053 3138 2203 3138 
+Q 3056 3138 3531 2711 
+Q 4006 2284 4006 1522 
+Q 4006 766 3489 337 
+Q 2972 -91 2053 -91 
+Q 1656 -91 1267 -14 
+Q 878 63 494 219 
+L 494 1166 
+Q 875 947 1217 837 
+Q 1559 728 1863 728 
+Q 2300 728 2551 942 
+Q 2803 1156 2803 1522 
+Q 2803 1891 2551 2103 
+Q 2300 2316 1863 2316 
+Q 1603 2316 1309 2248 
+Q 1016 2181 678 2041 
+L 678 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-73" d="M 3272 3391 
+L 3272 2541 
+Q 2913 2691 2578 2766 
+Q 2244 2841 1947 2841 
+Q 1628 2841 1473 2761 
+Q 1319 2681 1319 2516 
+Q 1319 2381 1436 2309 
+Q 1553 2238 1856 2203 
+L 2053 2175 
+Q 2913 2066 3209 1816 
+Q 3506 1566 3506 1031 
+Q 3506 472 3093 190 
+Q 2681 -91 1863 -91 
+Q 1516 -91 1145 -36 
+Q 775 19 384 128 
+L 384 978 
+Q 719 816 1070 734 
+Q 1422 653 1784 653 
+Q 2113 653 2278 743 
+Q 2444 834 2444 1013 
+Q 2444 1163 2330 1236 
+Q 2216 1309 1875 1350 
+L 1678 1375 
+Q 931 1469 631 1722 
+Q 331 1975 331 2491 
+Q 331 3047 712 3315 
+Q 1094 3584 1881 3584 
+Q 2191 3584 2531 3537 
+Q 2872 3491 3272 3391 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6c" d="M 538 4863 
+L 1656 4863 
+L 1656 0 
+L 538 0 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-74" d="M 1759 4494 
+L 1759 3500 
+L 2913 3500 
+L 2913 2700 
+L 1759 2700 
+L 1759 1216 
+Q 1759 972 1856 886 
+Q 1953 800 2241 800 
+L 2816 800 
+L 2816 0 
+L 1856 0 
+Q 1194 0 917 276 
+Q 641 553 641 1216 
+L 641 2700 
+L 84 2700 
+L 84 3500 
+L 641 3500 
+L 641 4494 
+L 1759 4494 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-79" d="M 78 3500 
+L 1197 3500 
+L 2138 1125 
+L 2938 3500 
+L 4056 3500 
+L 2584 -331 
+Q 2363 -916 2067 -1148 
+Q 1772 -1381 1288 -1381 
+L 641 -1381 
+L 641 -647 
+L 991 -647 
+Q 1275 -647 1404 -556 
+Q 1534 -466 1606 -231 
+L 1638 -134 
+L 78 3500 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-70" d="M 1656 506 
+L 1656 -1331 
+L 538 -1331 
+L 538 3500 
+L 1656 3500 
+L 1656 2988 
+Q 1888 3294 2169 3439 
+Q 2450 3584 2816 3584 
+Q 3463 3584 3878 3070 
+Q 4294 2556 4294 1747 
+Q 4294 938 3878 423 
+Q 3463 -91 2816 -91 
+Q 2450 -91 2169 54 
+Q 1888 200 1656 506 
+z
+M 2400 2772 
+Q 2041 2772 1848 2508 
+Q 1656 2244 1656 1747 
+Q 1656 1250 1848 986 
+Q 2041 722 2400 722 
+Q 2759 722 2948 984 
+Q 3138 1247 3138 1747 
+Q 3138 2247 2948 2509 
+Q 2759 2772 2400 2772 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-64" d="M 2919 2988 
+L 2919 4863 
+L 4044 4863 
+L 4044 0 
+L 2919 0 
+L 2919 506 
+Q 2688 197 2409 53 
+Q 2131 -91 1766 -91 
+Q 1119 -91 703 423 
+Q 288 938 288 1747 
+Q 288 2556 703 3070 
+Q 1119 3584 1766 3584 
+Q 2128 3584 2408 3439 
+Q 2688 3294 2919 2988 
+z
+M 2181 722 
+Q 2541 722 2730 984 
+Q 2919 1247 2919 1747 
+Q 2919 2247 2730 2509 
+Q 2541 2772 2181 2772 
+Q 1825 2772 1636 2509 
+Q 1447 2247 1447 1747 
+Q 1447 1247 1636 984 
+Q 1825 722 2181 722 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-69" d="M 538 3500 
+L 1656 3500 
+L 1656 0 
+L 538 0 
+L 538 3500 
+z
+M 538 4863 
+L 1656 4863 
+L 1656 3950 
+L 538 3950 
+L 538 4863 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6f" d="M 2203 2784 
+Q 1831 2784 1636 2517 
+Q 1441 2250 1441 1747 
+Q 1441 1244 1636 976 
+Q 1831 709 2203 709 
+Q 2569 709 2762 976 
+Q 2956 1244 2956 1747 
+Q 2956 2250 2762 2517 
+Q 2569 2784 2203 2784 
+z
+M 2203 3584 
+Q 3106 3584 3614 3096 
+Q 4122 2609 4122 1747 
+Q 4122 884 3614 396 
+Q 3106 -91 2203 -91 
+Q 1297 -91 786 396 
+Q 275 884 275 1747 
+Q 275 2609 786 3096 
+Q 1297 3584 2203 3584 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-28" d="M 2413 -844 
+L 1484 -844 
+Q 1006 -72 778 623 
+Q 550 1319 550 2003 
+Q 550 2688 779 3389 
+Q 1009 4091 1484 4856 
+L 2413 4856 
+Q 2013 4116 1813 3408 
+Q 1613 2700 1613 2009 
+Q 1613 1319 1811 609 
+Q 2009 -100 2413 -844 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-31" d="M 750 831 
+L 1813 831 
+L 1813 3847 
+L 722 3622 
+L 722 4441 
+L 1806 4666 
+L 2950 4666 
+L 2950 831 
+L 4013 831 
+L 4013 0 
+L 750 0 
+L 750 831 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-30" d="M 2944 2338 
+Q 2944 3213 2780 3570 
+Q 2616 3928 2228 3928 
+Q 1841 3928 1675 3570 
+Q 1509 3213 1509 2338 
+Q 1509 1453 1675 1090 
+Q 1841 728 2228 728 
+Q 2613 728 2778 1090 
+Q 2944 1453 2944 2338 
+z
+M 4147 2328 
+Q 4147 1169 3647 539 
+Q 3147 -91 2228 -91 
+Q 1306 -91 806 539 
+Q 306 1169 306 2328 
+Q 306 3491 806 4120 
+Q 1306 4750 2228 4750 
+Q 3147 4750 3647 4120 
+Q 4147 3491 4147 2328 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-52" d="M 2297 2597 
+Q 2675 2597 2839 2737 
+Q 3003 2878 3003 3200 
+Q 3003 3519 2839 3656 
+Q 2675 3794 2297 3794 
+L 1791 3794 
+L 1791 2597 
+L 2297 2597 
+z
+M 1791 1766 
+L 1791 0 
+L 588 0 
+L 588 4666 
+L 2425 4666 
+Q 3347 4666 3776 4356 
+Q 4206 4047 4206 3378 
+Q 4206 2916 3982 2619 
+Q 3759 2322 3309 2181 
+Q 3556 2125 3751 1926 
+Q 3947 1728 4147 1325 
+L 4800 0 
+L 3519 0 
+L 2950 1159 
+Q 2778 1509 2601 1637 
+Q 2425 1766 2131 1766 
+L 1791 1766 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-54" d="M 31 4666 
+L 4331 4666 
+L 4331 3756 
+L 2784 3756 
+L 2784 0 
+L 1581 0 
+L 1581 3756 
+L 31 3756 
+L 31 4666 
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-29" d="M 513 -844 
+Q 913 -100 1113 609 
+Q 1313 1319 1313 2009 
+Q 1313 2700 1113 3408 
+Q 913 4116 513 4856 
+L 1441 4856 
+Q 1916 4091 2145 3389 
+Q 2375 2688 2375 2003 
+Q 2375 1319 2147 623 
+Q 1919 -72 1441 -844 
+L 513 -844 
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-42"/>
+     <use xlink:href="#DejaVuSans-Bold-65" x="76.220703"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" x="144.042969"/>
+     <use xlink:href="#DejaVuSans-Bold-63" x="215.234375"/>
+     <use xlink:href="#DejaVuSans-Bold-68" x="274.511719"/>
+     <use xlink:href="#DejaVuSans-Bold-6d" x="345.703125"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="449.902344"/>
+     <use xlink:href="#DejaVuSans-Bold-72" x="517.382812"/>
+     <use xlink:href="#DejaVuSans-Bold-6b" x="566.699219"/>
+     <use xlink:href="#DejaVuSans-Bold-3a" x="633.203125"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="673.193359"/>
+     <use xlink:href="#DejaVuSans-Bold-35" x="708.007812"/>
+     <use xlink:href="#DejaVuSans-Bold-6d" x="777.587891"/>
+     <use xlink:href="#DejaVuSans-Bold-73" x="881.787109"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="941.308594"/>
+     <use xlink:href="#DejaVuSans-Bold-6c" x="976.123047"/>
+     <use xlink:href="#DejaVuSans-Bold-61" x="1010.400391"/>
+     <use xlink:href="#DejaVuSans-Bold-74" x="1077.880859"/>
+     <use xlink:href="#DejaVuSans-Bold-65" x="1125.683594"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" x="1193.505859"/>
+     <use xlink:href="#DejaVuSans-Bold-63" x="1264.697266"/>
+     <use xlink:href="#DejaVuSans-Bold-79" x="1323.974609"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="1389.160156"/>
+     <use xlink:href="#DejaVuSans-Bold-70" x="1423.974609"/>
+     <use xlink:href="#DejaVuSans-Bold-65" x="1495.556641"/>
+     <use xlink:href="#DejaVuSans-Bold-72" x="1563.378906"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="1612.695312"/>
+     <use xlink:href="#DejaVuSans-Bold-64" x="1647.509766"/>
+     <use xlink:href="#DejaVuSans-Bold-69" x="1719.091797"/>
+     <use xlink:href="#DejaVuSans-Bold-72" x="1753.369141"/>
+     <use xlink:href="#DejaVuSans-Bold-65" x="1802.685547"/>
+     <use xlink:href="#DejaVuSans-Bold-63" x="1870.507812"/>
+     <use xlink:href="#DejaVuSans-Bold-74" x="1929.785156"/>
+     <use xlink:href="#DejaVuSans-Bold-69" x="1977.587891"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" x="2011.865234"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" x="2080.566406"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="2151.757812"/>
+     <use xlink:href="#DejaVuSans-Bold-28" x="2186.572266"/>
+     <use xlink:href="#DejaVuSans-Bold-31" x="2232.275391"/>
+     <use xlink:href="#DejaVuSans-Bold-30" x="2301.855469"/>
+     <use xlink:href="#DejaVuSans-Bold-6d" x="2371.435547"/>
+     <use xlink:href="#DejaVuSans-Bold-73" x="2475.634766"/>
+     <use xlink:href="#DejaVuSans-Bold-20" x="2535.15625"/>
+     <use xlink:href="#DejaVuSans-Bold-52" x="2569.970703"/>
+     <use xlink:href="#DejaVuSans-Bold-54" x="2642.472656"/>
+     <use xlink:href="#DejaVuSans-Bold-54" x="2712.935547"/>
+     <use xlink:href="#DejaVuSans-Bold-29" x="2781.148438"/>
+    </g>
+   </g>
+   <g id="legend_1">
+    <g id="patch_17">
+     <path d="M 670.915 64.929687 
+L 840.71375 64.929687 
+Q 842.91375 64.929687 842.91375 62.729687 
+L 842.91375 31.537812 
+Q 842.91375 29.337812 840.71375 29.337812 
+L 670.915 29.337812 
+Q 668.715 29.337812 668.715 31.537812 
+L 668.715 62.729687 
+Q 668.715 64.929687 670.915 64.929687 
+z
+" style="fill: #ffffff; opacity: 0.8; stroke: #cccccc; stroke-linejoin: miter"/>
+    </g>
+    <g id="patch_18">
+     <path d="M 673.115 42.096094 
+L 695.115 42.096094 
+L 695.115 34.396094 
+L 673.115 34.396094 
+z
+" style="fill: #6c757d"/>
+    </g>
+    <g id="text_20">
+     <!-- persistent-postgresql -->
+     <g transform="translate(703.915 42.096094) scale(0.11 -0.11)">
+      <defs>
+       <path id="DejaVuSans-70" d="M 1159 525 
+L 1159 -1331 
+L 581 -1331 
+L 581 3500 
+L 1159 3500 
+L 1159 2969 
+Q 1341 3281 1617 3432 
+Q 1894 3584 2278 3584 
+Q 2916 3584 3314 3078 
+Q 3713 2572 3713 1747 
+Q 3713 922 3314 415 
+Q 2916 -91 2278 -91 
+Q 1894 -91 1617 61 
+Q 1341 213 1159 525 
+z
+M 3116 1747 
+Q 3116 2381 2855 2742 
+Q 2594 3103 2138 3103 
+Q 1681 3103 1420 2742 
+Q 1159 2381 1159 1747 
+Q 1159 1113 1420 752 
+Q 1681 391 2138 391 
+Q 2594 391 2855 752 
+Q 3116 1113 3116 1747 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-2d" d="M 313 2009 
+L 1997 2009 
+L 1997 1497 
+L 313 1497 
+L 313 2009 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-6f" d="M 1959 3097 
+Q 1497 3097 1228 2736 
+Q 959 2375 959 1747 
+Q 959 1119 1226 758 
+Q 1494 397 1959 397 
+Q 2419 397 2687 759 
+Q 2956 1122 2956 1747 
+Q 2956 2369 2687 2733 
+Q 2419 3097 1959 3097 
+z
+M 1959 3584 
+Q 2709 3584 3137 3096 
+Q 3566 2609 3566 1747 
+Q 3566 888 3137 398 
+Q 2709 -91 1959 -91 
+Q 1206 -91 779 398 
+Q 353 888 353 1747 
+Q 353 2609 779 3096 
+Q 1206 3584 1959 3584 
+z
+" transform="scale(0.015625)"/>
+       <path id="DejaVuSans-71" d="M 947 1747 
+Q 947 1113 1208 752 
+Q 1469 391 1925 391 
+Q 2381 391 2643 752 
+Q 2906 1113 2906 1747 
+Q 2906 2381 2643 2742 
+Q 2381 3103 1925 3103 
+Q 1469 3103 1208 2742 
+Q 947 2381 947 1747 
+z
+M 2906 525 
+Q 2725 213 2448 61 
+Q 2172 -91 1784 -91 
+Q 1150 -91 751 415 
+Q 353 922 353 1747 
+Q 353 2572 751 3078 
+Q 1150 3584 1784 3584 
+Q 2172 3584 2448 3432 
+Q 2725 3281 2906 2969 
+L 2906 3500 
+L 3481 3500 
+L 3481 -1331 
+L 2906 -1331 
+L 2906 525 
+z
+" transform="scale(0.015625)"/>
+      </defs>
+      <use xlink:href="#DejaVuSans-70"/>
+      <use xlink:href="#DejaVuSans-65" x="63.476562"/>
+      <use xlink:href="#DejaVuSans-72" x="125"/>
+      <use xlink:href="#DejaVuSans-73" x="166.113281"/>
+      <use xlink:href="#DejaVuSans-69" x="218.212891"/>
+      <use xlink:href="#DejaVuSans-73" x="245.996094"/>
+      <use xlink:href="#DejaVuSans-74" x="298.095703"/>
+      <use xlink:href="#DejaVuSans-65" x="337.304688"/>
+      <use xlink:href="#DejaVuSans-6e" x="398.828125"/>
+      <use xlink:href="#DejaVuSans-74" x="462.207031"/>
+      <use xlink:href="#DejaVuSans-2d" x="501.416016"/>
+      <use xlink:href="#DejaVuSans-70" x="537.5"/>
+      <use xlink:href="#DejaVuSans-6f" x="600.976562"/>
+      <use xlink:href="#DejaVuSans-73" x="662.158203"/>
+      <use xlink:href="#DejaVuSans-74" x="714.257812"/>
+      <use xlink:href="#DejaVuSans-67" x="753.466797"/>
+      <use xlink:href="#DejaVuSans-72" x="816.943359"/>
+      <use xlink:href="#DejaVuSans-65" x="855.806641"/>
+      <use xlink:href="#DejaVuSans-73" x="917.330078"/>
+      <use xlink:href="#DejaVuSans-71" x="969.429688"/>
+      <use xlink:href="#DejaVuSans-6c" x="1032.90625"/>
+     </g>
+    </g>
+    <g id="patch_19">
+     <path d="M 673.115 58.242031 
+L 695.115 58.242031 
+L 695.115 50.542031 
+L 673.115 50.542031 
+z
+" style="fill: #0d6efd"/>
+    </g>
+    <g id="text_21">
+     <!-- persistent-postgresql-ng -->
+     <g transform="translate(703.915 58.242031) scale(0.11 -0.11)">
+      <use xlink:href="#DejaVuSans-70"/>
+      <use xlink:href="#DejaVuSans-65" x="63.476562"/>
+      <use xlink:href="#DejaVuSans-72" x="125"/>
+      <use xlink:href="#DejaVuSans-73" x="166.113281"/>
+      <use xlink:href="#DejaVuSans-69" x="218.212891"/>
+      <use xlink:href="#DejaVuSans-73" x="245.996094"/>
+      <use xlink:href="#DejaVuSans-74" x="298.095703"/>
+      <use xlink:href="#DejaVuSans-65" x="337.304688"/>
+      <use xlink:href="#DejaVuSans-6e" x="398.828125"/>
+      <use xlink:href="#DejaVuSans-74" x="462.207031"/>
+      <use xlink:href="#DejaVuSans-2d" x="501.416016"/>
+      <use xlink:href="#DejaVuSans-70" x="537.5"/>
+      <use xlink:href="#DejaVuSans-6f" x="600.976562"/>
+      <use xlink:href="#DejaVuSans-73" x="662.158203"/>
+      <use xlink:href="#DejaVuSans-74" x="714.257812"/>
+      <use xlink:href="#DejaVuSans-67" x="753.466797"/>
+      <use xlink:href="#DejaVuSans-72" x="816.943359"/>
+      <use xlink:href="#DejaVuSans-65" x="855.806641"/>
+      <use xlink:href="#DejaVuSans-73" x="917.330078"/>
+      <use xlink:href="#DejaVuSans-71" x="969.429688"/>
+      <use xlink:href="#DejaVuSans-6c" x="1032.90625"/>
+      <use xlink:href="#DejaVuSans-2d" x="1060.689453"/>
+      <use xlink:href="#DejaVuSans-6e" x="1096.773438"/>
+      <use xlink:href="#DejaVuSans-67" x="1160.152344"/>
+     </g>
+    </g>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pdaba22e8e0">
+   <rect x="55.26375" y="23.837812" width="793.15" height="339.46681"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/persistent-postgresql-ng/bench/gen-charts.py
+++ b/persistent-postgresql-ng/bench/gen-charts.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Generate benchmark comparison SVGs for the README."""
+
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import numpy as np
+
+# Color scheme
+COLOR_OLD = '#6c757d'   # gray for persistent-postgresql
+COLOR_NEW = '#0d6efd'   # blue for persistent-postgresql-ng
+
+def make_chart(title, benchmarks, old_times, new_times, filename, unit='ms'):
+    fig, ax = plt.subplots(figsize=(12, 6))
+
+    x = np.arange(len(benchmarks))
+    width = 0.35
+
+    bars_old = ax.bar(x - width/2, old_times, width, label='persistent-postgresql', color=COLOR_OLD)
+    bars_new = ax.bar(x + width/2, new_times, width, label='persistent-postgresql-ng', color=COLOR_NEW)
+
+    ax.set_ylabel(f'Time ({unit})', fontsize=12)
+    ax.set_title(title, fontsize=14, fontweight='bold')
+    ax.set_xticks(x)
+    ax.set_xticklabels(benchmarks, rotation=25, ha='right', fontsize=10)
+    ax.legend(fontsize=11)
+    ax.grid(axis='y', alpha=0.3)
+
+    # Add speedup labels on the new bars
+    for i, (old, new) in enumerate(zip(old_times, new_times)):
+        if old > 0 and new > 0:
+            speedup = old / new
+            if speedup >= 1.3:
+                ax.annotate(f'{speedup:.0f}x',
+                    xy=(x[i] + width/2, new),
+                    xytext=(0, 5), textcoords='offset points',
+                    ha='center', fontsize=9, fontweight='bold', color='#0a58ca')
+
+    fig.tight_layout()
+    fig.savefig(filename, format='svg', bbox_inches='tight')
+    plt.close(fig)
+    print(f'Wrote {filename}')
+
+
+# --- 0ms latency ---
+benchmarks_0ms = [
+    'get x100',
+    'insert x100',
+    'upsert x100',
+    'delete x100',
+    'update x100',
+    'insertMany x1000',
+    'selectList x100',
+    'mixed DML x100',
+]
+old_0ms = [4.7, 12.8, 12.7, 12.9, 12.5, 14.1, 11.2, 29.9]
+new_0ms = [1.7, 10.8,  8.9,  9.6,  9.4,  5.3,  8.6, 14.6]
+
+make_chart(
+    'Benchmark: 0ms latency (localhost)',
+    benchmarks_0ms, old_0ms, new_0ms,
+    'persistent-postgresql-ng/bench/bench-0ms.svg'
+)
+
+# --- 1ms latency ---
+benchmarks_1ms = [
+    'get x100',
+    'insert x100',
+    'upsert x100',
+    'delete x100',
+    'update x100',
+    'replace x100',
+    'insertMany x1000',
+    'selectList x100',
+    'deleteWhere x100',
+]
+old_1ms = [310, 314, 321, 592, 555, 602, 31, 25.8, 750]
+new_1ms = [ 11,  13,  13,  25,  25,  27, 8.6, 16.6, 119]
+
+make_chart(
+    'Benchmark: 1ms latency per direction (2ms RTT)',
+    benchmarks_1ms, old_1ms, new_1ms,
+    'persistent-postgresql-ng/bench/bench-1ms.svg'
+)
+
+# --- 5ms latency ---
+benchmarks_5ms = [
+    'get x100',
+    'insert x100',
+    'insertMany x1000',
+    'selectList x100',
+    'select IN x20',
+]
+old_5ms = [1190, 1200, 72.6, 74.0, 70.3]
+new_5ms = [  50,   41, 22.8, 47.9, 44.1]
+
+make_chart(
+    'Benchmark: 5ms latency per direction (10ms RTT)',
+    benchmarks_5ms, old_5ms, new_5ms,
+    'persistent-postgresql-ng/bench/bench-5ms.svg'
+)


### PR DESCRIPTION
## Summary

- Add RFC describing the direct decode/encode design that bypasses `PersistValue` entirely
- Covers the `SqlBackend` bridge via `DirectEntity` + `Typeable`/`eqTypeRep`
- Covers compound type codecs (`PgDecode`/`PgEncode`) with reader-style DSL
- Covers Hedis-style automatic pipelining via lazy reply stream
- Adds ARCHITECTURE.md and README.md with benchmark results and SVG charts for persistent-postgresql-ng

## Stack

1/3 in stack.
2/3: https://github.com/iand675/persistent/pull/1
3/3: https://github.com/iand675/persistent/pull/2

## Test plan

- [ ] Review RFC design for correctness and completeness
