### PR TITLE
ci: fix flaky MongoDB "Connection refused" failures

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -68,10 +68,6 @@ jobs:
           cabal-version: ${{ matrix.cabal }}
       - name: Check MySQL connection
         run: mysql -utest -ptest -h127.0.0.1 --port=33306 test -e "SELECT 1;"
-      - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1.8.0
-        with:
-          mongodb-version: '5.0'
       - name: Start Redis
         uses: shogo82148/actions-setup-redis@v1
       - run: sudo apt-get update && sudo apt-get install -y libpcre3-dev
@@ -87,6 +83,30 @@ jobs:
             ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
             ${{ runner.os }}-${{ matrix.ghc }}-
       - run: cabal v2-build all --disable-optimization $CONFIG
+      # Start MongoDB *after* the heavy build, immediately before the tests that
+      # need it. Unlike postgres/mysql (declared as health-gated `services`),
+      # MongoDB is started by an action step with no readiness gate, and the
+      # test harness connects once with no retry. Starting it before the ~10m
+      # build left a long window where the container could be resource-starved
+      # and become unreachable, producing flaky "Connection refused" failures
+      # in the persistent-mongoDB suite.
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@1.12.0
+        with:
+          mongodb-version: '5.0'
+      - name: Wait for MongoDB to accept connections
+        run: |
+          for i in $(seq 1 30); do
+            if (exec 3<>/dev/tcp/127.0.0.1/27017) 2>/dev/null; then
+              exec 3>&- 3<&-
+              echo "MongoDB is accepting connections on 127.0.0.1:27017"
+              exit 0
+            fi
+            echo "Waiting for MongoDB... ($i/30)"
+            sleep 2
+          done
+          echo "MongoDB did not become reachable in time" >&2
+          exit 1
       - run: cabal v2-test all --disable-optimization $CONFIG --test-options "--fail-on-focus"
       - run: cabal v2-bench all --disable-optimization $CONFIG
       - run: cabal v2-sdist all


### PR DESCRIPTION
My other recent PR (https://github.com/yesodweb/persistent/pull/1609) was failing CI, but it looked unrelated to my changes. Digging into it more, it looked like the mongoDB test suite was failing, which was odd since I wasn't touching anything that should impact the mongo implementation. 

I poked around some with Claude (summary left below) and it noticed that the workflow for mongo was implemented as a singular action step rather than a service. 

This PR attempts to fix the flakiness in two ways: 
1) Move the startup to right before the test suite run, so it isn't sitting idle and unused while the build happens. 
2) Add a healthcheck. 
3) Bump the underlying action version, in case there are fixes upstream that help here. 

I'll run it a few times before marking the PR ready for review, but there are no code changes, just this fix to the CI workflow for mongo. 

## Problem

CI intermittently fails with the `persistent-mongoDB` test suite dying on:

```
uncaught exception: IOException of type NoSuchThing
Network.Socket.connect: <socket: 10>: does not exist (Connection refused)
```

One refused socket fails the entire suite (e.g. `102 examples, 89 failures`), which then cancels the rest of the `fail-fast` matrix. The same branches pass on re-run, so it's a flake rather than a real regression.

## Root cause

MongoDB is wired up differently from the other databases:

- **postgres** and **mysql** are declared as `services:` with `--health-cmd` health checks, so GitHub blocks the job until they're healthy. mysql additionally has an explicit `Check MySQL connection` step.
- **MongoDB** is started by a plain action step with **no readiness gate**, and the test harness (`persistent-mongoDB/test/MongoInit.hs` → `runConn`) connects **once with no retry/backoff**.

On top of that, `Start MongoDB` ran *before* the ~10 minute `cabal v2-build all`, leaving a long window in which the mongod container could be resource-starved (the build is memory-hungry on a 7 GB runner) and become unreachable by the time the tests connect.

## Fix

- Move `Start MongoDB` to immediately before `cabal v2-test`, after the build — shrinking the kill window to near zero.
- Add a readiness gate that waits for the port to accept connections. It's a plain bash `/dev/tcp` check, which mirrors the exact failure mode (a refused socket) and avoids depending on a `mongosh`/`mongo` client being present on the runner.
- Bump `supercharge/mongodb-github-action` 1.8.0 → 1.12.0.

This is workflow-only; no library or test code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)