### PR TITLE
ci: constrain megaparsec < 9.8 on GHC < 9.10

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -20,11 +20,15 @@ allow-newer:
     , bytestring-lexing:base
     , postgresql-simple-interval:persistent
 
--- megaparsec 9.8.0 uses an unqualified `foldl'`, which is only re-exported from
--- Prelude as of base-4.20 (GHC 9.10). On older GHCs it fails to compile with
--- "Variable not in scope: foldl'". Pin to < 9.8 there; newer GHCs build it fine.
-if impl(ghc < 9.10)
-    constraints: megaparsec < 9.8
+-- megaparsec 9.8.0 breaks the build in two ways:
+--   * On GHC < 9.10 it fails to compile ("Variable not in scope: foldl'"),
+--     because it relies on `foldl'` being re-exported from Prelude, which only
+--     happens as of base-4.20 (GHC 9.10).
+--   * On GHC >= 9.10 it compiles but changes how parse errors are rendered
+--     (the `^` caret under the offending token), which breaks the expected
+--     strings in Database.Persist.Quasi's test suite.
+-- Pin to < 9.8 across the whole matrix until the suite is updated upstream.
+constraints: megaparsec < 9.8
 
 source-repository-package
     type: git

--- a/cabal.project
+++ b/cabal.project
@@ -20,6 +20,12 @@ allow-newer:
     , bytestring-lexing:base
     , postgresql-simple-interval:persistent
 
+-- megaparsec 9.8.0 uses an unqualified `foldl'`, which is only re-exported from
+-- Prelude as of base-4.20 (GHC 9.10). On older GHCs it fails to compile with
+-- "Variable not in scope: foldl'". Pin to < 9.8 there; newer GHCs build it fine.
+if impl(ghc < 9.10)
+    constraints: megaparsec < 9.8
+
 source-repository-package
     type: git
     location: https://github.com/parsonsmatt/mysql


### PR DESCRIPTION
While trying to fix a CI issue in another PR (which came up on the actual functionality PR I was working on), I ran into this update to megaparsec which causes it to fail to build on older GHC versions. This pins the constraint for older versions so that everything can keep building. 

Claude summary below, in case it's useful. 

9.8 also causes test failures due to some other changes, so rather than a conditional fix I just pinned it below 9.8 everywhere: 
```
  test/Database/Persist/QuasiSpec.hs:1261:17: 
  1) Database.Persist.Quasi, tab error level setting, when configured to disallow tabs, rejects tab indentation
       expected: 2:1:
                   |
                 2 |  Id Text
                   | ^
                 unexpected tab
                 expecting valid whitespace
                 
                 3:1:
                   |
                 3 |  name String
                   | ^
                 unexpected tab
                 expecting valid whitespace
                 
        but got: 2:1:
                   |
                 2 |  Id Text
                   | 
                 unexpected tab
                 expecting valid whitespace
                 
                 3:1:
                   |
                 3 |  name String
                   | 
                 unexpected tab
                 expecting valid whitespace
                 

  To rerun use: --match "/Database/Persist/Quasi/tab error level setting/when configured to disallow tabs/rejects tab indentation/" --seed 608015465
  ```

## Problem

CI builds recently began failing on every GHC below 9.10 (8.8 – 9.8) while compiling a transitive dependency:

```
Text/Megaparsec/Stream.hs:517:26: error:
    • Variable not in scope: foldl' :: (b -> Char -> b) -> b -> [Char] -> b
    • Perhaps you want to add ‘foldl'’ to the import list
      in the import of ‘Data.Foldable’
Failed to build megaparsec-9.8.0 (which is required by test:test from
persistent-postgresql, test:test from persistent-sqlite and others).
```

`megaparsec-9.8.0` uses an unqualified `foldl'`, which is only re-exported from `Prelude` as of `base-4.20` (**GHC 9.10**). On older compilers it's a hard "not in scope" compile error.

It surfaced now because the workflow runs `cabal v2-freeze` fresh on every run (there's no committed `cabal.project.freeze`), so the solver always floats to the newest Hackage release — and `megaparsec-9.8.0` was recently published. GHC 9.10/9.12 compile it fine; everything ≤ 9.8 breaks. This affects `master` and every open PR equally, not any one branch.

