### PR TITLE
persistent-mysql: truncate foreign key constraint names to MySQL's 64 char limit

### DIFF
--- a/persistent-mysql/Database/Persist/MySQL.hs
+++ b/persistent-mysql/Database/Persist/MySQL.hs
@@ -1766,6 +1766,35 @@ putManySql' (filter isFieldNotGenerated -> fields) ent n = q
             , Util.commaSeparated updates
             ]
 
+-- | Generate the default foreign key constraint name for a given source table and
+-- source column name, truncated to fit MySQL's 64 character identifier limit.
+--
+-- MySQL, unlike Postgres, does not silently truncate identifiers that are too long;
+-- it raises an error instead (\"Identifier name ... is too long\"). Without this,
+-- persistent would suggest foreign key constraint names that MySQL simply refuses to
+-- create. This mirrors the truncation approach @persistent-postgresql@ already uses
+-- for the same underlying problem, just with MySQL's 64 character limit instead of
+-- Postgres' 63.
+refName :: EntityNameDB -> FieldNameDB -> ConstraintNameDB
+refName (EntityNameDB table) (FieldNameDB column) =
+    let
+        overhead = T.length $ T.concat ["_", "_fkey"]
+        (fromTable, fromColumn) = shortenNames overhead (T.length table, T.length column)
+     in
+        ConstraintNameDB $
+            T.concat [T.take fromTable table, "_", T.take fromColumn column, "_fkey"]
+  where
+    maximumIdentifierLength :: Int
+    maximumIdentifierLength = 64
+
+    shortenNames :: Int -> (Int, Int) -> (Int, Int)
+    shortenNames overhead (x, y)
+        | x + y + overhead <= maximumIdentifierLength = (x, y)
+        | x > y = shortenNames overhead (x - 1, y)
+        | otherwise = shortenNames overhead (x, y - 1)
+
 mysqlMkColumns
     :: [EntityDef] -> EntityDef -> ([Column], [UniqueDef], [ForeignDef])
-mysqlMkColumns allDefs t = mkColumns allDefs t emptyBackendSpecificOverrides
+mysqlMkColumns allDefs t =
+    mkColumns allDefs t $
+        setBackendSpecificForeignKeyName refName emptyBackendSpecificOverrides

--- a/persistent-mysql/persistent-mysql.cabal
+++ b/persistent-mysql/persistent-mysql.cabal
@@ -1,5 +1,5 @@
 name:               persistent-mysql
-version:            2.13.1.6
+version:            2.13.1.7
 license:            MIT
 license-file:       LICENSE
 author:             Felipe Lessa <felipe.lessa@gmail.com>, Michael Snoyman

--- a/persistent-mysql/test/main.hs
+++ b/persistent-mysql/test/main.hs
@@ -158,8 +158,8 @@ main = do
             , CustomPrimaryKeyReferenceTest.migration
             , MigrationColumnLengthTest.migration
             , TransactionLevelTest.migration
-            , -- , LongIdentifierTest.migration
-              ForeignKey.compositeMigrate
+            , LongIdentifierTest.migration
+            , ForeignKey.compositeMigrate
             ]
         PersistentTest.cleanDB
         ForeignKey.cleanDB
@@ -237,10 +237,7 @@ main = do
         MigrationIdempotencyTest.specsWith db
         MigrationTest.specsWith db
         CustomConstraintTest.specs db
-        -- TODO: implement automatic truncation for too long foreign keys, so we can run this test.
-        xdescribe
-            "The migration for this test currently fails because of MySQL's 64 character limit for identifiers. See https://github.com/yesodweb/persistent/issues/1000 for details"
-            $ LongIdentifierTest.specsWith db
+        LongIdentifierTest.specsWith db
         GeneratedColumnTestSQL.specsWith db
         JSONTest.specs
 

--- a/persistent-test/src/LongIdentifierTest.hs
+++ b/persistent-test/src/LongIdentifierTest.hs
@@ -19,7 +19,7 @@ import Init
 
 -- This test creates very long identifier names. The generated foreign key is over the length limit for Postgres and MySQL
 -- persistent-postgresql handles this by truncating foreign key names using the same algorithm that Postgres itself does (see 'refName' in Postgresql.hs)
--- MySQL currently doesn't run this test, and needs truncation logic for it to pass.
+-- persistent-mysql does the same, using MySQL's 64 character limit (see 'refName' in MySQL.hs)
 share
     [mkPersist sqlSettings, mkMigrate "migration"]
     [persistLowerCase|


### PR DESCRIPTION
## Description

Fixes #1000. `persistent-mysql` currently generates foreign key constraint names using the shared default scheme (`tableName_columnName_fkey`) with no length limit. Unlike Postgres, which silently truncates over-length identifiers (worked around in `persistent-postgresql` via `refName`, added in #996), MySQL just raises an error for identifiers over 64 characters.

This adds the MySQL equivalent of that same `refName` override, reusing the exact same truncation algorithm `persistent-postgresql` already uses (approximating how the database itself truncates), just with MySQL's 64-character limit instead of Postgres' 63, wired in via the existing `setBackendSpecificForeignKeyName` extension point.

## Evidence this is the intended fix

`persistent-test/src/LongIdentifierTest.hs` and its hookup in `persistent-mysql/test/main.hs` were already sitting there, explicitly disabled and waiting on exactly this:

```haskell
-- TODO: implement automatic truncation for too long foreign keys, so we can run this test.
xdescribe
    "The migration for this test currently fails because of MySQL's 64 character limit for identifiers. See https://github.com/yesodweb/persistent/issues/1000 for details"
    $ LongIdentifierTest.specsWith db
```

I enabled that test (both the `xdescribe` wrapper and the commented-out migration registration a few lines up) rather than leaving it disabled.

## Changes

- `persistent-mysql/Database/Persist/MySQL.hs` — add `refName`, mirroring `persistent-postgresql`'s function of the same name/signature almost exactly (`maximumIdentifierLength = 64` instead of `63`), and wire it into `mysqlMkColumns` via `setBackendSpecificForeignKeyName`.
- `persistent-mysql/test/main.hs` — enable `LongIdentifierTest`, which was previously disabled specifically because this was missing.
- `persistent-test/src/LongIdentifierTest.hs` — update the comment that said MySQL didn't run this test yet.
- `persistent-mysql/persistent-mysql.cabal` — bump patch version (2.13.1.6 → 2.13.1.7) per CONTRIBUTING.md's versioning guide (bug fix = patch bump).

Per CONTRIBUTING.md, I'll follow up with the `Changelog.md` entry once I have a PR number to link.

## Testing/Review Recommendations

I don't have a Haskell toolchain (no ghc/stack/cabal) available in this environment, so **I was not able to compile or run this locally** — please treat that as a real gap, not just a formality, and lean on CI here. What gives me confidence despite that:
- `refName`'s type signature and every symbol it uses (`EntityNameDB`, `FieldNameDB`, `ConstraintNameDB`, `setBackendSpecificForeignKeyName`, `emptyBackendSpecificOverrides`) come from `Database.Persist.Sql`, which `MySQL.hs` already imports unqualified — same import the Postgres file uses for the same symbols.
- The function body is the Postgres implementation with only the constant changed (63 → 64); I traced the `shortenNames` recursion by hand rather than just assuming it carries over.
- The now-enabled `LongIdentifierTest` is exactly the test the maintainers left in place for this fix (it references issue #1000 by number in its own skip message), so CI running it is a real, existing check of correctness, not something I added ad hoc.
