### PR TITLE
persistent/fix: make `loggedClose` uninterruptible

### DIFF
--- a/persistent/ChangeLog.md
+++ b/persistent/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for persistent
 
+# 2.18.1.1
+* [#1637](https://github.com/yesodweb/persistent/pull/1637)
+  * Fixes interruptible logging on connection closing inside `createSqlPoolWithConfig` since `resource-pool-0.5.x`.
+
 # 2.18.1.0
 * [#1616](https://github.com/yesodweb/persistent/pull/1616)
   * Allow overriding the default cascade option for foreign keys. 

--- a/persistent/Database/Persist/Sql/Run.hs
+++ b/persistent/Database/Persist/Sql/Run.hs
@@ -280,11 +280,11 @@ createSqlPoolWithConfig
     -> m (Pool backend)
 createSqlPoolWithConfig mkConn config = do
     logFunc <- askLoggerIO
-    -- Resource pool will swallow any exceptions from close. We want to log
-    -- them instead.
+    -- NOTE: resource-pool >= 0.5 no longer runs the pool's free action
+    -- uninterruptibly, and no longer swallows its exceptions.
     let
         loggedClose :: backend -> IO ()
-        loggedClose backend =
+        loggedClose backend = UE.uninterruptibleMask_ $
             close' backend `UE.catchAny` \e -> do
                 runLoggingT
                     (logError $ T.pack $ "Error closing database connection in pool: " ++ show e)

--- a/persistent/Database/Persist/Sql/Run.hs
+++ b/persistent/Database/Persist/Sql/Run.hs
@@ -282,15 +282,16 @@ createSqlPoolWithConfig mkConn config = do
     logFunc <- askLoggerIO
     -- NOTE: resource-pool >= 0.5 no longer runs the pool's free action
     -- uninterruptibly, and no longer swallows its exceptions.
+    -- - Sync exception will be caught and logged.
+    -- - Async exception will be propagated and also not interrupt closing.
     let
         loggedClose :: backend -> IO ()
         loggedClose backend =
             UE.uninterruptibleMask_ $
-                close' backend `UE.catchAny` \e -> do
+                close' backend `UE.catchAny` \e ->
                     runLoggingT
                         (logError $ T.pack $ "Error closing database connection in pool: " ++ show e)
                         logFunc
-                    UE.throwIO e
     liftIO $
         createPool
             (mkConn logFunc)

--- a/persistent/Database/Persist/Sql/Run.hs
+++ b/persistent/Database/Persist/Sql/Run.hs
@@ -284,12 +284,13 @@ createSqlPoolWithConfig mkConn config = do
     -- uninterruptibly, and no longer swallows its exceptions.
     let
         loggedClose :: backend -> IO ()
-        loggedClose backend = UE.uninterruptibleMask_ $
-            close' backend `UE.catchAny` \e -> do
-                runLoggingT
-                    (logError $ T.pack $ "Error closing database connection in pool: " ++ show e)
-                    logFunc
-                UE.throwIO e
+        loggedClose backend =
+            UE.uninterruptibleMask_ $
+                close' backend `UE.catchAny` \e -> do
+                    runLoggingT
+                        (logError $ T.pack $ "Error closing database connection in pool: " ++ show e)
+                        logFunc
+                    UE.throwIO e
     liftIO $
         createPool
             (mkConn logFunc)

--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -1,5 +1,5 @@
 name:               persistent
-version:            2.18.1.0
+version:            2.18.1.1
 license:            MIT
 license-file:       LICENSE
 author:             Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
Since `resource-pool-0.5.0.0` closing connections is no longer uninterruptible. There are reasons for this breaking behavioural changes and they need to be addressed on consumer side.

Closes #1636.

Before submitting your PR, check that you've:

- [X] Ran `fourmolu` on any changed files (`restyled` will do this for you, so
  accept the suggested changes if it makes them)
- [X] Adhered to the code style (see the `.editorconfig` and `fourmolu.yaml` files for details)

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR
- [x] Bumped the version number if there isn't an `(unreleased)` on the Changelog
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts)
