### PR TITLE
Fix #1635 Ease upper bound on aeson dependency

### DIFF
--- a/persistent/persistent.cabal
+++ b/persistent/persistent.cabal
@@ -23,7 +23,7 @@ extra-source-files:
 library
   default-language:   Haskell2010
   build-depends:
-      aeson                 >=1.0      && <2.3
+      aeson                 >=1.0      && <2.4
     , attoparsec
     , attoparsec-aeson      >=2.1.0.0  && <2.3
     , base                  >=4.11.1.0 && <5


### PR DESCRIPTION
See:
* https://github.com/commercialhaskell/stackage/issues/8016
* #1635 

This is no longer a burning platform because of:
* https://discourse.haskell.org/t/aeson-text-iso8601-have-a-vulnerability-lets-update-bounds/14627/4

Tested by building on Windows 11 with:
~~~text
> stack -w stack-ghc-9.10.3.yaml test --no-run-tests
~~~

and:
~~~yaml
# stack-ghc-9.10.3.yaml

snapshot: lts-24.56 # GHC 9.10.3

packages:
  - ./persistent
  - ./persistent-sqlite
  - ./persistent-test
  - ./persistent-mongoDB
# The Haskell mysql package (a dependency) does not support Windows, unpatched:
# - ./persistent-mysql
  - ./persistent-postgresql
  - ./persistent-redis
  - ./persistent-qq

allow-newer: true
allow-newer-deps:
- postgresql-simple

extra-deps:
# lts-24.56 specifies aeson-2.2.5.0:
- aeson-2.3.1.0@sha256:9570d664d4ca7a8bf9177b0d0849909554042cc39b260e3e19d1bd6a7d2d5433,6404
# lts-24.56 omits postgresql-simple-interval, a dependency of persistent-postgresql:
- postgresql-simple-interval-1.0.1.2@sha256:437e6a7b3a2985ebfffdb3312bb35043f25eefe592096439e209cf8ca9efa4cc,1922
~~~